### PR TITLE
False positive for private property used in string

### DIFF
--- a/tests/Sniffs/Classes/UnusedPrivateElementsSniffTest.php
+++ b/tests/Sniffs/Classes/UnusedPrivateElementsSniffTest.php
@@ -44,22 +44,23 @@ class UnusedPrivateElementsSniffTest extends \SlevomatCodingStandard\Sniffs\Test
 			'Class ClassWithSomeUnusedProperties contains write-only property: $writeOnlyProperty'
 		);
 		$this->assertNoSniffError($resultFile, 33);
+		$this->assertNoSniffError($resultFile, 35);
 		$this->assertSniffError(
 			$resultFile,
-			48,
+			51,
 			UnusedPrivateElementsSniff::CODE_UNUSED_METHOD,
 			'Class ClassWithSomeUnusedProperties contains unused private method: unusedPrivateMethod'
 		);
-		$this->assertNoSniffError($resultFile, 51);
-		$this->assertNoSniffError($resultFile, 58);
-		$this->assertNoSniffError($resultFile, 63);
+		$this->assertNoSniffError($resultFile, 54);
+		$this->assertNoSniffError($resultFile, 61);
+		$this->assertNoSniffError($resultFile, 66);
 		$this->assertSniffError(
 			$resultFile,
-			68,
+			71,
 			UnusedPrivateElementsSniff::CODE_UNUSED_METHOD,
 			'Class ClassWithSomeUnusedProperties contains unused private method: unusedStaticPrivateMethod'
 		);
-		$this->assertNoSniffError($resultFile, 73);
+		$this->assertNoSniffError($resultFile, 76);
 	}
 
 }

--- a/tests/Sniffs/Classes/data/ClassWithSomeUnusedProperties.php
+++ b/tests/Sniffs/Classes/data/ClassWithSomeUnusedProperties.php
@@ -32,12 +32,15 @@ class ClassWithSomeUnusedProperties extends \Consistence\Object
 	/** @ORM\Column(name="foo") */
 	private $doctrineProperty;
 
+	private $propertyUsedInString;
+
 	public function foo()
 	{
 		$this->usedProperty->foo();
 		$this->writeOnlyProperty = 'foo';
 		$this->unusedPropertyWhichNameIsAlsoAFunction();
 		$this->usedPrivateMethod();
+		echo "{$this->propertyUsedInString}";
 	}
 
 	private function usedPrivateMethod()


### PR DESCRIPTION
Hey, found a bug where private properties are marked as unused even if they used in double quoted strings `"{$this->foo}"`.