### PR TITLE
Better Classes.UnusedPrivateElements Sniff

### DIFF
--- a/tests/Sniffs/Classes/data/ClassWithSomeUnusedProperties.php
+++ b/tests/Sniffs/Classes/data/ClassWithSomeUnusedProperties.php
@@ -9,6 +9,8 @@ class ClassWithSomeUnusedProperties extends \Consistence\Object
 
 	private $usedProperty;
 
+	private $usedPropertyInString;
+
 	/**
 	 * @set(visibility="private")
 	 */
@@ -35,6 +37,7 @@ class ClassWithSomeUnusedProperties extends \Consistence\Object
 	public function foo()
 	{
 		$this->usedProperty->foo();
+		$test = "{$this->usedPropertyInString}";
 		$this->writeOnlyProperty = 'foo';
 		$this->unusedPropertyWhichNameIsAlsoAFunction();
 		$this->usedPrivateMethod();


### PR DESCRIPTION
Hello, 

I think, sniff `SlevomatCodingStandard.Classes.UnusedPrivateElements` should not warn, if I use private property in string. I don't remember name of general rule which it prohibits, but I think some new option like `alwaysUsedPropertiesAnnotations` would be great. Hmm? :)

Thanks