### PR TITLE
Fix of bug in allowFullyQualifiedNameForCollidingClasses flag for ReferenceUsedNamesOnlySniff

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Namespaces/ReferenceUsedNamesOnlySniff.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/ReferenceUsedNamesOnlySniff.php
@@ -150,7 +150,7 @@ class ReferenceUsedNamesOnlySniff implements \PHP_CodeSniffer_Sniff
 
 			if ($this->allowFullyQualifiedNameForCollidingClasses) {
 				$unqualifiedClassName = NamespaceHelper::getUnqualifiedNameFromFullyQualifiedName($name);
-				if (isset($referencesIndex[$unqualifiedClassName]) || in_array($unqualifiedClassName, $definedClassesIndex ?? [], true)) {
+				if (isset($referencesIndex[$unqualifiedClassName]) || array_key_exists($unqualifiedClassName, $definedClassesIndex ?? [])) {
 					continue;
 				}
 			}

--- a/SlevomatCodingStandard/Sniffs/Namespaces/ReferenceUsedNamesOnlySniff.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/ReferenceUsedNamesOnlySniff.php
@@ -149,7 +149,7 @@ class ReferenceUsedNamesOnlySniff implements \PHP_CodeSniffer_Sniff
 			$canonicalName = NamespaceHelper::normalizeToCanonicalName($name);
 
 			if ($this->allowFullyQualifiedNameForCollidingClasses) {
-				$unqualifiedClassName = NamespaceHelper::getUnqualifiedNameFromFullyQualifiedName($referencedName->getNameAsReferencedInFile());
+				$unqualifiedClassName = NamespaceHelper::getUnqualifiedNameFromFullyQualifiedName($name);
 				if (isset($referencesIndex[$unqualifiedClassName]) || in_array($unqualifiedClassName, $definedClassesIndex ?? [], true)) {
 					continue;
 				}

--- a/tests/Sniffs/Namespaces/ReferenceUsedNamesOnlySniffTest.php
+++ b/tests/Sniffs/Namespaces/ReferenceUsedNamesOnlySniffTest.php
@@ -605,4 +605,23 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 		$this->assertSniffError($report, 14, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
 	}
 
+	public function testCollidingClassNameExtendsAllowed()
+	{
+		$report = $this->checkFile(
+			__DIR__ . '/data/collidingClassNameExtends.php',
+			['allowFullyQualifiedNameForCollidingClasses' => true]
+		);
+		$this->assertNoSniffErrorInFile($report);
+	}
+
+	public function testCollidingClassNameExtendsDisabled()
+	{
+		$report = $this->checkFile(
+			__DIR__ . '/data/collidingClassNameExtends.php',
+			['allowFullyQualifiedNameForCollidingClasses' => false]
+		);
+		$this->assertSame(1, $report->getErrorCount());
+		$this->assertSniffError($report, 5, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
+	}
+
 }

--- a/tests/Sniffs/Namespaces/data/collidingClassNameExtends.php
+++ b/tests/Sniffs/Namespaces/data/collidingClassNameExtends.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Alpha;
+
+class Foo extends \Beta\Foo {
+
+}


### PR DESCRIPTION
There were bug in finding referenced classes in their index. Instead of looking into keys I have looked into values, which of course cannot work.