### PR TITLE
Splits CODE_MISSING_PARAMETER_TYPE_HINT into two

### DIFF
--- a/SlevomatCodingStandard/Sniffs/TypeHints/TypeHintDeclarationSniff.php
+++ b/SlevomatCodingStandard/Sniffs/TypeHints/TypeHintDeclarationSniff.php
@@ -20,6 +20,8 @@ class TypeHintDeclarationSniff implements \PHP_CodeSniffer_Sniff
 	const NAME = 'SlevomatCodingStandard.TypeHints.TypeHintDeclaration';
 
 	const CODE_MISSING_PARAMETER_TYPE_HINT = 'MissingParameterTypeHint';
+	
+	const CODE_MISSING_PARAMETER_TYPE_HINT_AND_DOC = 'MissingParameterTypeHintAndDoc';
 
 	const CODE_MISSING_PROPERTY_TYPE_HINT = 'MissingPropertyTypeHint';
 
@@ -132,7 +134,7 @@ class TypeHintDeclarationSniff implements \PHP_CodeSniffer_Sniff
 			}
 		}
 
-		if (SuppressHelper::isSniffSuppressed($phpcsFile, $functionPointer, $this->getSniffName(self::CODE_MISSING_PARAMETER_TYPE_HINT))) {
+		if (SuppressHelper::isSniffSuppressed($phpcsFile, $functionPointer, $this->getSniffName(self::CODE_MISSING_PARAMETER_TYPE_HINT_AND_DOC))) {
 			return;
 		}
 
@@ -146,7 +148,7 @@ class TypeHintDeclarationSniff implements \PHP_CodeSniffer_Sniff
 						$parameterName
 					),
 					$functionPointer,
-					self::CODE_MISSING_PARAMETER_TYPE_HINT
+					self::CODE_MISSING_PARAMETER_TYPE_HINT_AND_DOC
 				);
 
 				continue;


### PR DESCRIPTION
For some reason constant `CODE_MISSING_PARAMETER_TYPE_HINT` is used for two different situations – one is for missing the doc and the hint in the same time, the other one is for suggesting using hint, because it should be possible (the message says).

In many cases it’s OK and I should always use hint, but in my case I just inherited a method from a parent, who isn’t mine but it’s from a framework. In this case I’m not able to use hint, because it breaks the PHP rule about the “parameters in all inherited methods must be the same type”. Funny is that setting the return type declarations isn’t a problem. 

So in this PR I’ve split this constant into two separated and thanks to that I’m able to use `exclude ` in my own ruleset and still keep using the annotation for missing hint and docs in the same time.