### PR TITLE
[failing test only] complex annotation can be marked as useful

### DIFF
--- a/tests/Sniffs/TypeHints/TypeHintDeclarationSniffTest.php
+++ b/tests/Sniffs/TypeHints/TypeHintDeclarationSniffTest.php
@@ -18,7 +18,7 @@ class TypeHintDeclarationSniffTest extends \SlevomatCodingStandard\Sniffs\TestCa
 			],
 			'usefulAnnotations' => [
 				'@see',
-				'@Assert',
+				'@Assert\Callback',
 			],
 		]));
 	}

--- a/tests/Sniffs/TypeHints/TypeHintDeclarationSniffTest.php
+++ b/tests/Sniffs/TypeHints/TypeHintDeclarationSniffTest.php
@@ -18,6 +18,7 @@ class TypeHintDeclarationSniffTest extends \SlevomatCodingStandard\Sniffs\TestCa
 			],
 			'usefulAnnotations' => [
 				'@see',
+				'@Assert',
 			],
 		]));
 	}

--- a/tests/Sniffs/TypeHints/data/typeHintDeclarationNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/typeHintDeclarationNoErrors.php
@@ -220,6 +220,15 @@ abstract class FooClass
 	}
 
 	/**
+	 * @Assert\Callback()
+	 * @param string $a
+	 * @param string $b
+	 */
+	public function withUsefulComplexAnnotation(string $a, string $b)
+	{
+	}
+
+	/**
 	 * @return mixed
 	 */
 	abstract public function withMixedReturnAnnotation();


### PR DESCRIPTION
Complex annotations such as `@Assert\Callback()` cannot be marked as useful, see the failing test.


**Workaround:** Add description to the docblock such as _Remove this text when the `@Assert\Callback()` annotation can be marked as useful_