### PR TITLE
Fix coveralls not working reliably in builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ before_script:
 script:
   - bin/phing
 after_script:
-  - php bin/coveralls -v --config build/coveralls.yml
+  - if [ "${TRAVIS_ALLOW_FAILURE}" = false ]; then
+        wget https://github.com/satooshi/php-coveralls/releases/download/v1.0.0/coveralls.phar
+        && php coveralls.phar --verbose --config build/coveralls.yml;
+    fi
 notifications:
   email: false

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
 		"jakub-onderka/php-parallel-lint": "^0.9.2",
 		"phing/phing": "^2.16",
 		"phpstan/phpstan": "^0.6.3",
-		"phpunit/phpunit": "^6.0.1",
-		"satooshi/php-coveralls": "^1.0"
+		"phpunit/phpunit": "^6.0.1"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
See https://travis-ci.org/slevomat/coding-standard/jobs/225657198#L348 - currently builds with dependencies lowest are failing to send coverage.

This replaces the composer dependency with direct download which has the added benefit that dependencies do not influence the repo dependencies.