### PR TITLE
ClassConstantVisibilitySniff: Make the sniff fixable

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Classes/ClassConstantVisibilitySniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/ClassConstantVisibilitySniff.php
@@ -51,7 +51,7 @@ class ClassConstantVisibilitySniff implements \PHP_CodeSniffer_Sniff
 
 		$visibilityPointer = TokenHelper::findPreviousEffective($phpcsFile, $constantPointer - 1);
 		if (!in_array($tokens[$visibilityPointer]['code'], [T_PUBLIC, T_PROTECTED, T_PRIVATE], true)) {
-			$phpcsFile->addError(
+			$fix = $phpcsFile->addFixableError(
 				sprintf(
 					'Constant %s::%s visibility missing.',
 					ClassHelper::getFullyQualifiedName($phpcsFile, $classPointer),
@@ -60,6 +60,11 @@ class ClassConstantVisibilitySniff implements \PHP_CodeSniffer_Sniff
 				$constantPointer,
 				self::CODE_MISSING_CONSTANT_VISIBILITY
 			);
+			if ($fix) {
+				$phpcsFile->fixer->beginChangeset();
+				$phpcsFile->fixer->addContentBefore($constantPointer, 'public ');
+				$phpcsFile->fixer->endChangeset();
+			}
 		}
 	}
 

--- a/tests/Sniffs/Classes/ClassConstantVisibilitySniffTest.php
+++ b/tests/Sniffs/Classes/ClassConstantVisibilitySniffTest.php
@@ -49,4 +49,14 @@ class ClassConstantVisibilitySniffTest extends \SlevomatCodingStandard\Sniffs\Te
 		$this->assertNoSniffErrorInFile($report);
 	}
 
+	public function testFixableMissingVisibility()
+	{
+		$report = $this->checkFile(
+			__DIR__ . '/data/fixableMissingVisibility.php',
+			[],
+			[ClassConstantVisibilitySniff::CODE_MISSING_CONSTANT_VISIBILITY]
+		);
+		$this->assertAllFixedInFile($report);
+	}
+
 }

--- a/tests/Sniffs/Classes/data/fixableMissingVisibility.fixed.php
+++ b/tests/Sniffs/Classes/data/fixableMissingVisibility.fixed.php
@@ -1,0 +1,33 @@
+<?php
+
+const NON_CLASS = 1;
+
+interface A
+{
+
+	public const HELLO = 2;
+
+}
+
+class B
+{
+
+	public const WORLD = 3;
+
+}
+
+class C
+{
+
+	public const A = 1;
+	public const B = 2;
+	public const C = 3;
+
+}
+
+class D
+{
+
+	public const A = 1, B = 2, C = 3;
+
+}

--- a/tests/Sniffs/Classes/data/fixableMissingVisibility.php
+++ b/tests/Sniffs/Classes/data/fixableMissingVisibility.php
@@ -1,0 +1,33 @@
+<?php
+
+const NON_CLASS = 1;
+
+interface A
+{
+
+	const HELLO = 2;
+
+}
+
+class B
+{
+
+	const WORLD = 3;
+
+}
+
+class C
+{
+
+	const A = 1;
+	const B = 2;
+	const C = 3;
+
+}
+
+class D
+{
+
+	const A = 1, B = 2, C = 3;
+
+}


### PR DESCRIPTION
It's safe to assume the constant should have public visibility, because it's the default. ☺️ 

Granted, not all previously public constants should stay public, but it's up to the developer to decide (later).