### PR TITLE
Autodisable PHP 7.1 only sniffs

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Classes/ClassConstantVisibilitySniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/ClassConstantVisibilitySniff.php
@@ -11,10 +11,21 @@ class ClassConstantVisibilitySniff implements \PHP_CodeSniffer_Sniff
 	const CODE_MISSING_CONSTANT_VISIBILITY = 'MissingConstantVisibility';
 
 	/**
+	 * Automatically disables the sniff on unusable version, to be removed when only PHP 7.1+ is supported
+	 *
+	 * @var bool
+	 */
+	public $enabled = PHP_VERSION_ID >= 70100;
+
+	/**
 	 * @return int[]
 	 */
 	public function register(): array
 	{
+		if (!$this->enabled) {
+			return [];
+		}
+
 		return [
 			T_CONST,
 		];

--- a/SlevomatCodingStandard/Sniffs/TypeHints/NullableTypeForNullDefaultValueSniff.php
+++ b/SlevomatCodingStandard/Sniffs/TypeHints/NullableTypeForNullDefaultValueSniff.php
@@ -10,10 +10,21 @@ class NullableTypeForNullDefaultValueSniff implements \PHP_CodeSniffer_Sniff
 	const CODE_NULLABILITY_SYMBOL_REQUIRED = 'NullabilitySymbolRequired';
 
 	/**
+	 * Automatically disables the sniff on unusable version, to be removed when only PHP 7.1+ is supported
+	 *
+	 * @var bool
+	 */
+	public $enabled = PHP_VERSION_ID >= 70100;
+
+	/**
 	 * @return int[]
 	 */
 	public function register(): array
 	{
+		if (!$this->enabled) {
+			return [];
+		}
+
 		return [
 			T_FUNCTION,
 			T_CLOSURE,

--- a/tests/Sniffs/Classes/ClassConstantVisibilitySniffTest.php
+++ b/tests/Sniffs/Classes/ClassConstantVisibilitySniffTest.php
@@ -7,7 +7,9 @@ class ClassConstantVisibilitySniffTest extends \SlevomatCodingStandard\Sniffs\Te
 
 	public function testErrors()
 	{
-		$report = $this->checkFile(__DIR__ . '/data/classWithConstants.php');
+		$report = $this->checkFile(__DIR__ . '/data/classWithConstants.php', [
+			'enabled' => true,
+		]);
 
 		$this->assertSame(1, $report->getErrorCount());
 
@@ -25,13 +27,25 @@ class ClassConstantVisibilitySniffTest extends \SlevomatCodingStandard\Sniffs\Te
 
 	public function testNoClassConstants()
 	{
-		$report = $this->checkFile(__DIR__ . '/data/noClassConstants.php');
+		$report = $this->checkFile(__DIR__ . '/data/noClassConstants.php', [
+			'enabled' => true,
+		]);
 		$this->assertNoSniffErrorInFile($report);
 	}
 
 	public function testNoClassConstantsWithNamespace()
 	{
-		$report = $this->checkFile(__DIR__ . '/data/noClassConstantsWithNamespace.php');
+		$report = $this->checkFile(__DIR__ . '/data/noClassConstantsWithNamespace.php', [
+			'enabled' => true,
+		]);
+		$this->assertNoSniffErrorInFile($report);
+	}
+
+	public function testDisabledSniff()
+	{
+		$report = $this->checkFile(__DIR__ . '/data/classWithConstants.php', [
+			'enabled' => false,
+		]);
 		$this->assertNoSniffErrorInFile($report);
 	}
 

--- a/tests/Sniffs/TypeHints/NullableTypeForNullDefaultValueSniffTest.php
+++ b/tests/Sniffs/TypeHints/NullableTypeForNullDefaultValueSniffTest.php
@@ -7,12 +7,16 @@ class NullableTypeForNullDefaultValueSniffTest extends \SlevomatCodingStandard\S
 
 	public function testNoErrors()
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/nullableTypeForNullDefaultValueNoErrors.php'));
+		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/nullableTypeForNullDefaultValueNoErrors.php', [
+			'enabled' => true,
+		]));
 	}
 
 	public function testErrors()
 	{
-		$report = $this->checkFile(__DIR__ . '/data/nullableTypeForNullDefaultValueErrors.php');
+		$report = $this->checkFile(__DIR__ . '/data/nullableTypeForNullDefaultValueErrors.php', [
+			'enabled' => true,
+		]);
 
 		$this->assertSame(11, $report->getErrorCount());
 
@@ -33,8 +37,18 @@ class NullableTypeForNullDefaultValueSniffTest extends \SlevomatCodingStandard\S
 	public function testFixable()
 	{
 		$codes = [NullableTypeForNullDefaultValueSniff::CODE_NULLABILITY_SYMBOL_REQUIRED];
-		$report = $this->checkFile(__DIR__ . '/data/fixableNullableTypeForNullDefaultValue.php', [], $codes);
+		$report = $this->checkFile(__DIR__ . '/data/fixableNullableTypeForNullDefaultValue.php', [
+			'enabled' => true,
+		], $codes);
 		$this->assertAllFixedInFile($report);
+	}
+
+	public function testDisabledSniff()
+	{
+		$report = $this->checkFile(__DIR__ . '/data/nullableTypeForNullDefaultValueErrors.php', [
+			'enabled' => false,
+		]);
+		$this->assertNoSniffErrorInFile($report);
 	}
 
 }


### PR DESCRIPTION
If you are still on PHP 7, or you are supporting it (probably most of libraries nowadays) then Slevomat ruleset is not really working out of the box, because it is telling you that you should fix this code for PHP 7.1.

There is already some autodetection in `TypeHintDeclarationSniff` so I added the same method for the two PHP 7.1 only sniffs. Of course this can be removed when the support for PHP 7.0 is dropped. I haven't documented the new options in the readme for the same reason - if anyone knows that they will not need this, they should still exclude it.