### PR TITLE
Support for multiple extensions

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Files/FilepathNamespaceExtractor.php
+++ b/SlevomatCodingStandard/Sniffs/Files/FilepathNamespaceExtractor.php
@@ -7,23 +7,33 @@ use SlevomatCodingStandard\Helpers\StringHelper;
 class FilepathNamespaceExtractor
 {
 
+	const DEFAULT_EXTENSIONS = [
+		'php',
+	];
+
 	/** @var string[] */
 	private $rootNamespaces;
 
 	/** @var boolean[] dir(string) => true(boolean) */
 	private $skipDirs;
 
+	/** @var string[] */
+	private $extensions;
+
 	/**
 	 * @param string[] $rootNamespaces directory(string) => namespace
 	 * @param string[] $skipDirs
+	 * @param string[] $extensions index(integer) => extension
 	 */
 	public function __construct(
 		array $rootNamespaces,
-		array $skipDirs
+		array $skipDirs,
+		array $extensions
 	)
 	{
 		$this->rootNamespaces = $rootNamespaces;
 		$this->skipDirs = array_fill_keys($skipDirs, true);
+		$this->extensions = $extensions;
 	}
 
 	/**
@@ -32,7 +42,8 @@ class FilepathNamespaceExtractor
 	 */
 	public function getTypeNameFromProjectPath($path)
 	{
-		if (pathinfo($path, PATHINFO_EXTENSION) !== 'php') {
+		$extension = pathinfo($path, PATHINFO_EXTENSION);
+		if (!in_array($extension, $this->extensions ?: self::DEFAULT_EXTENSIONS)) {
 			return null;
 		}
 
@@ -66,7 +77,7 @@ class FilepathNamespaceExtractor
 			return !isset($this->skipDirs[$pathPart]);
 		}));
 
-		return substr($typeName, 0, -strlen('.php'));
+		return substr($typeName, 0, -strlen('.' . $extension));
 	}
 
 }

--- a/SlevomatCodingStandard/Sniffs/Files/TypeNameMatchesFileNameSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Files/TypeNameMatchesFileNameSniff.php
@@ -11,6 +11,9 @@ class TypeNameMatchesFileNameSniff implements \PHP_CodeSniffer_Sniff
 	/** @var string[] path(string) => namespace */
 	public $rootNamespaces = [];
 
+	/** @var string[] index(integer) => extension */
+	public $extensions = [];
+
 	/** @var string[] path(string) => namespace */
 	private $normalizedRootNamespaces;
 
@@ -85,7 +88,8 @@ class TypeNameMatchesFileNameSniff implements \PHP_CodeSniffer_Sniff
 		if ($this->namespaceExtractor === null) {
 			$this->namespaceExtractor = new FilepathNamespaceExtractor(
 				$this->getRootNamespaces(),
-				$this->getSkipDirs()
+				$this->getSkipDirs(),
+				$this->extensions
 			);
 		}
 

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -5,6 +5,7 @@
 	<rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
 		<properties>
 			<property name="rootNamespaces" type="array" value="SlevomatCodingStandard=>SlevomatCodingStandard,tests=>SlevomatCodingStandard"/>
+			<property name="extensions" type="array" value="php,phpt"/>
 		</properties>
 	</rule>
 	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameAfterKeyword">

--- a/tests/Sniffs/Files/FilepathNamespaceExtractorTest.php
+++ b/tests/Sniffs/Files/FilepathNamespaceExtractorTest.php
@@ -13,46 +13,82 @@ class FilepathNamespaceExtractorTest extends \PHPUnit_Framework_TestCase
 			[
 				$root . '/unknown',
 				null,
+				['php'],
 			],
 			[
 				$root . '/app',
 				null,
+				['php'],
 			],
 			[
 				$root . '/app/components',
 				null,
+				['php'],
 			],
 			[
 				$root . '/app/components.php',
 				'Slevomat\\components',
+				['php'],
 			],
 			[
 				$root . '/app/Foo/Foo.swift',
 				null,
+				['php'],
 			],
 			[
 				$root . '/app/Foo/Foo.php',
 				'Slevomat\\Foo\\Foo',
+				['php'],
 			],
 			[
 				$root . '/tests/UnitTestCase.php',
 				'Slevomat\\UnitTestCase',
+				['php'],
 			],
 			[
 				$root . '/app/model/Auth/DatabaseAuthenticator.php',
 				'Slevomat\\Auth\\DatabaseAuthenticator',
+				['php'],
 			],
 			[
 				$root . '/app/services/Delivery/Premise/AbstractPremiseImporter.php',
 				'Slevomat\\Delivery\\Premise\\AbstractPremiseImporter',
+				['php'],
 			],
 			[
 				$root . '/app/ui/Admin/Newsletter/CreatePresenter.php',
 				'Slevomat\\UI\\Admin\\Newsletter\\CreatePresenter',
+				['php'],
 			],
 			[
 				$root . '/tests/services/Delivery/Goods3rd/data/StatusEnum.php',
 				'Slevomat\\Delivery\\Goods3rd\\StatusEnum',
+				['php'],
+			],
+			[
+				$root . '/tests/services/Delivery/Goods3rd/data/StatusEnum.php',
+				'Slevomat\\Delivery\\Goods3rd\\StatusEnum',
+				[],
+			],
+			[
+				$root . '/tests/services/Delivery/Goods3rd/data/StatusEnum.php',
+				'Slevomat\\Delivery\\Goods3rd\\StatusEnum',
+				['php'],
+			],
+			[
+				$root . '/tests/services/Delivery/Goods3rd/data/StatusEnum.php',
+				'Slevomat\\Delivery\\Goods3rd\\StatusEnum',
+				['php', 'lsp'],
+			],
+			[
+				$root . '/app/Foo/FooTest.phpt',
+				'Slevomat\\Foo\\FooTest',
+				['php', 'phpt'],
+			],
+			[
+				$root . '/app/Foo/FooTest.phpt',
+				null,
+				['.php', '.phpt'],
 			],
 		];
 	}
@@ -61,8 +97,9 @@ class FilepathNamespaceExtractorTest extends \PHPUnit_Framework_TestCase
 	 * @dataProvider dataGetTypeNameFromProjectPath
 	 * @param string $path
 	 * @param string $expectedNamespace
+	 * @param array $allowedExtensions
 	 */
-	public function testGetTypeNameFromProjectPath($path, $expectedNamespace)
+	public function testGetTypeNameFromProjectPath($path, $expectedNamespace, $allowedExtensions)
 	{
 		$extractor = new FilepathNamespaceExtractor(
 			[
@@ -70,7 +107,8 @@ class FilepathNamespaceExtractorTest extends \PHPUnit_Framework_TestCase
 				'app' => 'Slevomat',
 				'tests' => 'Slevomat',
 			],
-			['components', 'forms', 'model', 'models', 'services', 'stubs', 'data']
+			['components', 'forms', 'model', 'models', 'services', 'stubs', 'data'],
+			$allowedExtensions
 		);
 		$path = str_replace('/', DIRECTORY_SEPARATOR, $path);
 		$this->assertSame($expectedNamespace, $extractor->getTypeNameFromProjectPath($path));


### PR DESCRIPTION
In the current release it is not possible to run phpcs against Nette Tester tests without fail, because the tester requires files with .phpt extension. So, every time I try to run phpcs I end up with fail as namespace does not match with filepath. 