### PR TITLE
EmptyLinesAroundTypeBracesSniff: Allow configurable number of lines around braces

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Types/EmptyLinesAroundTypeBracesSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Types/EmptyLinesAroundTypeBracesSniff.php
@@ -2,6 +2,8 @@
 
 namespace SlevomatCodingStandard\Sniffs\Types;
 
+use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
+
 class EmptyLinesAroundTypeBracesSniff implements \PHP_CodeSniffer_Sniff
 {
 
@@ -9,9 +11,19 @@ class EmptyLinesAroundTypeBracesSniff implements \PHP_CodeSniffer_Sniff
 
 	const CODE_MULTIPLE_EMPTY_LINES_AFTER_OPENING_BRACE = 'MultipleEmptyLinesAfterOpeningBrace';
 
+	const CODE_INCORRECT_EMPTY_LINES_AFTER_OPENING_BRACE = 'IncorrectEmptyLinesAfterOpeningBrace';
+
 	const CODE_NO_EMPTY_LINE_BEFORE_CLOSING_BRACE = 'NoEmptyLineBeforeClosingBrace';
 
 	const CODE_MULTIPLE_EMPTY_LINES_BEFORE_CLOSING_BRACE = 'MultipleEmptyLinesBeforeClosingBrace';
+
+	const CODE_INCORRECT_EMPTY_LINES_BEFORE_CLOSING_BRACE = 'IncorrectEmptyLinesBeforeClosingBrace';
+
+	/** @var int */
+	public $linesCountAfterOpeningBrace = 1;
+
+	/** @var int */
+	public $linesCountBeforeClosingBrace = 1;
 
 	/**
 	 * @return int[]
@@ -32,73 +44,118 @@ class EmptyLinesAroundTypeBracesSniff implements \PHP_CodeSniffer_Sniff
 	 */
 	public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPointer)
 	{
+		$this->processOpeningBrace($phpcsFile, $stackPointer);
+		$this->processClosingBrace($phpcsFile, $stackPointer);
+	}
+
+	private function processOpeningBrace(\PHP_CodeSniffer_File $phpcsFile, int $stackPointer)
+	{
 		$tokens = $phpcsFile->getTokens();
 		$typeToken = $tokens[$stackPointer];
 		$openerPointer = $typeToken['scope_opener'];
 		$openerToken = $tokens[$openerPointer];
 		$nextPointerAfterOpeningBrace = $phpcsFile->findNext(T_WHITESPACE, $openerPointer + 1, null, true);
 		$nextTokenAfterOpeningBrace = $tokens[$nextPointerAfterOpeningBrace];
-
+		$linesCountAfterOpeningBrace = SniffSettingsHelper::normalizeInteger($this->linesCountAfterOpeningBrace);
 		$lines = $nextTokenAfterOpeningBrace['line'] - $openerToken['line'] - 1;
-		if ($lines === 0) {
-			$fix = $phpcsFile->addFixableError(sprintf(
-				'There must be one empty line after %s opening brace.',
-				$typeToken['content']
-			), $openerPointer, self::CODE_NO_EMPTY_LINE_AFTER_OPENING_BRACE);
 
-			if ($fix) {
-				$phpcsFile->fixer->beginChangeset();
-				$phpcsFile->fixer->addNewline($openerPointer);
-				$phpcsFile->fixer->endChangeset();
-			}
-		} elseif ($lines > 1) {
-			$fix = $phpcsFile->addFixableError(sprintf(
-				'There must be one empty line after %s opening brace.',
-				$typeToken['content']
-			), $openerPointer, self::CODE_MULTIPLE_EMPTY_LINES_AFTER_OPENING_BRACE);
-
-			if ($fix) {
-				$phpcsFile->fixer->beginChangeset();
-				for ($i = $openerPointer + 3; $i < $nextPointerAfterOpeningBrace; $i++) {
-					if ($tokens[$i]['content'] !== $phpcsFile->eolChar) {
-						break;
-					}
-					$phpcsFile->fixer->replaceToken($i, '');
-				}
-				$phpcsFile->fixer->endChangeset();
-			}
+		if ($lines === $linesCountAfterOpeningBrace) {
+			return;
 		}
 
+		if ($linesCountAfterOpeningBrace === 1) {
+			if ($lines === 0) {
+				$fix = $phpcsFile->addFixableError(sprintf(
+					'There must be one empty line after %s opening brace.',
+					$typeToken['content']
+				), $openerPointer, self::CODE_NO_EMPTY_LINE_AFTER_OPENING_BRACE);
+			} else {
+				$fix = $phpcsFile->addFixableError(sprintf(
+					'There must be one empty line after %s opening brace.',
+					$typeToken['content']
+				), $openerPointer, self::CODE_MULTIPLE_EMPTY_LINES_AFTER_OPENING_BRACE);
+			}
+		} else {
+			$fix = $phpcsFile->addFixableError(sprintf(
+				'There must be exactly %d empty lines after %s opening brace.',
+				$linesCountAfterOpeningBrace,
+				$typeToken['content']
+			), $openerPointer, self::CODE_INCORRECT_EMPTY_LINES_AFTER_OPENING_BRACE);
+		}
+
+		if (!$fix) {
+			return;
+		}
+
+		if ($lines < $linesCountAfterOpeningBrace) {
+			$phpcsFile->fixer->beginChangeset();
+			for ($i = $lines; $i < $linesCountAfterOpeningBrace; $i++) {
+				$phpcsFile->fixer->addNewline($openerPointer);
+			}
+			$phpcsFile->fixer->endChangeset();
+		} else {
+			$phpcsFile->fixer->beginChangeset();
+			for ($i = $openerPointer + $linesCountAfterOpeningBrace + 2; $i < $nextPointerAfterOpeningBrace; $i++) {
+				if ($tokens[$i]['content'] !== $phpcsFile->eolChar) {
+					break;
+				}
+				$phpcsFile->fixer->replaceToken($i, '');
+			}
+			$phpcsFile->fixer->endChangeset();
+		}
+	}
+
+	private function processClosingBrace(\PHP_CodeSniffer_File $phpcsFile, int $stackPointer)
+	{
+		$tokens = $phpcsFile->getTokens();
+		$typeToken = $tokens[$stackPointer];
 		$closerPointer = $typeToken['scope_closer'];
 		$closerToken = $tokens[$closerPointer];
 		$previousPointerBeforeClosingBrace = $phpcsFile->findPrevious(T_WHITESPACE, $closerPointer - 1, null, true);
 		$previousTokenBeforeClosingBrace = $tokens[$previousPointerBeforeClosingBrace];
-
+		$linesCountBeforeClosingBrace = SniffSettingsHelper::normalizeInteger($this->linesCountBeforeClosingBrace);
 		$lines = $closerToken['line'] - $previousTokenBeforeClosingBrace['line'] - 1;
-		if ($lines === 0) {
-			$fix = $phpcsFile->addFixableError(sprintf(
-				'There must be one empty line before %s closing brace.',
-				$typeToken['content']
-			), $closerPointer, self::CODE_NO_EMPTY_LINE_BEFORE_CLOSING_BRACE);
 
-			if ($fix) {
-				$phpcsFile->fixer->beginChangeset();
+		if ($lines === $linesCountBeforeClosingBrace) {
+			return;
+		}
+
+		if ($linesCountBeforeClosingBrace === 1) {
+			if ($lines === 0) {
+				$fix = $phpcsFile->addFixableError(sprintf(
+					'There must be one empty line before %s closing brace.',
+					$typeToken['content']
+				), $closerPointer, self::CODE_NO_EMPTY_LINE_BEFORE_CLOSING_BRACE);
+			} else {
+				$fix = $phpcsFile->addFixableError(sprintf(
+					'There must be one empty line before %s closing brace.',
+					$typeToken['content']
+				), $closerPointer, self::CODE_MULTIPLE_EMPTY_LINES_BEFORE_CLOSING_BRACE);
+			}
+		} else {
+			$fix = $phpcsFile->addFixableError(sprintf(
+				'There must be exactly %d empty lines before %s closing brace.',
+				$linesCountBeforeClosingBrace,
+				$typeToken['content']
+			), $closerPointer, self::CODE_INCORRECT_EMPTY_LINES_BEFORE_CLOSING_BRACE);
+		}
+
+		if (!$fix) {
+			return;
+		}
+
+		if ($lines < $linesCountBeforeClosingBrace) {
+			$phpcsFile->fixer->beginChangeset();
+			for ($i = $lines; $i < $linesCountBeforeClosingBrace; $i++) {
 				$phpcsFile->fixer->addNewlineBefore($closerPointer);
-				$phpcsFile->fixer->endChangeset();
 			}
-		} elseif ($lines > 1) {
-			$fix = $phpcsFile->addFixableError(sprintf(
-				'There must be one empty line before %s closing brace.',
-				$typeToken['content']
-			), $closerPointer, self::CODE_MULTIPLE_EMPTY_LINES_BEFORE_CLOSING_BRACE);
-
-			if ($fix) {
-				$phpcsFile->fixer->beginChangeset();
-				for ($i = $previousPointerBeforeClosingBrace + 3; $i < $closerPointer; $i++) {
-					$phpcsFile->fixer->replaceToken($i, '');
-				}
-				$phpcsFile->fixer->endChangeset();
+			$phpcsFile->fixer->endChangeset();
+		} else {
+			$phpcsFile->fixer->beginChangeset();
+			for ($i = $previousPointerBeforeClosingBrace + $linesCountBeforeClosingBrace + 2; $i < $closerPointer; $i++) {
+				$phpcsFile->fixer->replaceToken($i, '');
 			}
+			$phpcsFile->fixer->endChangeset();
 		}
 	}
 

--- a/tests/Sniffs/Types/EmptyLinesAroundTypeBracesSniffTest.php
+++ b/tests/Sniffs/Types/EmptyLinesAroundTypeBracesSniffTest.php
@@ -54,4 +54,84 @@ class EmptyLinesAroundTypeBracesSniffTest extends \SlevomatCodingStandard\Sniffs
 		$this->assertAllFixedInFile($report);
 	}
 
+	public function testCorrectCorrectEmptyLinesWithZeroLines()
+	{
+		$report = $this->checkFile(__DIR__ . '/data/correctEmptyLinesZeroLines.php', [
+			'linesCountAfterOpeningBrace' => 0,
+			'linesCountBeforeClosingBrace' => 0,
+		]);
+
+		$this->assertNoSniffErrorInFile($report);
+	}
+
+	public function testOneLineAfterOpeningBraceWithZeroExpected()
+	{
+		$report = $this->checkFile(
+			__DIR__ . '/data/oneEmptyLineAfterOpeningBraceWithZeroExpected.php',
+			['linesCountAfterOpeningBrace' => 0],
+			[EmptyLinesAroundTypeBracesSniff::CODE_INCORRECT_EMPTY_LINES_AFTER_OPENING_BRACE]
+		);
+
+		$this->assertSame(1, $report->getErrorCount());
+
+		$this->assertSniffError($report, 4, EmptyLinesAroundTypeBracesSniff::CODE_INCORRECT_EMPTY_LINES_AFTER_OPENING_BRACE);
+
+		$this->assertAllFixedInFile($report);
+	}
+
+	public function testOneLineBeforeClosingBraceWithZeroExpected()
+	{
+		$report = $this->checkFile(
+			__DIR__ . '/data/oneEmptyLineBeforeClosingBraceWithZeroExpected.php',
+			['linesCountBeforeClosingBrace' => 0],
+			[EmptyLinesAroundTypeBracesSniff::CODE_INCORRECT_EMPTY_LINES_BEFORE_CLOSING_BRACE]
+		);
+
+		$this->assertSame(1, $report->getErrorCount());
+
+		$this->assertSniffError($report, 10, EmptyLinesAroundTypeBracesSniff::CODE_INCORRECT_EMPTY_LINES_BEFORE_CLOSING_BRACE);
+
+		$this->assertAllFixedInFile($report);
+	}
+
+	public function testCorrectCorrectEmptyLinesWithTwoLines()
+	{
+		$report = $this->checkFile(__DIR__ . '/data/correctEmptyLinesTwoLines.php', [
+			'linesCountAfterOpeningBrace' => 2,
+			'linesCountBeforeClosingBrace' => 2,
+		]);
+
+		$this->assertNoSniffErrorInFile($report);
+	}
+
+	public function testOneLineAfterOpeningBraceWithTwoExpected()
+	{
+		$report = $this->checkFile(
+			__DIR__ . '/data/oneEmptyLineAfterOpeningBraceWithTwoExpected.php',
+			['linesCountAfterOpeningBrace' => 2],
+			[EmptyLinesAroundTypeBracesSniff::CODE_INCORRECT_EMPTY_LINES_AFTER_OPENING_BRACE]
+		);
+
+		$this->assertSame(1, $report->getErrorCount());
+
+		$this->assertSniffError($report, 4, EmptyLinesAroundTypeBracesSniff::CODE_INCORRECT_EMPTY_LINES_AFTER_OPENING_BRACE);
+
+		$this->assertAllFixedInFile($report);
+	}
+
+	public function testOneLineBeforeClosingBraceWithTwoExpected()
+	{
+		$report = $this->checkFile(
+			__DIR__ . '/data/oneEmptyLineBeforeClosingBraceWithTwoExpected.php',
+			['linesCountBeforeClosingBrace' => 2],
+			[EmptyLinesAroundTypeBracesSniff::CODE_INCORRECT_EMPTY_LINES_BEFORE_CLOSING_BRACE]
+		);
+
+		$this->assertSame(1, $report->getErrorCount());
+
+		$this->assertSniffError($report, 12, EmptyLinesAroundTypeBracesSniff::CODE_INCORRECT_EMPTY_LINES_BEFORE_CLOSING_BRACE);
+
+		$this->assertAllFixedInFile($report);
+	}
+
 }

--- a/tests/Sniffs/Types/data/correctEmptyLinesTwoLines.php
+++ b/tests/Sniffs/Types/data/correctEmptyLinesTwoLines.php
@@ -1,0 +1,13 @@
+<?php
+
+class Foo
+{
+
+
+	public function bar()
+	{
+
+	}
+
+
+}

--- a/tests/Sniffs/Types/data/correctEmptyLinesZeroLines.php
+++ b/tests/Sniffs/Types/data/correctEmptyLinesZeroLines.php
@@ -1,0 +1,9 @@
+<?php
+
+class Foo
+{
+	public function bar()
+	{
+
+	}
+}

--- a/tests/Sniffs/Types/data/oneEmptyLineAfterOpeningBraceWithTwoExpected.fixed.php
+++ b/tests/Sniffs/Types/data/oneEmptyLineAfterOpeningBraceWithTwoExpected.fixed.php
@@ -1,0 +1,13 @@
+<?php
+
+class Foo
+{
+
+
+	public function bar()
+	{
+
+	}
+
+
+}

--- a/tests/Sniffs/Types/data/oneEmptyLineAfterOpeningBraceWithTwoExpected.php
+++ b/tests/Sniffs/Types/data/oneEmptyLineAfterOpeningBraceWithTwoExpected.php
@@ -1,0 +1,12 @@
+<?php
+
+class Foo
+{
+
+	public function bar()
+	{
+
+	}
+
+
+}

--- a/tests/Sniffs/Types/data/oneEmptyLineAfterOpeningBraceWithZeroExpected.fixed.php
+++ b/tests/Sniffs/Types/data/oneEmptyLineAfterOpeningBraceWithZeroExpected.fixed.php
@@ -1,0 +1,9 @@
+<?php
+
+class Foo
+{
+	public function bar()
+	{
+
+	}
+}

--- a/tests/Sniffs/Types/data/oneEmptyLineAfterOpeningBraceWithZeroExpected.php
+++ b/tests/Sniffs/Types/data/oneEmptyLineAfterOpeningBraceWithZeroExpected.php
@@ -1,0 +1,10 @@
+<?php
+
+class Foo
+{
+
+	public function bar()
+	{
+
+	}
+}

--- a/tests/Sniffs/Types/data/oneEmptyLineBeforeClosingBraceWithTwoExpected.fixed.php
+++ b/tests/Sniffs/Types/data/oneEmptyLineBeforeClosingBraceWithTwoExpected.fixed.php
@@ -1,0 +1,13 @@
+<?php
+
+class Foo
+{
+
+
+	public function bar()
+	{
+
+	}
+
+
+}

--- a/tests/Sniffs/Types/data/oneEmptyLineBeforeClosingBraceWithTwoExpected.php
+++ b/tests/Sniffs/Types/data/oneEmptyLineBeforeClosingBraceWithTwoExpected.php
@@ -1,0 +1,12 @@
+<?php
+
+class Foo
+{
+
+
+	public function bar()
+	{
+
+	}
+
+}

--- a/tests/Sniffs/Types/data/oneEmptyLineBeforeClosingBraceWithZeroExpected.fixed.php
+++ b/tests/Sniffs/Types/data/oneEmptyLineBeforeClosingBraceWithZeroExpected.fixed.php
@@ -1,0 +1,9 @@
+<?php
+
+class Foo
+{
+	public function bar()
+	{
+
+	}
+}

--- a/tests/Sniffs/Types/data/oneEmptyLineBeforeClosingBraceWithZeroExpected.php
+++ b/tests/Sniffs/Types/data/oneEmptyLineBeforeClosingBraceWithZeroExpected.php
@@ -1,0 +1,10 @@
+<?php
+
+class Foo
+{
+	public function bar()
+	{
+
+	}
+
+}


### PR DESCRIPTION
This PR allows configurable number of empty lines after opening brace and closing brace, using `$linesCountAfterOpeningBrace` and `$linesCountAfterOpeningBrace` respectively.

Both default to 1 empty line which is current behavior, thus BC should be preserved.

Motivation is simple, there is a code out there that requires either no or 2-3 spaces.