### PR TITLE
UnusedUsesSniff - fixed multiple exceptions in catch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 php:
   - 5.6
   - 7.0
+  - 7.1
 before_script:
   - composer self-update
 script:

--- a/SlevomatCodingStandard/Helpers/ReferencedNameHelper.php
+++ b/SlevomatCodingStandard/Helpers/ReferencedNameHelper.php
@@ -103,6 +103,29 @@ class ReferencedNameHelper
 							) {
 								$type = ReferencedName::TYPE_CONSTANT;
 							}
+						} elseif (
+							PHP_VERSION_ID >= 70100
+							&& ($tokens[$previousTokenBeforeStartPointer]['code'] === T_BITWISE_OR
+							|| $tokens[$previousTokenBeforeStartPointer]['code'] === T_OPEN_PARENTHESIS)
+						) {
+							$exclude = [T_BITWISE_OR, T_OPEN_PARENTHESIS];
+							$catchPointer = TokenHelper::findPreviousExcluding(
+								$phpcsFile,
+								array_merge($exclude, TokenHelper::$nameTokenCodes, TokenHelper::$ineffectiveTokenCodes),
+								$previousTokenBeforeStartPointer - 1
+							);
+							$exclude = [T_BITWISE_OR];
+							$openParenthesisPointer = TokenHelper::findPreviousExcluding(
+								$phpcsFile,
+								array_merge($exclude, TokenHelper::$nameTokenCodes, TokenHelper::$ineffectiveTokenCodes),
+								$previousTokenBeforeStartPointer
+							);
+							if (
+								$tokens[$catchPointer]['code'] !== T_CATCH
+								|| $tokens[$openParenthesisPointer]['code'] !== T_OPEN_PARENTHESIS
+							) {
+								$type = ReferencedName::TYPE_CONSTANT;
+							}
 						} else {
 							$type = ReferencedName::TYPE_CONSTANT;
 						}

--- a/tests/Helpers/ReferencedNameHelperTest.php
+++ b/tests/Helpers/ReferencedNameHelperTest.php
@@ -42,6 +42,33 @@ class ReferencedNameHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		}
 	}
 
+	/**
+	 * @requires PHP 7.1
+	 */
+	public function testMultipleExceptionsCatch()
+	{
+		$codeSnifferFile = $this->getCodeSnifferFile(
+			__DIR__ . '/data/multipleExceptionsCatch.php'
+		);
+
+		$foundTypes = [
+			['doSomething', true, false],
+			['FirstDoubleException', false, false],
+			['\Foo\SecondDoubleException', false, false],
+			['\Foo\Bar\FirstMultipleException', false, false],
+			['SecondMultipleException', false, false],
+			['ThirdMultipleException', false, false],
+		];
+
+		$names = ReferencedNameHelper::getAllReferencedNames($codeSnifferFile, 0);
+		$this->assertCount(count($foundTypes), $names);
+		foreach ($names as $i => $referencedName) {
+			$this->assertSame($foundTypes[$i][0], $referencedName->getNameAsReferencedInFile());
+			$this->assertSame($foundTypes[$i][1], $referencedName->isFunction(), $foundTypes[$i][0]);
+			$this->assertSame($foundTypes[$i][2], $referencedName->isConstant(), $foundTypes[$i][0]);
+		}
+	}
+
 	public function testFindReferencedNameEndPointerOnNonReferencedName()
 	{
 		$codeSnifferFile = $this->getCodeSnifferFile(

--- a/tests/Helpers/data/multipleExceptionsCatch.php
+++ b/tests/Helpers/data/multipleExceptionsCatch.php
@@ -1,0 +1,9 @@
+<?php // lint >= 7.1
+
+try {
+	doSomething();
+} catch (FirstDoubleException | \Foo\SecondDoubleException $e) {
+	throw $e;
+} catch (\Foo\Bar\FirstMultipleException | SecondMultipleException | ThirdMultipleException $e) {
+	throw $e;
+}


### PR DESCRIPTION
Updated `ReferencedNameHelper` to recognize all exception classes within php 7.1 [multiple exception catch](https://wiki.php.net/rfc/multiple-catch).