### PR TITLE
Use root relative path for 'installed_paths'

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ Mention Slevomat Coding Standard in your project's `ruleset.xml`:
 ```xml
 <?xml version="1.0"?>
 <ruleset name="AcmeProject">
-	<config name="installed_paths" value="../../slevomat/coding-standard"/><!-- relative path from PHPCS source location -->
+	<config name="installed_paths" value="vendor/slevomat/coding-standard/SlevomatCodingStandard"/>
 </ruleset>
 ```
 


### PR DESCRIPTION
Existing documentation suggested using relative path to phpcs which didn't work for me (also it didn't include 'SlevomatCodingStandard' folder), switching to relative path from the root of the project worked.