### PR TITLE
Do not try to trim non-string values in settings

### DIFF
--- a/SlevomatCodingStandard/Helpers/SniffSettingsHelper.php
+++ b/SlevomatCodingStandard/Helpers/SniffSettingsHelper.php
@@ -28,8 +28,12 @@ class SniffSettingsHelper
 	{
 		$normalizedSettings = [];
 		foreach ($settings as $key => $value) {
-			$key = trim($key);
-			$value = trim($value);
+			if (is_string($key)) {
+				$key = trim($key);
+			}
+			if (is_string($value)) {
+				$value = trim($value);
+			}
 			if ($key === '' || $value === '') {
 				continue;
 			}

--- a/tests/Helpers/SniffSettingsHelperTest.php
+++ b/tests/Helpers/SniffSettingsHelperTest.php
@@ -43,4 +43,16 @@ class SniffSettingsHelperTest extends \PHPUnit_Framework_TestCase
 		]));
 	}
 
+	public function testNormalizeAssociativeArrayWithIntegerKeys()
+	{
+		$this->assertSame([
+			'app/ui' => 'Slevomat\UI',
+			'app' => 'Slevomat',
+		], SniffSettingsHelper::normalizeAssociativeArray([
+			'app/ui' => 'Slevomat\UI',
+			'app' => 'Slevomat',
+			0 => '  ',
+		]));
+	}
+
 }


### PR DESCRIPTION
This happens if there is an associative array settins with string ending on a separate line producing and "empty" settings entry, e.g. something like:

```xml
    <rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
        <properties>
            <property name="rootNamespaces" type="array" value="
                src => Consistence,
                tests => Consistence,
            "/>
        </properties>
    </rule>
```