### PR TITLE
[2.0] AnnotationHelper does not handle parametrized annotations properly [failing-test]

### DIFF
--- a/tests/Helpers/AnnotationHelperTest.php
+++ b/tests/Helpers/AnnotationHelperTest.php
@@ -52,6 +52,13 @@ class AnnotationHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$this->assertSame('string $b', $annotations[1]);
 	}
 
+	public function testFunctionWithParametrizedAnnotation()
+	{
+		$annotations = AnnotationHelper::getAnnotationsByName($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), 'withParametrizedAnnotation'), '@Route');
+		$this->assertCount(1, $annotations);
+		$this->assertSame('("/", name="homepage")', $annotations[0]);
+	}
+
 	public function testFunctionWithoutAnnotation()
 	{
 		$this->assertCount(0, AnnotationHelper::getAnnotationsByName($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), 'withoutAnnotation'), '@param'));

--- a/tests/Helpers/data/annotation.php
+++ b/tests/Helpers/data/annotation.php
@@ -32,6 +32,11 @@ interface WithoutAnnotation
 	public function withAnnotation($b, $c);
 
 	/**
+	 * @Route("/", name="homepage")
+	 */
+	public function withParametrizedAnnotation();
+
+	/**
 	 * Without annotation
 	 */
 	public function withoutAnnotation();


### PR DESCRIPTION
I'm getting invalid `SlevomatCodingStandard.Typehints.TypeHintDeclaration.uselessDocComment` error.

With the following setup complex annotation (such as `@Route("/")` are not parsed properly and therefore the docblock with such annotation is seen as useless.
```
    <rule ref="SlevomatCodingStandard.Typehints.TypeHintDeclaration">
        <properties>
            <property name="usefulAnnotations" type="array" value="
                @Route
            "/>
        </properties>
    </rule>
```

This PR contains failing test (passes when there is space after `@Route` in `annotation.php`)