### PR TITLE
UnusedUsesSniff: Fix detection of partially referenced functions and constants

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Namespaces/UnusedUsesSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/UnusedUsesSniff.php
@@ -41,12 +41,13 @@ class UnusedUsesSniff implements \PHP_CodeSniffer_Sniff
 			$pointer = $referencedName->getStartPointer();
 			$nameParts = NamespaceHelper::getNameParts($name);
 			$nameAsReferencedInFile = $nameParts[0];
+			$nameReferencedWithoutSubNamespace = count($nameParts) === 1;
 			$normalizedNameAsReferencedInFile = UseStatement::normalizedNameAsReferencedInFile($nameAsReferencedInFile);
 			if (
 				!NamespaceHelper::isFullyQualifiedName($name)
 				&& isset($unusedNames[$normalizedNameAsReferencedInFile])
 			) {
-				if (!$referencedName->hasSameUseStatementType($unusedNames[$normalizedNameAsReferencedInFile])) {
+				if ($nameReferencedWithoutSubNamespace && !$referencedName->hasSameUseStatementType($unusedNames[$normalizedNameAsReferencedInFile])) {
 					continue;
 				}
 				if ($unusedNames[$normalizedNameAsReferencedInFile]->getNameAsReferencedInFile() !== $nameAsReferencedInFile) {

--- a/tests/Sniffs/Namespaces/UnusedUsesSniffTest.php
+++ b/tests/Sniffs/Namespaces/UnusedUsesSniffTest.php
@@ -88,6 +88,13 @@ class UnusedUsesSniffTest extends \SlevomatCodingStandard\Sniffs\TestCase
 		$this->assertNoSniffError($this->getFileReport(), 19);
 	}
 
+	public function testPartialuses()
+	{
+		$this->assertNoSniffError($this->getFileReport(), 20);
+		$this->assertNoSniffError($this->getFileReport(), 21);
+		$this->assertNoSniffError($this->getFileReport(), 22);
+	}
+
 	public function testUsedUseInAnnotationWithDisabledSearchAnnotations()
 	{
 		$report = $this->checkFile(__DIR__ . '/data/unusedUsesInAnnotation.php', [

--- a/tests/Sniffs/Namespaces/data/unusedUses.php
+++ b/tests/Sniffs/Namespaces/data/unusedUses.php
@@ -17,6 +17,9 @@ use X;
 use Lorem\FirstInterface;
 use Ipsum\SecondInterface;
 use Zetta\Rasmus;
+use My\PartialClass;
+use My\PartialFunction;
+use My\PartialConstant;
 
 class TestClass implements FirstInterface, SecondInterface
 {
@@ -32,6 +35,10 @@ class TestClass implements FirstInterface, SecondInterface
 		$unusedConstant = new UNUSED_CONSTANT();
 		UsedFunction();
 		doFoo(USED_CONSTANT);
+
+		new PartialClass\UsedClass();
+		PartialFunction\usedFunction();
+		PartialConstant\USED_CONSTANT;
 
 		return new NewObject();
 	}


### PR DESCRIPTION
Fix for #138.