### PR TITLE
TestCase: Obtain Sniff path from reflection instead of hardcoded path

### DIFF
--- a/tests/Sniffs/TestCase.php
+++ b/tests/Sniffs/TestCase.php
@@ -30,11 +30,9 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 		$codeSniffer->registerSniffs([$this->getSniffPath()], [], []);
 
 		if (count($codesToCheck) > 0) {
-			$classReflection = new \ReflectionClass($this->getSniffClassName());
-
 			$ruleset = $propertyReflection->getValue($codeSniffer);
 
-			foreach ($classReflection->getConstants() as $constantName => $constantValue) {
+			foreach ($this->getSniffClassReflection()->getConstants() as $constantName => $constantValue) {
 				if (strpos($constantName, 'CODE_') === 0 && !in_array($constantValue, $codesToCheck, true)) {
 					$ruleset[sprintf('%s.%s', $this->getSniffName(), $constantValue)]['severity'] = 0;
 				}
@@ -157,14 +155,18 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
 	protected function getSniffPath(): string
 	{
-		$path = $this->getSniffClassName();
+		return $this->getSniffClassReflection()->getFileName();
+	}
 
-		$path = str_replace('\\', '/', $path);
-		$path = str_replace('SlevomatCodingStandard', __DIR__ . '/../../SlevomatCodingStandard', $path);
+	protected function getSniffClassReflection(): \ReflectionClass
+	{
+		static $reflection;
 
-		$path .= '.php';
+		if ($reflection === null) {
+			$reflection = new \ReflectionClass($this->getSniffClassName());
+		}
 
-		return realpath($path);
+		return $reflection;
 	}
 
 }


### PR DESCRIPTION
Since my sniffs are heavily based on your approach, I also took the opportunity to use your TestCase with an easy-to-use assertion logic.
The only issue was that I had to overrride TestCase::getSniffPath() to work in a more generic way.

This PR keeps the behavior, but allows consumers to smoothly use your TestCase for their own sniffs, without the need to overrride the method.