### PR TITLE
composer: autoload sniffs so they can be used in 3rd party apps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,14 @@
 		"phpunit/phpunit": "^5.0",
 		"satooshi/php-coveralls": "^1.0"
 	},
+	"autoload": {
+		"psr-4": {
+			"SlevomatCodingStandard\\": "SlevomatCodingStandard"
+		}
+	},
 	"autoload-dev": {
 		"psr-4": {
-			"SlevomatCodingStandard\\": ["SlevomatCodingStandard/", "tests/"]
+			"SlevomatCodingStandard\\": "tests"
 		},
 		"files": [
 			"vendor/consistence/coding-standard/tests/Sniffs/TestCase.php"


### PR DESCRIPTION
This is needed, if I want to use those sniffs via composer autoload, and not custom PHP_CodeSniffer autoload.

Ref: https://github.com/Symplify/PHP7_CodeSniffer