### PR TITLE
Added NullableTypeForNullDefaultValueSniff

### DIFF
--- a/SlevomatCodingStandard/Sniffs/TypeHints/NullableTypeForNullDefaultValueSniff.php
+++ b/SlevomatCodingStandard/Sniffs/TypeHints/NullableTypeForNullDefaultValueSniff.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\TypeHints;
+
+use SlevomatCodingStandard\Helpers\TokenHelper;
+
+class NullableTypeForNullDefaultValueSniff implements \PHP_CodeSniffer_Sniff
+{
+
+	const CODE_NULLABILITY_SYMBOL_REQUIRED = 'NullabilitySymbolRequired';
+
+	/**
+	 * @return int[]
+	 */
+	public function register(): array
+	{
+		return [
+			T_FUNCTION,
+			T_CLOSURE,
+		];
+	}
+
+	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+	 * @param \PHP_CodeSniffer_File $phpcsFile
+	 * @param int $functionPointer
+	 */
+	public function process(\PHP_CodeSniffer_File $phpcsFile, $functionPointer)
+	{
+		$tokens = $phpcsFile->getTokens();
+		$startPointer = $tokens[$functionPointer]['parenthesis_opener'] + 1;
+		$endPointer = $tokens[$functionPointer]['parenthesis_closer'];
+
+		for ($i = $startPointer; $i < $endPointer; $i++) {
+			if ($tokens[$i]['code'] !== T_VARIABLE) {
+				continue;
+			}
+
+			$parameterName = $tokens[$i]['content'];
+
+			$afterVariablePointer = TokenHelper::findNextEffective($phpcsFile, $i + 1);
+			if ($tokens[$afterVariablePointer]['code'] !== T_EQUAL) {
+				continue;
+			}
+
+			$afterEqualsPointer = TokenHelper::findNextEffective($phpcsFile, $afterVariablePointer + 1);
+			if ($tokens[$afterEqualsPointer]['code'] !== T_NULL) {
+				continue;
+			}
+
+			$typeHintTokens = [T_NS_SEPARATOR, T_STRING, T_SELF, T_PARENT, T_ARRAY_HINT, T_CALLABLE];
+			$ignoreTokensToFindTypeHint = array_merge(TokenHelper::$ineffectiveTokenCodes, [T_BITWISE_AND, T_ELLIPSIS]);
+			$typeHintPointer = TokenHelper::findPreviousExcluding($phpcsFile, $ignoreTokensToFindTypeHint, $i - 1, $startPointer);
+
+			if ($typeHintPointer === null || !in_array($tokens[$typeHintPointer]['code'], $typeHintTokens, true)) {
+				continue;
+			};
+
+			$ignoreTokensToSkipTypeHint = array_merge(TokenHelper::$ineffectiveTokenCodes, $typeHintTokens);
+			$beforeTypeHintPointer = TokenHelper::findPreviousExcluding($phpcsFile, $ignoreTokensToSkipTypeHint, $typeHintPointer - 1, $startPointer);
+
+			if ($beforeTypeHintPointer !== null && $tokens[$beforeTypeHintPointer]['code'] === T_NULLABLE) {
+				continue;
+			}
+
+			$fix = $phpcsFile->addFixableError(
+				sprintf('Parameter %s has null default value, but is not marked as nullable.', $parameterName),
+				$i,
+				self::CODE_NULLABILITY_SYMBOL_REQUIRED
+			);
+
+			if ($fix) {
+				$firstTypehint = TokenHelper::findNextEffective($phpcsFile, $beforeTypeHintPointer === null ? $startPointer : $beforeTypeHintPointer + 1);
+
+				$phpcsFile->fixer->beginChangeset();
+				$phpcsFile->fixer->addContent($firstTypehint - 1, '?');
+				$phpcsFile->fixer->endChangeset();
+			}
+		}
+	}
+
+}

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -2,6 +2,7 @@
 <ruleset name="Slevomat Coding Standard">
 	<rule ref="SlevomatCodingStandard/ruleset.xml">
 		<exclude name="SlevomatCodingStandard.Classes.ClassConstantVisibility"/><!-- PHP >= 7.1 only -->
+		<exclude name="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/><!-- PHP >= 7.1 only -->
 	</rule>
 	<rule ref="vendor/consistence/coding-standard/Consistence/ruleset.xml">
 		<exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedIF"/><!-- Allow empty if statements - usually with a comment -->

--- a/tests/Sniffs/TypeHints/NullableTypeForNullDefaultValueSniffTest.php
+++ b/tests/Sniffs/TypeHints/NullableTypeForNullDefaultValueSniffTest.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\TypeHints;
+
+class NullableTypeForNullDefaultValueSniffTest extends \SlevomatCodingStandard\Sniffs\TestCase
+{
+
+	public function testNoErrors()
+	{
+		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/nullableTypeForNullDefaultValueNoErrors.php'));
+	}
+
+	public function testErrors()
+	{
+		$report = $this->checkFile(__DIR__ . '/data/nullableTypeForNullDefaultValueErrors.php');
+
+		$this->assertSame(11, $report->getErrorCount());
+
+		$code = NullableTypeForNullDefaultValueSniff::CODE_NULLABILITY_SYMBOL_REQUIRED;
+		$this->assertSniffError($report, 3, $code);
+		$this->assertSniffError($report, 8, $code);
+		$this->assertSniffError($report, 15, $code);
+		$this->assertSniffError($report, 22, $code);
+		$this->assertSniffError($report, 27, $code);
+		$this->assertSniffError($report, 32, $code);
+		$this->assertSniffError($report, 37, $code);
+		$this->assertSniffError($report, 42, $code);
+		$this->assertSniffError($report, 47, $code);
+		$this->assertSniffError($report, 52, $code);
+		$this->assertSniffError($report, 57, $code);
+	}
+
+	public function testFixable()
+	{
+		$codes = [NullableTypeForNullDefaultValueSniff::CODE_NULLABILITY_SYMBOL_REQUIRED];
+		$report = $this->checkFile(__DIR__ . '/data/fixableNullableTypeForNullDefaultValue.php', [], $codes);
+		$this->assertAllFixedInFile($report);
+	}
+
+}

--- a/tests/Sniffs/TypeHints/data/fixableNullableTypeForNullDefaultValue.fixed.php
+++ b/tests/Sniffs/TypeHints/data/fixableNullableTypeForNullDefaultValue.fixed.php
@@ -1,0 +1,43 @@
+<?php // lint >= 7.1
+
+class FooBar
+{
+
+	public function foo(?\DateTimeImmutable & $dateTime = null)
+	{
+		function (?string $string = null) {
+
+		};
+	}
+
+	public function invalid(?bool $bool = null)
+	{
+
+	}
+
+	public function withNullableParamBefore(?float $float, ?bool $param1 = null)
+	{
+
+	}
+
+	public function withParamAfter(?bool $param2 = null, ?array & ... $ellipsis)
+	{
+
+	}
+
+	public function reference(?float & $ref = null)
+	{
+
+	}
+
+	public function multiline(
+		?bool $param1 = null,
+		?array $param2 = null,
+		?callable $param3 = null,
+		?self $param4 = null
+	)
+	{
+
+	}
+
+}

--- a/tests/Sniffs/TypeHints/data/fixableNullableTypeForNullDefaultValue.php
+++ b/tests/Sniffs/TypeHints/data/fixableNullableTypeForNullDefaultValue.php
@@ -1,0 +1,43 @@
+<?php // lint >= 7.1
+
+class FooBar
+{
+
+	public function foo(\DateTimeImmutable & $dateTime = null)
+	{
+		function (string $string = null) {
+
+		};
+	}
+
+	public function invalid(bool $bool = null)
+	{
+
+	}
+
+	public function withNullableParamBefore(?float $float, bool $param1 = null)
+	{
+
+	}
+
+	public function withParamAfter(bool $param2 = null, ?array & ... $ellipsis)
+	{
+
+	}
+
+	public function reference(float & $ref = null)
+	{
+
+	}
+
+	public function multiline(
+		bool $param1 = null,
+		array $param2 = null,
+		callable $param3 = null,
+		self $param4 = null
+	)
+	{
+
+	}
+
+}

--- a/tests/Sniffs/TypeHints/data/nullableTypeForNullDefaultValueErrors.php
+++ b/tests/Sniffs/TypeHints/data/nullableTypeForNullDefaultValueErrors.php
@@ -1,0 +1,62 @@
+<?php // lint >= 7.1
+
+function foo(\DateTimeImmutable & $dateTime = null)
+{
+
+}
+
+$callback = function (string $string = null) {
+
+};
+
+interface Foo
+{
+
+	public function doFoo(int $int = null);
+
+}
+
+class FooBar
+{
+
+	public function invalid(bool $bool = null)
+	{
+
+	}
+
+	public function myself(self $self = null)
+	{
+
+	}
+
+	public function array(array $array = null)
+	{
+
+	}
+
+	public function parent(parent $parent = null)
+	{
+
+	}
+
+	public function callable(callable $callable = null)
+	{
+
+	}
+
+	public function withNullableParamBefore(?float $float, \Foo\Bar\Baz $param1 = null)
+	{
+
+	}
+
+	public function withParamAfter(bool $param2 = null, ?array & ... $ellipsis)
+	{
+
+	}
+
+	public function reference(float & $ref = null)
+	{
+
+	}
+
+}

--- a/tests/Sniffs/TypeHints/data/nullableTypeForNullDefaultValueNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/nullableTypeForNullDefaultValueNoErrors.php
@@ -1,0 +1,65 @@
+<?php // lint >= 7.1
+
+function foo(?\DateTimeImmutable & $dateTime = null)
+{
+
+}
+
+$callback = function (?string $string = null) {
+
+};
+
+trait Foo
+{
+
+	public function doFoo(?int $int = null)
+	{
+
+	}
+
+}
+
+class FooBar extends \stdClass
+{
+
+	public function valid(?bool $bool = null, $noTypehint = null, ?int $int, string $a = 'default', ?string $b = 'null')
+	{
+
+	}
+
+	public function myself(?self $self = null)
+	{
+
+	}
+
+	public function array(?array $array = null)
+	{
+
+	}
+
+	public function parent(?parent $parent = null)
+	{
+
+	}
+
+	public function callable(?callable $callable = null)
+	{
+
+	}
+
+	public function withNullableParamBefore(float $float, ?\Foo\Bar\Baz $param1 = null)
+	{
+
+	}
+
+	public function withParamAfter(?bool $param2 = null, array ...$ellipsis)
+	{
+
+	}
+
+	public function reference(?float & $ref = null, ...$test)
+	{
+
+	}
+
+}


### PR DESCRIPTION
- Enforces using nullability symbol `?` when using `null` as default value, e.g. `bool $param = null` > `?bool $param = null`. 
- I'm not sure with the naming, any better ideas?
- Reason to enforce it: you should use nullability symbol if parameter accepts null value no matter what the default value is. So, if you change from `?bool $param = false` to `?bool $param = null`, you don't need to change typehint - you are changing only default value.