### PR TITLE
[#188] Supports usage camelized `inheritdoc` annotation

### DIFF
--- a/SlevomatCodingStandard/Sniffs/TypeHints/TypeHintDeclarationSniff.php
+++ b/SlevomatCodingStandard/Sniffs/TypeHints/TypeHintDeclarationSniff.php
@@ -992,7 +992,7 @@ class TypeHintDeclarationSniff implements \PHP_CodeSniffer\Sniffs\Sniff
 			return false;
 		}
 
-		return strpos($docComment, '@inheritdoc') !== false;
+		return stripos($docComment, '@inheritdoc') !== false;
 	}
 
 }

--- a/tests/Sniffs/TypeHints/data/typeHintDeclarationNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/typeHintDeclarationNoErrors.php
@@ -631,4 +631,19 @@ abstract class FooClass
 		return true;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
+	public function camelizedInheritdoc($a)
+	{
+		return true;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function camelizedInheritdocAnnotation($a)
+	{
+		return true;
+	}
 }


### PR DESCRIPTION
Use case-insensitive function to check - `stripos`