### PR TITLE
Allow FQN references for colliding classes

### DIFF
--- a/SlevomatCodingStandard/Helpers/ClassHelper.php
+++ b/SlevomatCodingStandard/Helpers/ClassHelper.php
@@ -24,20 +24,30 @@ class ClassHelper
 	 */
 	public static function getAllNames(\PHP_CodeSniffer_File $codeSnifferFile): array
 	{
-		$getAllClassPointers = function (\PHP_CodeSniffer_File $codeSnifferFile, &$previousClassPointer): \Generator {
-			$previousClassPointer = $nextClassPointer = $codeSnifferFile->findNext(TokenHelper::$typeKeywordTokenCodes, $previousClassPointer + 1);
-			if ($nextClassPointer !== null) {
-				yield $nextClassPointer;
-			}
-		};
 		$previousClassPointer = 0;
 
 		return array_map(
-			function (int $classPointer) use ($codeSnifferFile) {
+			function (int $classPointer) use ($codeSnifferFile): string {
 				return self::getName($codeSnifferFile, $classPointer);
 			},
-			iterator_to_array($getAllClassPointers($codeSnifferFile, $previousClassPointer))
+			iterator_to_array(self::getAllClassPointers($codeSnifferFile, $previousClassPointer))
 		);
+	}
+
+	/**
+	 * @param \PHP_CodeSniffer_File $codeSnifferFile
+	 * @param int|bool $previousClassPointer
+	 *
+	 * @return \Generator
+	 */
+	private static function getAllClassPointers(\PHP_CodeSniffer_File $codeSnifferFile, &$previousClassPointer): \Generator
+	{
+		while ($previousClassPointer !== false) {
+			$previousClassPointer = $codeSnifferFile->findNext(TokenHelper::$typeKeywordTokenCodes, $previousClassPointer + 1);
+			if ($previousClassPointer !== false) {
+				yield $previousClassPointer;
+			}
+		}
 	}
 
 }

--- a/SlevomatCodingStandard/Helpers/ClassHelper.php
+++ b/SlevomatCodingStandard/Helpers/ClassHelper.php
@@ -18,4 +18,26 @@ class ClassHelper
 		return $tokens[$codeSnifferFile->findNext(T_STRING, $classPointer + 1, $tokens[$classPointer]['scope_opener'])]['content'];
 	}
 
+	/**
+	 * @param \PHP_CodeSniffer_File $codeSnifferFile
+	 * @return string[]
+	 */
+	public static function getAllNames(\PHP_CodeSniffer_File $codeSnifferFile): array
+	{
+		$getAllClassPointers = function (\PHP_CodeSniffer_File $codeSnifferFile, &$previousClassPointer): \Generator {
+			$previousClassPointer = $nextClassPointer = $codeSnifferFile->findNext(TokenHelper::$typeKeywordTokenCodes, $previousClassPointer + 1);
+			if ($nextClassPointer !== null) {
+				yield $nextClassPointer;
+			}
+		};
+		$previousClassPointer = 0;
+
+		return array_map(
+			function (int $classPointer) use ($codeSnifferFile) {
+				return self::getName($codeSnifferFile, $classPointer);
+			},
+			iterator_to_array($getAllClassPointers($codeSnifferFile, $previousClassPointer))
+		);
+	}
+
 }

--- a/SlevomatCodingStandard/Sniffs/Namespaces/ReferenceUsedNamesOnlySniff.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/ReferenceUsedNamesOnlySniff.php
@@ -150,7 +150,7 @@ class ReferenceUsedNamesOnlySniff implements \PHP_CodeSniffer_Sniff
 
 			if ($this->allowFullyQualifiedNameForCollidingClasses) {
 				$unqualifiedClassName = NamespaceHelper::getUnqualifiedNameFromFullyQualifiedName($referencedName->getNameAsReferencedInFile());
-				if (isset($referencesIndex[$unqualifiedClassName]) || in_array($unqualifiedClassName, $definedClassesIndex ?? [])) {
+				if (isset($referencesIndex[$unqualifiedClassName]) || in_array($unqualifiedClassName, $definedClassesIndex ?? [], true)) {
 					continue;
 				}
 			}

--- a/SlevomatCodingStandard/Sniffs/Namespaces/ReferenceUsedNamesOnlySniff.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/ReferenceUsedNamesOnlySniff.php
@@ -2,7 +2,9 @@
 
 namespace SlevomatCodingStandard\Sniffs\Namespaces;
 
+use SlevomatCodingStandard\Helpers\ClassHelper;
 use SlevomatCodingStandard\Helpers\NamespaceHelper;
+use SlevomatCodingStandard\Helpers\ReferencedName;
 use SlevomatCodingStandard\Helpers\ReferencedNameHelper;
 use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
 use SlevomatCodingStandard\Helpers\StringHelper;
@@ -51,6 +53,9 @@ class ReferenceUsedNamesOnlySniff implements \PHP_CodeSniffer_Sniff
 
 	/** @var string[]|null */
 	private $normalizedNamespacesRequiredToUse;
+
+	/** @var bool */
+	public $allowFullyQualifiedNameForCollidingClasses = false;
 
 	/**
 	 * @return int[]
@@ -125,10 +130,31 @@ class ReferenceUsedNamesOnlySniff implements \PHP_CodeSniffer_Sniff
 		$tokens = $phpcsFile->getTokens();
 
 		$referencedNames = ReferencedNameHelper::getAllReferencedNames($phpcsFile, $openTagPointer);
+
+		if ($this->allowFullyQualifiedNameForCollidingClasses) {
+			$referencesIndex = array_flip(
+				array_map(
+					function (ReferencedName $referencedName): string {
+						return $referencedName->getNameAsReferencedInFile();
+					},
+					$referencedNames
+				)
+			);
+			$definedClassesIndex = array_flip(ClassHelper::getAllNames($phpcsFile));
+		}
+
 		foreach ($referencedNames as $referencedName) {
 			$name = $referencedName->getNameAsReferencedInFile();
 			$nameStartPointer = $referencedName->getStartPointer();
 			$canonicalName = NamespaceHelper::normalizeToCanonicalName($name);
+
+			if ($this->allowFullyQualifiedNameForCollidingClasses) {
+				$unqualifiedClassName = NamespaceHelper::getUnqualifiedNameFromFullyQualifiedName($referencedName->getNameAsReferencedInFile());
+				if (isset($referencesIndex[$unqualifiedClassName]) || in_array($unqualifiedClassName, $definedClassesIndex ?? [])) {
+					continue;
+				}
+			}
+
 			if (NamespaceHelper::isFullyQualifiedName($name)) {
 				$isExceptionByName = StringHelper::endsWith($name, 'Exception')
 					|| $name === '\Throwable'

--- a/tests/Helpers/ClassHelperTest.php
+++ b/tests/Helpers/ClassHelperTest.php
@@ -27,4 +27,22 @@ class ClassHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$this->assertSame('FooTrait', ClassHelper::getName($codeSnifferFile, $this->findClassPointerByName($codeSnifferFile, 'FooTrait')));
 	}
 
+	public function testGetAllNamesWithNamespace()
+	{
+		$codeSnifferFile = $this->getCodeSnifferFile(__DIR__ . '/data/classWithNamespace.php');
+		$this->assertSame(['FooClass', 'FooInterface', 'FooTrait'], ClassHelper::getAllNames($codeSnifferFile));
+	}
+
+	public function testGetAllNamesWithoutNamespace()
+	{
+		$codeSnifferFile = $this->getCodeSnifferFile(__DIR__ . '/data/classWithoutNamespace.php');
+		$this->assertSame(['FooClass', 'FooInterface', 'FooTrait'], ClassHelper::getAllNames($codeSnifferFile));
+	}
+
+	public function testGetAllNamesWithNoClass()
+	{
+		$codeSnifferFile = $this->getCodeSnifferFile(__DIR__ . '/data/namespacedFile.php');
+		$this->assertSame([], ClassHelper::getAllNames($codeSnifferFile));
+	}
+
 }

--- a/tests/Sniffs/Namespaces/ReferenceUsedNamesOnlySniffTest.php
+++ b/tests/Sniffs/Namespaces/ReferenceUsedNamesOnlySniffTest.php
@@ -551,4 +551,44 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 		$this->assertAllFixedInFile($report);
 	}
 
+	public function testCollidingClassNameDifferentNamespacesAllowed()
+	{
+		$report = $this->checkFile(
+			__DIR__ . '/data/collidingClassNameDifferentNamespaces.php',
+			['allowFullyQualifiedNameForCollidingClasses' => true]
+		);
+		$this->assertNoSniffErrorInFile($report);
+	}
+
+	public function testCollidingClassNameDifferentNamespacesDisallowed()
+	{
+		$report = $this->checkFile(
+			__DIR__ . '/data/collidingClassNameDifferentNamespaces.php',
+			['allowFullyQualifiedNameForCollidingClasses' => false]
+		);
+		$this->assertSniffError($report, 13, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
+		$this->assertSniffError($report, 14, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
+	}
+
+	public function testCollidingClassNameDifferentNamespacesMoreClassesAllowed()
+	{
+		$report = $this->checkFile(
+			__DIR__ . '/data/collidingClassNameDifferentNamespacesMoreClasses.php',
+			['allowFullyQualifiedNameForCollidingClasses' => true]
+		);
+		$this->assertNoSniffErrorInFile($report);
+	}
+
+	public function testCollidingClassNameDifferentNamespacesMoreClassesDisallowed()
+	{
+		$report = $this->checkFile(
+			__DIR__ . '/data/collidingClassNameDifferentNamespacesMoreClasses.php',
+			['allowFullyQualifiedNameForCollidingClasses' => false]
+		);
+		$this->assertSniffError($report, 7, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
+		$this->assertSniffError($report, 8, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
+		$this->assertSniffError($report, 11, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
+		$this->assertSniffError($report, 12, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
+	}
+
 }

--- a/tests/Sniffs/Namespaces/data/collidingClassNameDifferentNamespaces.php
+++ b/tests/Sniffs/Namespaces/data/collidingClassNameDifferentNamespaces.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Alpha;
+
+use Bar\Foo;
+
+class Beta {
+
+	public function barFoo(): Foo {
+		return new Foo();
+	}
+
+	public function bazFoo(): \Baz\Foo {
+		return new \Baz\Foo();
+	}
+
+}

--- a/tests/Sniffs/Namespaces/data/collidingClassNameDifferentNamespacesMoreClasses.php
+++ b/tests/Sniffs/Namespaces/data/collidingClassNameDifferentNamespacesMoreClasses.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Alpha;
+
+class Beta {
+
+	public function barFoo(): \Bar\Foo {
+		return new \Bar\Foo();
+	}
+
+	public function bazFoo(): \Baz\Foo {
+		return new \Baz\Foo();
+	}
+
+}
+
+class Foo {
+
+	public function alphaFoo(): Foo {
+		return new Foo();
+	}
+
+}


### PR DESCRIPTION
This way it is possible to allow FQN by param in sniff. It is disabled by default and therefore do not do any BC.