### PR TITLE
Do not report @var $f as non-FQN

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Namespaces/FullyQualifiedClassNameInAnnotationSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/FullyQualifiedClassNameInAnnotationSniff.php
@@ -2,6 +2,7 @@
 
 namespace SlevomatCodingStandard\Sniffs\Namespaces;
 
+use SlevomatCodingStandard\Helpers\StringHelper;
 use SlevomatCodingStandard\Helpers\TokenHelper;
 use SlevomatCodingStandard\Helpers\TypeHintHelper;
 
@@ -51,7 +52,11 @@ class FullyQualifiedClassNameInAnnotationSniff implements \PHP_CodeSniffer\Sniff
 		foreach ($typeHints as $typeHint) {
 			$typeHint = preg_replace('~(\[\])+$~', '', $typeHint);
 			$lowercasedTypeHint = strtolower($typeHint);
-			if (TypeHintHelper::isSimpleTypeHint($lowercasedTypeHint) || TypeHintHelper::isSimpleUnofficialTypeHints($lowercasedTypeHint)) {
+			if (
+				TypeHintHelper::isSimpleTypeHint($lowercasedTypeHint)
+				|| TypeHintHelper::isSimpleUnofficialTypeHints($lowercasedTypeHint)
+				|| StringHelper::startsWith($typeHint, '$')
+			) {
 				continue;
 			}
 

--- a/tests/Sniffs/Namespaces/data/fullyQualifiedClassNameInAnnotationNoErrors.php
+++ b/tests/Sniffs/Namespaces/data/fullyQualifiedClassNameInAnnotationNoErrors.php
@@ -23,6 +23,9 @@ class FooClass
 
 		/** @var $coo self */
 		$coo = $this->get();
+
+		/** @var $missingTypeDefinition */
+		$missingTypeDefinition = [];
 	}
 
 	/**


### PR DESCRIPTION
Currently inline `@var` without type was still reported as non conforming to FQN, for example:

```
 5 | ERROR | Class name \$c in @var should be referenced via a fully qualified name. (SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation.NonFullyQualifiedClassName)
```

Sure, it does not make sense to have such a inline PHPDoc, but it happens and it can't be relied on other sniffs completedy (this is detected by `SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration`), because it would make trouble when fixing (which I am preparing) for example.

I didn't want to test multiple positions (since the other sniff does that already), so I am just testing if the evaluated thing is a variable/parameter name, which suggests that no type checks should be performed.