### PR TITLE
Normalize array properties

### DIFF
--- a/SlevomatCodingStandard/Helpers/SniffSettingsHelper.php
+++ b/SlevomatCodingStandard/Helpers/SniffSettingsHelper.php
@@ -20,4 +20,23 @@ class SniffSettingsHelper
 		return array_values($settings);
 	}
 
+	/**
+	 * @param mixed[] $settings
+	 * @return mixed[]
+	 */
+	public static function normalizeAssociativeArray(array $settings)
+	{
+		$normalizedSettings = [];
+		foreach ($settings as $key => $value) {
+			$key = trim($key);
+			$value = trim($value);
+			if ($key === '' || $value === '') {
+				continue;
+			}
+			$normalizedSettings[$key] = $value;
+		}
+
+		return $normalizedSettings;
+	}
+
 }

--- a/SlevomatCodingStandard/Sniffs/Classes/UnusedPrivateElementsSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/UnusedPrivateElementsSniff.php
@@ -3,6 +3,7 @@
 namespace SlevomatCodingStandard\Sniffs\Classes;
 
 use PHP_CodeSniffer_File;
+use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
 use SlevomatCodingStandard\Helpers\StringHelper;
 use SlevomatCodingStandard\Helpers\TokenHelper;
 
@@ -19,7 +20,13 @@ class UnusedPrivateElementsSniff implements \PHP_CodeSniffer_Sniff
 	public $alwaysUsedPropertiesAnnotations = [];
 
 	/** @var string[] */
+	private $normalizedAlwaysUsedPropertiesAnnotations;
+
+	/** @var string[] */
 	public $alwaysUsedPropertiesSuffixes = [];
+
+	/** @var string[] */
+	private $normalizedAlwaysUsedPropertiesSuffixes;
 
 	/**
 	 * @return integer[]
@@ -29,6 +36,30 @@ class UnusedPrivateElementsSniff implements \PHP_CodeSniffer_Sniff
 		return [
 			T_CLASS,
 		];
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private function getAlwaysUsedPropertiesAnnotations()
+	{
+		if ($this->normalizedAlwaysUsedPropertiesAnnotations === null) {
+			$this->normalizedAlwaysUsedPropertiesAnnotations = SniffSettingsHelper::normalizeArray($this->alwaysUsedPropertiesAnnotations);
+		}
+
+		return $this->normalizedAlwaysUsedPropertiesAnnotations;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private function getAlwaysUsedPropertiesSuffixes()
+	{
+		if ($this->normalizedAlwaysUsedPropertiesSuffixes === null) {
+			$this->normalizedAlwaysUsedPropertiesSuffixes = SniffSettingsHelper::normalizeArray($this->alwaysUsedPropertiesSuffixes);
+		}
+
+		return $this->normalizedAlwaysUsedPropertiesSuffixes;
 	}
 
 	/**
@@ -180,7 +211,7 @@ class UnusedPrivateElementsSniff implements \PHP_CodeSniffer_Sniff
 			$phpDocTags = $this->getPhpDocTags($phpcsFile, $tokens, $visibilityModifiedTokenPointer);
 			foreach ($phpDocTags as $tag) {
 				preg_match('#([@a-zA-Z\\\]+)#', $tag, $matches);
-				if (in_array($matches[1], $this->alwaysUsedPropertiesAnnotations, true)) {
+				if (in_array($matches[1], $this->getAlwaysUsedPropertiesAnnotations(), true)) {
 					continue 2;
 				}
 			}
@@ -188,7 +219,7 @@ class UnusedPrivateElementsSniff implements \PHP_CodeSniffer_Sniff
 			$propertyToken = $tokens[$propertyTokenPointer];
 			$name = substr($propertyToken['content'], 1);
 
-			foreach ($this->alwaysUsedPropertiesSuffixes as $prefix) {
+			foreach ($this->getAlwaysUsedPropertiesSuffixes() as $prefix) {
 				if (StringHelper::endsWith($name, $prefix)) {
 					continue 2;
 				}

--- a/SlevomatCodingStandard/Sniffs/Files/TypeNameMatchesFileNameSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Files/TypeNameMatchesFileNameSniff.php
@@ -2,6 +2,7 @@
 
 namespace SlevomatCodingStandard\Sniffs\Files;
 
+use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
 use SlevomatCodingStandard\Helpers\StringHelper;
 
 class TypeNameMatchesFileNameSniff implements \PHP_CodeSniffer_Sniff
@@ -10,11 +11,20 @@ class TypeNameMatchesFileNameSniff implements \PHP_CodeSniffer_Sniff
 	/** @var string[] path(string) => namespace */
 	public $rootNamespaces = [];
 
+	/** @var string[] path(string) => namespace */
+	private $normalizedRootNamespaces;
+
 	/** @var string */
 	public $skipDirs = [];
 
+	/** @var string */
+	private $normalizedSkipDirs;
+
 	/** @var string[] */
 	public $ignoredNamespaces = [];
+
+	/** @var string[] */
+	private $normalizedIgnoredNamespaces;
 
 	/** @var \SlevomatCodingStandard\Sniffs\Files\FilepathNamespaceExtractor */
 	private $namespaceExtractor;
@@ -32,14 +42,50 @@ class TypeNameMatchesFileNameSniff implements \PHP_CodeSniffer_Sniff
 	}
 
 	/**
+	 * @return string[] path(string) => namespace
+	 */
+	private function getRootNamespaces()
+	{
+		if ($this->normalizedRootNamespaces === null) {
+			$this->normalizedRootNamespaces = SniffSettingsHelper::normalizeAssociativeArray($this->rootNamespaces);
+		}
+
+		return $this->normalizedRootNamespaces;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private function getSkipDirs()
+	{
+		if ($this->normalizedSkipDirs === null) {
+			$this->normalizedSkipDirs = SniffSettingsHelper::normalizeArray($this->skipDirs);
+		}
+
+		return $this->normalizedSkipDirs;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private function getIgnoredNamespaces()
+	{
+		if ($this->normalizedIgnoredNamespaces === null) {
+			$this->normalizedIgnoredNamespaces = SniffSettingsHelper::normalizeArray($this->ignoredNamespaces);
+		}
+
+		return $this->normalizedIgnoredNamespaces;
+	}
+
+	/**
 	 * @return \SlevomatCodingStandard\Sniffs\Files\FilepathNamespaceExtractor
 	 */
 	private function getNamespaceExtractor()
 	{
 		if ($this->namespaceExtractor === null) {
 			$this->namespaceExtractor = new FilepathNamespaceExtractor(
-				$this->rootNamespaces,
-				$this->skipDirs
+				$this->getRootNamespaces(),
+				$this->getSkipDirs()
 			);
 		}
 
@@ -78,7 +124,7 @@ class TypeNameMatchesFileNameSniff implements \PHP_CodeSniffer_Sniff
 			return;
 		}
 
-		foreach ($this->ignoredNamespaces as $ignoredNamespace) {
+		foreach ($this->getIgnoredNamespaces() as $ignoredNamespace) {
 			if (StringHelper::startsWith($typeName, $ignoredNamespace . '\\')) {
 				return;
 			}


### PR DESCRIPTION
So that configuration options in XML can be written on multiple lines as in `FullyQualifiedClassNameAfterKeywordSniff`, `FullyQualifiedExceptionsSniff` or `ReferenceUsedNamesOnlySniff`.

With this normalization for example namespaces can be configured in a much more readable and diff-friendly way:
```xml
	<rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
		<properties>
			<property name="rootNamespaces" type="array" value="
				SlevomatCodingStandard => SlevomatCodingStandard,
				tests => SlevomatCodingStandard
			"/>
		</properties>
	</rule>
```