### PR TITLE
Add failing test case for trait method renaming

### DIFF
--- a/tests/Sniffs/Namespaces/data/fullyQualifiedGlobalConstantsNoErrors.php
+++ b/tests/Sniffs/Namespaces/data/fullyQualifiedGlobalConstantsNoErrors.php
@@ -9,9 +9,20 @@ namespace Foo
 	{
 
 	}
+	
+	trait Baz
+	{
+		public function __construct()
+		{
+		}
+	}
 
 	class Boo implements Doo
 	{
+		use Baz {
+			__construct as initTrait;
+		}
+		
 		public function __construct()
 		{
 			\PHP_VERSION;


### PR DESCRIPTION
When renaming a method while importing a trait, the `FullyQualifiedGlobalConstantsSniff` class incorrectly reports the two method names as global constants, which results in errors and potentially failing code when running `phpcbf`.

I don't have an idea how to fix this but thought I'd provide a failing test case to get started.