### PR TITLE
ReferenceUsedNamesOnlySniff: Add option to allow fully-qualified global classes

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Namespaces/ReferenceUsedNamesOnlySniff.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/ReferenceUsedNamesOnlySniff.php
@@ -29,6 +29,9 @@ class ReferenceUsedNamesOnlySniff implements \PHP_CodeSniffer_Sniff
 	/** @var bool */
 	public $allowFullyQualifiedExceptions = false;
 
+	/** @var bool */
+	public $allowFullyQualifiedGlobalClasses = false;
+
 	/** @var string[] */
 	public $specialExceptionNames = [];
 
@@ -185,7 +188,7 @@ class ReferenceUsedNamesOnlySniff implements \PHP_CodeSniffer_Sniff
 							$phpcsFile->fixer->replaceToken($nameStartPointer, substr($tokens[$nameStartPointer]['content'], 1));
 							$phpcsFile->fixer->endChangeset();
 						}
-					} else {
+					} elseif (!$this->allowFullyQualifiedGlobalClasses || NamespaceHelper::hasNamespace($name)) {
 						$fix = $phpcsFile->addFixableError(sprintf(
 							'Type %s should not be referenced via a fully qualified name, but via a use statement.',
 							$name

--- a/tests/Sniffs/Namespaces/ReferenceUsedNamesOnlySniffTest.php
+++ b/tests/Sniffs/Namespaces/ReferenceUsedNamesOnlySniffTest.php
@@ -541,6 +541,17 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 		$this->assertContains('Value for keyword token not found, constant "T_FOO" is not defined', $report->getErrors()[1][1][0]['message']);
 	}
 
+	public function testAllowingFullyQualifiedGlobalTypes()
+	{
+		$report = $this->checkFile(
+			__DIR__ . '/data/fullyQualifiedGlobalClassesInNamespace.php',
+			[
+				'allowFullyQualifiedGlobalClasses' => true,
+			]
+		);
+		$this->assertNoSniffErrorInFile($report);
+	}
+
 
 	public function testFixableReferenceViaFullyQualifiedName()
 	{

--- a/tests/Sniffs/Namespaces/data/fullyQualifiedGlobalClassesInNamespace.php
+++ b/tests/Sniffs/Namespaces/data/fullyQualifiedGlobalClassesInNamespace.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Foo;
+
+class Bar implements \Iterator
+{
+
+	public function baz(\DateTimeInterface $date)
+	{
+
+	}
+
+}
+
+new \DateTimeImmutable();
+
+echo \DateTime::ISO8601;


### PR DESCRIPTION
This should resolve #76. Setting `allowFullyQualifiedGlobalClasses` to `true` should enable ignoring FQCN from global namespace.

Many people (myself included) prefer FQCN for classes from global namespace rather than putting them in use.

The change seems a bit too simple for such complex code so please check whether it's enough or something else needs changing. 😊 