### PR TITLE
TypeHintDeclarationSniff: Respect inheritance when suggesting adding native type hints (failing test only)

### DIFF
--- a/tests/Sniffs/TypeHints/TypeHintDeclarationSniffTest.php
+++ b/tests/Sniffs/TypeHints/TypeHintDeclarationSniffTest.php
@@ -189,6 +189,16 @@ class TypeHintDeclarationSniffTest extends \SlevomatCodingStandard\Sniffs\TestCa
 		$this->assertSniffError($report, 27, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
 	}
 
+	public function testMissingParameterTypeHintCheckHonorsCompatibilityWithParent()
+	{
+		$report = $this->checkFile(
+			__DIR__ . '/data/typeHintDeclarationParameterTypeHintParentCompatibilityNoErrors.php',
+			[],
+			[TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT]
+		);
+		$this->assertNoSniffErrorInFile($report);
+	}
+
 	public function testFixableReturnTypeHints()
 	{
 		$report = $this->checkFile(__DIR__ . '/data/fixableReturnTypeHints.php', [

--- a/tests/Sniffs/TypeHints/data/typeHintDeclarationParameterTypeHintParentCompatibilityNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/typeHintDeclarationParameterTypeHintParentCompatibilityNoErrors.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace FooNamespace;
+
+abstract class FooClass
+{
+
+	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+	 * @param int $foo
+	 */
+	abstract public function withAbstractUntypedParameter($foo);
+
+	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+	 * @param int $foo
+	 */
+	public function withUntypedParameter($foo)
+	{
+
+	}
+
+}
+
+interface BarInterface
+{
+
+	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+	 * @param int $foo
+	 */
+	public function withInterfaceUntypedParameter($foo);
+
+}
+
+final class BazClass extends FooClass implements BarInterface
+{
+
+	/**
+	 * @param int $foo
+	 */
+	public function withInterfaceUntypedParameter($foo)
+	{
+
+	}
+
+	/**
+	 * @param int $foo
+	 */
+	public function withAbstractUntypedParameter($foo)
+	{
+
+	}
+
+	/**
+	 * @param int $foo
+	 */
+	public function withUntypedParameter($foo)
+	{
+
+	}
+
+}


### PR DESCRIPTION
The TypeHintDeclaration.MissingParameterTypeHint currently does not verify whether the typehint could be added or not.
When the ancestor has a parameter without type (i.e. Symfony, Doctrine and other PHP5-compatible code), it still wants to add the type, even though it'd be a violation of the inheritance.

Only failing test added (at least for now).