### PR TITLE
add failing test useless docblock

### DIFF
--- a/tests/Sniffs/TypeHints/data/fixableUselessDocComments.fixed.php
+++ b/tests/Sniffs/TypeHints/data/fixableUselessDocComments.fixed.php
@@ -7,6 +7,11 @@ function useless(string $a): void
 
 }
 
+function uselessAligned(string $a, int $b): void
+{
+
+}
+
 /**
  * @param string[] $a
  * @return string[]

--- a/tests/Sniffs/TypeHints/data/fixableUselessDocComments.php
+++ b/tests/Sniffs/TypeHints/data/fixableUselessDocComments.php
@@ -12,6 +12,16 @@ function useless(string $a): void
 }
 
 /**
+ * @param string $a
+ * @param int    $b
+ * @return void
+ */
+function uselessAligned(string $a, int $b): void
+{
+
+}
+
+/**
  * @param string[] $a
  * @return string[]
  */


### PR DESCRIPTION
Hey,

There's a bug in detecting useless docblock when parameters are aligned, as in my failing test case.
I did try to fix it, but ran out of time trying to fix your regex.

Hopefully you can fix it faster than me :)

Cheers.