### PR TITLE
do not report typehints with invalid names as non-FQN

### DIFF
--- a/SlevomatCodingStandard/Helpers/TypeHelper.php
+++ b/SlevomatCodingStandard/Helpers/TypeHelper.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Helpers;
+
+class TypeHelper
+{
+
+	/**
+	 * Validates type name according to the allowed characters in type names + namespaces
+	 *
+	 * @link http://php.net/manual/en/language.oop5.basic.php
+	 *
+	 * @param string $typeName
+	 * @return bool
+	 */
+	public static function isTypeName(string $typeName): bool
+	{
+		$matches = [];
+		$result = preg_match('~^(\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)+$~', $typeName, $matches);
+		if ($result === false) {
+			throw new \Exception('PREG error ' . preg_last_error());
+		}
+
+		return !($result === 0 || $matches === null);
+	}
+
+}

--- a/SlevomatCodingStandard/Sniffs/Namespaces/FullyQualifiedClassNameInAnnotationSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/FullyQualifiedClassNameInAnnotationSniff.php
@@ -2,8 +2,8 @@
 
 namespace SlevomatCodingStandard\Sniffs\Namespaces;
 
-use SlevomatCodingStandard\Helpers\StringHelper;
 use SlevomatCodingStandard\Helpers\TokenHelper;
+use SlevomatCodingStandard\Helpers\TypeHelper;
 use SlevomatCodingStandard\Helpers\TypeHintHelper;
 
 class FullyQualifiedClassNameInAnnotationSniff implements \PHP_CodeSniffer\Sniffs\Sniff
@@ -55,7 +55,7 @@ class FullyQualifiedClassNameInAnnotationSniff implements \PHP_CodeSniffer\Sniff
 			if (
 				TypeHintHelper::isSimpleTypeHint($lowercasedTypeHint)
 				|| TypeHintHelper::isSimpleUnofficialTypeHints($lowercasedTypeHint)
-				|| StringHelper::startsWith($typeHint, '$')
+				|| !TypeHelper::isTypeName($typeHint)
 			) {
 				continue;
 			}

--- a/tests/Helpers/TypeHelperTest.php
+++ b/tests/Helpers/TypeHelperTest.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Helpers;
+
+class TypeHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
+{
+
+	/**
+	 * @return string[][]
+	 */
+	public function dataValidTypeNames(): array
+	{
+		return [
+			['Foo'],
+			['\\Foo'],
+			['Foo\\Bar'],
+			['\\Foo\\Bar'],
+			['Foo\\Bar\\Baz'],
+			['\\Foo\\Bar\\Baz'],
+			['Foo1'],
+			['string'],
+			['resource'],
+			['self'],
+			['static'],
+		];
+	}
+
+	/**
+	 * @dataProvider dataValidTypeNames
+	 * @param string $typeName
+	 */
+	public function testValidTypeName(string $typeName)
+	{
+		$this->assertTrue(TypeHelper::isTypeName($typeName));
+	}
+
+	/**
+	 * @return string[][]
+	 */
+	public function dataNotValidTypeNames(): array
+	{
+		return [
+			['1Foo'],
+			['$this'],
+			['Foo\\'],
+			['Foo[]'],
+			['[]'],
+		];
+	}
+
+	/**
+	 * @dataProvider dataNotValidTypeNames
+	 * @param string $typeName
+	 */
+	public function testNotValidTypeName(string $typeName)
+	{
+		$this->assertFalse(TypeHelper::isTypeName($typeName));
+	}
+
+}


### PR DESCRIPTION
Follow-up to #223 with more generic solution - basically don't try to derive FQN names from something that is not a valid PHP type name.