### PR TITLE
[failing test] Class used as targetEntity should not be reported as unused

### DIFF
--- a/tests/Sniffs/Namespaces/UnusedUsesSniffTest.php
+++ b/tests/Sniffs/Namespaces/UnusedUsesSniffTest.php
@@ -94,7 +94,7 @@ class UnusedUsesSniffTest extends \SlevomatCodingStandard\Sniffs\TestCase
 			'searchAnnotations' => false,
 		]);
 
-		$this->assertSame(4, $report->getErrorCount());
+		$this->assertSame(5, $report->getErrorCount());
 
 		$this->assertSniffError(
 			$report,
@@ -110,13 +110,13 @@ class UnusedUsesSniffTest extends \SlevomatCodingStandard\Sniffs\TestCase
 		);
 		$this->assertSniffError(
 			$report,
-			7,
+			8,
 			UnusedUsesSniff::CODE_UNUSED_USE,
 			'Type X is not used in this file.'
 		);
 		$this->assertSniffError(
 			$report,
-			8,
+			9,
 			UnusedUsesSniff::CODE_UNUSED_USE,
 			'Type XX is not used in this file.'
 		);
@@ -132,7 +132,7 @@ class UnusedUsesSniffTest extends \SlevomatCodingStandard\Sniffs\TestCase
 
 		$this->assertSniffError(
 			$report,
-			8,
+			9,
 			UnusedUsesSniff::CODE_UNUSED_USE,
 			'Type XX is not used in this file.'
 		);

--- a/tests/Sniffs/Namespaces/data/unusedUsesInAnnotation.php
+++ b/tests/Sniffs/Namespaces/data/unusedUsesInAnnotation.php
@@ -4,6 +4,7 @@ namespace Foo;
 
 use Assert;
 use Doctrine\ORM\Mapping as ORM;
+use Foo\Bar;
 use X;
 use XX;
 
@@ -17,6 +18,12 @@ class Boo
 	 * @ORM\Id()
 	 */
 	public $id;
+
+	/**
+	 * @ORM\OneToMany(targetEntity=Bar::class, mappedBy="boo")
+	 * @var \Foo\Bar[]
+	 */
+	private $bars;
 
 	/**
 	 * @Assert


### PR DESCRIPTION
When the class is used as `targetEntity` in Doctrine annotation, it is reported as unused and it should not be. (PHPStorm detects this properly)