### PR TITLE
False positive for UnusedMethod when self::privateMethod() is used

### DIFF
--- a/tests/Sniffs/Classes/data/classWithPrivateMethodCalledOnSelfInstance.php
+++ b/tests/Sniffs/Classes/data/classWithPrivateMethodCalledOnSelfInstance.php
@@ -8,6 +8,8 @@ class ClassWithPrivateMethodCalledOnSelfInstance
 		$self = new self();
 		$self->setUp();
 
+		self::bar();
+
 		return $self;
 	}
 
@@ -18,6 +20,10 @@ class ClassWithPrivateMethodCalledOnSelfInstance
 	public static function foo()
 	{
 		return new self();
+	}
+
+	private static function bar()
+	{
 	}
 
 }


### PR DESCRIPTION
I discovered another one false positive for static method. Failing test is attached.