### PR TITLE
Set package type to phpcodesniffer-standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
 	"name": "slevomat/coding-standard",
 	"description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
 	"license": "MIT",
+	"type": "phpcodesniffer-standard",
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"config": {


### PR DESCRIPTION
Set package type to phpcodesniffer-standard to support composer phpcs plugins, like https://github.com/DealerDirect/phpcodesniffer-composer-installer