### PR TITLE
TypeHintDeclarationSniff: Implemented inspection of useless parameter & return annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Sniff provides the following settings:
 * `enableVoidTypeHint`: enforces to transform `@return void` into native `void` return typehint. It's on by default if you're on PHP 7.1.
 * `traversableTypeHints`: enforces which typehints must have specified contained type. E. g. if you set this to `\Doctrine\Common\Collections\Collection`, then `\Doctrine\Common\Collections\Collection` must always be supplied with the contained type: `\Doctrine\Common\Collections\Collection|Foo[]`.
 * `usefulAnnotations`: prevents reporting and removing useless phpDocs if they contain an additional configured annotation like `@dataProvider`.
+* `enableEachParameterAndReturnInspection`: enables inspection and fixing of `@param` and `@return` annotations separately. Useful when you only want to document parameters or return values that could not be expressed natively (i.e. member types of `array` or `Traversable`).
 
 #### SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly 🔧
 

--- a/tests/Sniffs/TypeHints/TypeHintDeclarationSniffTest.php
+++ b/tests/Sniffs/TypeHints/TypeHintDeclarationSniffTest.php
@@ -191,6 +191,43 @@ class TypeHintDeclarationSniffTest extends \SlevomatCodingStandard\Sniffs\TestCa
 		$this->assertSniffError($report, 27, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
 	}
 
+	public function testEnabledEachParameterAndReturnInspectionNoErrors()
+	{
+		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/typeHintDeclarationEnabledEachParameterAndReturnInspectionNoErrors.php', [
+			'enableNullableTypeHints' => false,
+			'enableVoidTypeHint' => false,
+			'enableEachParameterAndReturnInspection' => true,
+		]));
+	}
+
+	public function testEnabledEachParameterAndReturnInspectionErrors()
+	{
+		$report = $this->checkFile(__DIR__ . '/data/typeHintDeclarationEnabledEachParameterAndReturnInspectionErrors.php', [
+			'enableNullableTypeHints' => false,
+			'enableVoidTypeHint' => false,
+			'usefulAnnotations' => ['@useful'],
+			'enableEachParameterAndReturnInspection' => true,
+		]);
+
+		$this->assertSame(11, $report->getErrorCount());
+
+		$parameterMessage = function (string $method, string $parameter): string {
+			return sprintf('Method \FooNamespace\FooClass::%s() has useless @param annotation for parameter $%s.', $method, $parameter);
+		};
+
+		$this->assertSniffError($report, 11, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		$this->assertSniffError($report, 18, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		$this->assertSniffError($report, 27, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		$this->assertSniffError($report, 35, TypeHintDeclarationSniff::CODE_USELESS_PARAMETER_ANNOTATION, $parameterMessage('withUselessParameterButRequiredReturn', 'foo'));
+		$this->assertSniffError($report, 45, TypeHintDeclarationSniff::CODE_USELESS_PARAMETER_ANNOTATION, $parameterMessage('withMultipleUselessParametersAndReturn', 'foo'));
+		$this->assertSniffError($report, 45, TypeHintDeclarationSniff::CODE_USELESS_PARAMETER_ANNOTATION, $parameterMessage('withMultipleUselessParametersAndReturn', 'baz'));
+		$this->assertSniffError($report, 45, TypeHintDeclarationSniff::CODE_USELESS_RETURN_ANNOTATION);
+		$this->assertSniffError($report, 53, TypeHintDeclarationSniff::CODE_USELESS_PARAMETER_ANNOTATION, $parameterMessage('withDescriptionAndUselessParameter', 'foo'));
+		$this->assertSniffError($report, 61, TypeHintDeclarationSniff::CODE_USELESS_RETURN_ANNOTATION);
+		$this->assertSniffError($report, 69, TypeHintDeclarationSniff::CODE_USELESS_PARAMETER_ANNOTATION, $parameterMessage('withUsefulAnnotationAndUselessParameter', 'foo'));
+		$this->assertSniffError($report, 77, TypeHintDeclarationSniff::CODE_USELESS_RETURN_ANNOTATION);
+	}
+
 	public function testFixableReturnTypeHints()
 	{
 		$report = $this->checkFile(__DIR__ . '/data/fixableReturnTypeHints.php', [
@@ -255,6 +292,18 @@ class TypeHintDeclarationSniffTest extends \SlevomatCodingStandard\Sniffs\TestCa
 			'enableNullableTypeHints' => true,
 			'enableVoidTypeHint' => true,
 		], [TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT]);
+
+		$this->assertAllFixedInFile($report);
+	}
+
+	public function testFixableEnableEachParameterAndReturnInspection()
+	{
+		$report = $this->checkFile(__DIR__ . '/data/fixableEnableEachParameterAndReturnInspection.php', [
+			'enableNullableTypeHints' => false,
+			'enableVoidTypeHint' => false,
+			'enableEachParameterAndReturnInspection' => true,
+			'usefulAnnotations' => ['@useful'],
+		], [TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT, TypeHintDeclarationSniff::CODE_USELESS_PARAMETER_ANNOTATION, TypeHintDeclarationSniff::CODE_USELESS_RETURN_ANNOTATION]);
 
 		$this->assertAllFixedInFile($report);
 	}

--- a/tests/Sniffs/TypeHints/data/fixableEnableEachParameterAndReturnInspection.fixed.php
+++ b/tests/Sniffs/TypeHints/data/fixableEnableEachParameterAndReturnInspection.fixed.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace FooNamespace;
+
+abstract class FooClass
+{
+
+	public function withUselessDocCommentHavingUselessReturn(): int
+	{
+	}
+
+	public function withUselessDocCommentHavingUselessParameter(int $foo)
+	{
+	}
+
+	public function withUselessDocCommentHavingUselessParametersAndReturn(int $foo, string $bar): int
+	{
+	}
+
+	/**
+	 * @return int[]
+	 */
+	public function withUselessParameterButRequiredReturn(int $foo): array
+	{
+	}
+
+	/**
+	 * @param int[] $bar
+	 */
+	public function withMultipleUselessParametersAndReturn(int $foo, array $bar, int $baz): int
+	{
+	}
+
+	/**
+	 * Test
+	 */
+	public function withDescriptionAndUselessParameter(int $foo)
+	{
+	}
+
+	/**
+	 * Test
+	 */
+	public function withDescriptionAndUselessReturn(): int
+	{
+	}
+
+	/**
+	 * @useful test
+	 */
+	public function withUsefulAnnotationAndUselessParameter(int $foo)
+	{
+	}
+
+	/**
+	 * @useful test
+	 */
+	public function withUsefulAnnotationAndUselessReturn(): int
+	{
+	}
+
+	public function withMalformedParameters(int $foo)
+	{
+	}
+
+	/**
+	 * @param hello
+	 * @useful hello
+	 * @param
+	 */
+	public function withMalformedAndUsefulTags(int $foo)
+	{
+	}
+
+}

--- a/tests/Sniffs/TypeHints/data/fixableEnableEachParameterAndReturnInspection.php
+++ b/tests/Sniffs/TypeHints/data/fixableEnableEachParameterAndReturnInspection.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace FooNamespace;
+
+abstract class FooClass
+{
+
+	/**
+	 * @return int
+	 */
+	public function withUselessDocCommentHavingUselessReturn(): int
+	{
+	}
+
+	/**
+	 * @param int $foo
+	 */
+	public function withUselessDocCommentHavingUselessParameter(int $foo)
+	{
+	}
+
+	/**
+	 * @param int $foo
+	 * @param string $bar
+	 * @return int
+	 */
+	public function withUselessDocCommentHavingUselessParametersAndReturn(int $foo, string $bar): int
+	{
+	}
+
+	/**
+	 * @param int $foo
+	 * @return int[]
+	 */
+	public function withUselessParameterButRequiredReturn(int $foo): array
+	{
+	}
+
+	/**
+	 * @param int $foo
+	 * @param int[] $bar
+	 * @param int $baz
+	 * @return int
+	 */
+	public function withMultipleUselessParametersAndReturn(int $foo, array $bar, int $baz): int
+	{
+	}
+
+	/**
+	 * Test
+	 * @param int $foo
+	 */
+	public function withDescriptionAndUselessParameter(int $foo)
+	{
+	}
+
+	/**
+	 * Test
+	 * @return int
+	 */
+	public function withDescriptionAndUselessReturn(): int
+	{
+	}
+
+	/**
+	 * @useful test
+	 * @param int $foo
+	 */
+	public function withUsefulAnnotationAndUselessParameter(int $foo)
+	{
+	}
+
+	/**
+	 * @useful test
+	 * @return int
+	 */
+	public function withUsefulAnnotationAndUselessReturn(): int
+	{
+	}
+
+	/**
+	 * @param hello
+	 * @param int $foo
+	 * @param
+	 */
+	public function withMalformedParameters(int $foo)
+	{
+	}
+
+	/**
+	 * @param hello
+	 * @useful hello
+	 * @param int $foo
+	 * @param
+	 */
+	public function withMalformedAndUsefulTags(int $foo)
+	{
+	}
+
+}

--- a/tests/Sniffs/TypeHints/data/typeHintDeclarationEnabledEachParameterAndReturnInspectionErrors.php
+++ b/tests/Sniffs/TypeHints/data/typeHintDeclarationEnabledEachParameterAndReturnInspectionErrors.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace FooNamespace;
+
+abstract class FooClass
+{
+
+	/**
+	 * @return int
+	 */
+	public function withUselessDocCommentHavingUselessReturn(): int
+	{
+	}
+
+	/**
+	 * @param int $foo
+	 */
+	public function withUselessDocCommentHavingUselessParameter(int $foo)
+	{
+	}
+
+	/**
+	 * @param int $foo
+	 * @param string $bar
+	 * @return int
+	 */
+	public function withUselessDocCommentHavingUselessParametersAndReturn(int $foo, string $bar): int
+	{
+	}
+
+	/**
+	 * @param int $foo
+	 * @return int[]
+	 */
+	public function withUselessParameterButRequiredReturn(int $foo): array
+	{
+	}
+
+	/**
+	 * @param int $foo
+	 * @param int[] $bar
+	 * @param int $baz
+	 * @return int
+	 */
+	public function withMultipleUselessParametersAndReturn(int $foo, array $bar, int $baz): int
+	{
+	}
+
+	/**
+	 * Test
+	 * @param int $foo
+	 */
+	public function withDescriptionAndUselessParameter(int $foo)
+	{
+	}
+
+	/**
+	 * Test
+	 * @return int
+	 */
+	public function withDescriptionAndUselessReturn(): int
+	{
+	}
+
+	/**
+	 * @useful test
+	 * @param int $foo
+	 */
+	public function withUsefulAnnotationAndUselessParameter(int $foo)
+	{
+	}
+
+	/**
+	 * @useful test
+	 * @return int
+	 */
+	public function withUsefulAnnotationAndUselessReturn(): int
+	{
+	}
+
+}

--- a/tests/Sniffs/TypeHints/data/typeHintDeclarationEnabledEachParameterAndReturnInspectionNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/typeHintDeclarationEnabledEachParameterAndReturnInspectionNoErrors.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace FooNamespace;
+
+abstract class FooClass
+{
+
+	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration
+	 * @param int $foo
+	 * @return int
+	 */
+	public function withGlobalSuppress(int $foo, array $bar): int
+	{
+	}
+
+	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessParameterAnnotation
+	 * @param int $foo
+	 * @param int[] $bar
+	 */
+	public function withParameterSuppress(int $foo, array $bar)
+	{
+	}
+
+	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessReturnAnnotation
+	 * @param int[] $bar
+	 * @return int
+	 */
+	public function withReturnSuppress(int $foo, array $bar): int
+	{
+	}
+
+	/**
+	 * @param int[] $bar
+	 */
+	public function withSomeParametersOmitted(int $foo, array $bar): int
+	{
+	}
+
+}


### PR DESCRIPTION
This PR aims to provide an opt-in check for useless parameter & return type validation.
The main difference from current UselessDocComment is that it checks each parameter / return separately, not a whole doc block. It also provides a separate sniff code so it could be explicitly suppressed/checked/fixed.
It's primarily useful in PHP 7.1+ code where most of the annotations have no added value (basically only iterables are useful, or explicit comments). This approach is already used i.e. by Nette Framework.
It also provides a CBF fixer extension so it will greatly ease migration from 5.x or 7.0 to 7.1+.

Feature is backward-compatible, opt-in using `enableEachParameterAndReturnInspection` switch (off by default).

Unfortunately it required a substantial refactoring of the checkUselessDocComment method so it doesn't use returns for decision-making.
It also fixed a bug with detecting useless doc comments with annotations only (see changed test).

(PS: @ondrejmirtes mentioned on Slack that you might not be interested in such feature since you have a rule to either have full or none doc block, or would or even have to vote for this... Let me know, I'd eventually have to keep it in my own fork then.)