### PR TITLE
Detect property reads inside double quoted strings

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Classes/UnusedPrivateElementsSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/UnusedPrivateElementsSniff.php
@@ -376,7 +376,8 @@ class UnusedPrivateElementsSniff implements \PHP_CodeSniffer_Sniff
 					&& isset($tokens[$index + 1])
 					&& $tokens[$index + 1][0] === T_OBJECT_OPERATOR
 					&& isset($tokens[$index + 2])
-					&& $tokens[$index + 2][0] === T_STRING;
+					&& $tokens[$index + 2][0] === T_STRING
+					&& (!isset($tokens[$index + 3]) || is_array($tokens[$index + 3]) || $tokens[$index + 3] !== '(');
 			},
 			ARRAY_FILTER_USE_BOTH
 		);

--- a/tests/Sniffs/Classes/UnusedPrivateElementsSniffTest.php
+++ b/tests/Sniffs/Classes/UnusedPrivateElementsSniffTest.php
@@ -101,4 +101,9 @@ class UnusedPrivateElementsSniffTest extends \SlevomatCodingStandard\Sniffs\Test
 		);
 	}
 
+	public function testClassWithPropertyReadInString()
+	{
+		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/classWithPropertyReadInString.php'));
+	}
+
 }

--- a/tests/Sniffs/Classes/UnusedPrivateElementsSniffTest.php
+++ b/tests/Sniffs/Classes/UnusedPrivateElementsSniffTest.php
@@ -103,7 +103,15 @@ class UnusedPrivateElementsSniffTest extends \SlevomatCodingStandard\Sniffs\Test
 
 	public function testClassWithPropertyReadInString()
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/classWithPropertyReadInString.php'));
+		$resultFile = $this->checkFile(__DIR__ . '/data/classWithPropertyReadInString.php');
+
+		$this->assertNoSniffError($resultFile, 6);
+		$this->assertSniffError(
+			$resultFile,
+			7,
+			UnusedPrivateElementsSniff::CODE_WRITE_ONLY_PROPERTY,
+			'Class Foo contains write-only property $foo.'
+		);
 	}
 
 }

--- a/tests/Sniffs/Classes/data/classWithPropertyReadInString.php
+++ b/tests/Sniffs/Classes/data/classWithPropertyReadInString.php
@@ -1,0 +1,18 @@
+<?php
+
+class Foo
+{
+
+	private $bar;
+
+	public function __construct(string $bar)
+	{
+		$this->bar = $bar;
+	}
+
+	public function __toString(): string
+	{
+		return "foo{$this->bar}";
+	}
+
+}

--- a/tests/Sniffs/Classes/data/classWithPropertyReadInString.php
+++ b/tests/Sniffs/Classes/data/classWithPropertyReadInString.php
@@ -4,15 +4,17 @@ class Foo
 {
 
 	private $bar;
+	private $foo;
 
-	public function __construct(string $bar)
+	public function __construct(string $bar, string $foo)
 	{
 		$this->bar = $bar;
+		$this->foo = $foo;
 	}
 
 	public function __toString(): string
 	{
-		return "foo{$this->bar}";
+		return "foo{$this->bar}bar{$this->foo()}";
 	}
 
 }


### PR DESCRIPTION
Previous version of sniff was not detecting property reads inside of double quoted strings (unfortuntelly, phpcs internal tokenizer does not tokenize content of double quoted strings - manual parsing needed to be done).