### PR TITLE
Lock development dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
 		"squizlabs/php_codesniffer": "^2.8.1"
 	},
 	"require-dev": {
-		"jakub-onderka/php-parallel-lint": "^0.9.2",
-		"phing/phing": "^2.16",
-		"phpstan/phpstan": "^0.6.3",
-		"phpunit/phpunit": "^6.0.1"
+		"jakub-onderka/php-parallel-lint": "0.9.2",
+		"phing/phing": "2.16",
+		"phpstan/phpstan": "0.6.4",
+		"phpunit/phpunit": "6.1.2"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
See https://travis-ci.org/slevomat/coding-standard/jobs/225657198#L348 - currently builds with dependencies lowest are failing to send coverage, because the coverage was not generated due to PHPUnit bug fixed in [6.0.2](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#602---2017-02-03). Testing lowest dev dependencies makes no sense, because they do not impact package users. So the only introduce unnecessary complexity.