### PR TITLE
Incorrect detection of Yoda in expression beginning with cast

### DIFF
--- a/SlevomatCodingStandard/Sniffs/ControlStructures/YodaComparisonSniff.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/YodaComparisonSniff.php
@@ -20,6 +20,8 @@ class YodaComparisonSniff implements \PHP_CodeSniffer_Sniff
 
 	const DYNAMISM_FUNCTION_CALL = self::DYNAMISM_VARIABLE;
 
+	const DYNAMISM_CAST = self::DYNAMISM_VARIABLE;
+
 	/** @var integer[] */
 	private $tokenDynamism;
 
@@ -58,7 +60,7 @@ class YodaComparisonSniff implements \PHP_CodeSniffer_Sniff
 				T_STRING => self::DYNAMISM_FUNCTION_CALL,
 			];
 
-			$this->tokenDynamism = $this->tokenDynamism + array_fill_keys(array_keys(\PHP_CodeSniffer_Tokens::$castTokens), 3);
+			$this->tokenDynamism = $this->tokenDynamism + array_fill_keys(array_keys(\PHP_CodeSniffer_Tokens::$castTokens), self::DYNAMISM_CAST);
 		}
 
 		return $this->tokenDynamism;

--- a/tests/Sniffs/ControlStructures/YodaComparisonSniffTest.php
+++ b/tests/Sniffs/ControlStructures/YodaComparisonSniffTest.php
@@ -14,7 +14,7 @@ class YodaComparisonSniffTest extends \SlevomatCodingStandard\Sniffs\TestCase
 	public function dataIncorrectFile()
 	{
 		$lineNumbers = [];
-		foreach (range(3, 22) as $lineNumber) {
+		foreach (range(3, 24) as $lineNumber) {
 			$lineNumbers[$lineNumber] = [$lineNumber];
 		}
 

--- a/tests/Sniffs/ControlStructures/data/allYodaComparisons.php
+++ b/tests/Sniffs/ControlStructures/data/allYodaComparisons.php
@@ -16,6 +16,8 @@ Foo::BAR === $foo + 2;
 Foo::BAR === $this->foo();
 -1 === $foo;
 +1 === $foo;
+(int) FOO === $bar;
+FOO === (int) $bar;
 (BAR === foo() || (
 	['test'] === Foo::BAR
 )) ? 123.0 === Foo::BAR

--- a/tests/Sniffs/ControlStructures/data/noYodaComparisons.php
+++ b/tests/Sniffs/ControlStructures/data/noYodaComparisons.php
@@ -22,6 +22,8 @@ count($cartItem->getReservations()) !== $neededReservationsAmount;
 $optionalPartOpeningBracePosition !== strlen($part) - 1;
 $optionalPartOpeningBracePosition !== \Nette\Utils\Strings::length($part) - 1;
 foo() + 2 === Foo::BAR;
+(int) $foo === $bar;
+$foo === (int) $bar;
 
 if (
 	$foo($bar) === [Foo::BAR, Foo::BAZ] && (


### PR DESCRIPTION
If there is a cast on the left side of the expression, this is incorrectly detected as a yoda comparison:

```php
<?php

(int) $foo === $bar;
```
results in:
```
 3 | ERROR | [x] Yoda comparisons are prohibited.
```

I have tried to fix this but I am not sure why there was a dynamism value of `3`, which is the thing I think throws this off balance. I have tried to replace this with the "dynamic" dynamism, which fixes my issue, but I am not sure about other cases, see:

```php
<?php

(int) FOO === $bar;
```

I consider this to be a Yoda statement, but with that dynamism change it would not be  - that is why the tests fail now.

When I thought about this I think the cast should be "skipped" for the purpose of the evaluation, because they don't change the nature of the expressions regarding its dynamism? What is your opinion?

cc @ondrejmirtes 
