### PR TITLE
FullyQualifiedGlobal{Constants,Functions}Sniff: Refactor logic into shared ancestor

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Namespaces/AbstractFullyQualifiedGlobalReference.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/AbstractFullyQualifiedGlobalReference.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Namespaces;
+
+use SlevomatCodingStandard\Helpers\NamespaceHelper;
+use SlevomatCodingStandard\Helpers\ReferencedName;
+use SlevomatCodingStandard\Helpers\ReferencedNameHelper;
+use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
+use SlevomatCodingStandard\Helpers\UseStatementHelper;
+
+abstract class AbstractFullyQualifiedGlobalReference
+{
+
+	public const CODE_NON_FULLY_QUALIFIED = 'NonFullyQualified';
+
+	/** @var string[] */
+	public $exclude = [];
+
+	/** @var string[]|null */
+	private $normalizedExclude;
+
+	/**
+	 * @return mixed[]
+	 */
+	public function register(): array
+	{
+		return [
+			T_OPEN_TAG,
+		];
+	}
+
+	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile
+	 * @param int $openTagPointer
+	 */
+	public function process(\PHP_CodeSniffer\Files\File $phpcsFile, $openTagPointer): void
+	{
+		$tokens = $phpcsFile->getTokens();
+
+		$referencedNames = ReferencedNameHelper::getAllReferencedNames($phpcsFile, $openTagPointer);
+		$useStatements = UseStatementHelper::getUseStatements($phpcsFile, $openTagPointer);
+		$exclude = array_flip($this->getNormalizedExclude());
+
+		foreach ($referencedNames as $referencedName) {
+			$name = $referencedName->getNameAsReferencedInFile();
+			$canonicalName = $this->isCaseSensitive() ? $name : strtolower($name);
+			$referenceNamePointer = $referencedName->getStartPointer();
+
+			if (!$this->isValidType($referencedName)) {
+				continue;
+			}
+
+			if (NamespaceHelper::isFullyQualifiedName($name)) {
+				continue;
+			}
+
+			if (NamespaceHelper::hasNamespace($name)) {
+				continue;
+			}
+
+			if (array_key_exists($canonicalName, $useStatements)) {
+				continue;
+			}
+
+			if (array_key_exists($canonicalName, $exclude)) {
+				continue;
+			}
+
+			$fix = $phpcsFile->addFixableError(sprintf($this->getNotFullyQualifiedMessage(), $tokens[$referenceNamePointer]['content']), $referenceNamePointer, self::CODE_NON_FULLY_QUALIFIED);
+			if ($fix) {
+				$phpcsFile->fixer->beginChangeset();
+				$phpcsFile->fixer->addContentBefore($referenceNamePointer, NamespaceHelper::NAMESPACE_SEPARATOR);
+				$phpcsFile->fixer->endChangeset();
+			}
+		}
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private function getNormalizedExclude(): array
+	{
+		if ($this->normalizedExclude === null) {
+			$exclude = SniffSettingsHelper::normalizeArray($this->exclude);
+
+			if (!$this->isCaseSensitive()) {
+				$exclude = array_map(function (string $name): string {
+					return strtolower($name);
+				}, $exclude);
+			}
+
+			$this->normalizedExclude = $exclude;
+		}
+		return $this->normalizedExclude;
+	}
+
+	abstract protected function getNotFullyQualifiedMessage(): string;
+
+	abstract protected function isCaseSensitive(): bool;
+
+	abstract protected function isValidType(ReferencedName $name): bool;
+
+}

--- a/SlevomatCodingStandard/Sniffs/Namespaces/FullyQualifiedGlobalConstantsSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/FullyQualifiedGlobalConstantsSniff.php
@@ -2,87 +2,25 @@
 
 namespace SlevomatCodingStandard\Sniffs\Namespaces;
 
-use SlevomatCodingStandard\Helpers\NamespaceHelper;
-use SlevomatCodingStandard\Helpers\ReferencedNameHelper;
-use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
-use SlevomatCodingStandard\Helpers\UseStatementHelper;
+use SlevomatCodingStandard\Helpers\ReferencedName;
 
-class FullyQualifiedGlobalConstantsSniff implements \PHP_CodeSniffer\Sniffs\Sniff
+class FullyQualifiedGlobalConstantsSniff
+	extends \SlevomatCodingStandard\Sniffs\Namespaces\AbstractFullyQualifiedGlobalReference
 {
 
-	public const CODE_NON_FULLY_QUALIFIED = 'NonFullyQualified';
-
-	/** @var string[] */
-	public $exclude = [];
-
-	/** @var string[]|null */
-	private $normalizedExclude;
-
-	/**
-	 * @return mixed[]
-	 */
-	public function register(): array
+	protected function getNotFullyQualifiedMessage(): string
 	{
-		return [
-			T_OPEN_TAG,
-		];
+		return 'Constant %s should be referenced via a fully qualified name.';
 	}
 
-	/**
-	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile
-	 * @param int $openTagPointer
-	 */
-	public function process(\PHP_CodeSniffer\Files\File $phpcsFile, $openTagPointer): void
+	protected function isCaseSensitive(): bool
 	{
-		$tokens = $phpcsFile->getTokens();
-
-		$referencedNames = ReferencedNameHelper::getAllReferencedNames($phpcsFile, $openTagPointer);
-		$useStatements = UseStatementHelper::getUseStatements($phpcsFile, $openTagPointer);
-		$exclude = array_flip($this->getNormalizedExclude());
-
-		foreach ($referencedNames as $referencedName) {
-			$name = $referencedName->getNameAsReferencedInFile();
-			$referenceNamePointer = $referencedName->getStartPointer();
-
-			if (!$referencedName->isConstant()) {
-				continue;
-			}
-
-			if (NamespaceHelper::isFullyQualifiedName($name)) {
-				continue;
-			}
-
-			if (NamespaceHelper::hasNamespace($name)) {
-				continue;
-			}
-
-			if (array_key_exists($name, $useStatements)) {
-				continue;
-			}
-
-			if (array_key_exists($name, $exclude)) {
-				continue;
-			}
-
-			$fix = $phpcsFile->addFixableError(sprintf('Constant %s should be referenced via a fully qualified name.', $tokens[$referenceNamePointer]['content']), $referenceNamePointer, self::CODE_NON_FULLY_QUALIFIED);
-			if ($fix) {
-				$phpcsFile->fixer->beginChangeset();
-				$phpcsFile->fixer->addContentBefore($referenceNamePointer, NamespaceHelper::NAMESPACE_SEPARATOR);
-				$phpcsFile->fixer->endChangeset();
-			}
-		}
+		return true;
 	}
 
-	/**
-	 * @return string[]
-	 */
-	private function getNormalizedExclude(): array
+	protected function isValidType(ReferencedName $name): bool
 	{
-		if ($this->normalizedExclude === null) {
-			$this->normalizedExclude = SniffSettingsHelper::normalizeArray($this->exclude);
-		}
-		return $this->normalizedExclude;
+		return $name->isConstant();
 	}
 
 }

--- a/SlevomatCodingStandard/Sniffs/Namespaces/FullyQualifiedGlobalFunctionsSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/FullyQualifiedGlobalFunctionsSniff.php
@@ -2,92 +2,25 @@
 
 namespace SlevomatCodingStandard\Sniffs\Namespaces;
 
-use SlevomatCodingStandard\Helpers\NamespaceHelper;
-use SlevomatCodingStandard\Helpers\ReferencedNameHelper;
-use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
-use SlevomatCodingStandard\Helpers\UseStatementHelper;
+use SlevomatCodingStandard\Helpers\ReferencedName;
 
-class FullyQualifiedGlobalFunctionsSniff implements \PHP_CodeSniffer\Sniffs\Sniff
+class FullyQualifiedGlobalFunctionsSniff
+	extends \SlevomatCodingStandard\Sniffs\Namespaces\AbstractFullyQualifiedGlobalReference
 {
 
-	public const CODE_NON_FULLY_QUALIFIED = 'NonFullyQualified';
-
-	/** @var string[] */
-	public $exclude = [];
-
-	/** @var string[]|null */
-	private $normalizedExclude;
-
-	/**
-	 * @return mixed[]
-	 */
-	public function register(): array
+	protected function getNotFullyQualifiedMessage(): string
 	{
-		return [
-			T_OPEN_TAG,
-		];
+		return 'Function %s() should be referenced via a fully qualified name.';
 	}
 
-	/**
-	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile
-	 * @param int $openTagPointer
-	 */
-	public function process(\PHP_CodeSniffer\Files\File $phpcsFile, $openTagPointer): void
+	protected function isCaseSensitive(): bool
 	{
-		$tokens = $phpcsFile->getTokens();
-
-		$referencedNames = ReferencedNameHelper::getAllReferencedNames($phpcsFile, $openTagPointer);
-		$useStatements = UseStatementHelper::getUseStatements($phpcsFile, $openTagPointer);
-		$exclude = array_flip($this->getNormalizedExclude());
-
-		foreach ($referencedNames as $referencedName) {
-			$name = $referencedName->getNameAsReferencedInFile();
-			$canonicalName = strtolower($name);
-			$referenceNamePointer = $referencedName->getStartPointer();
-
-			if (!$referencedName->isFunction()) {
-				continue;
-			}
-
-			if (NamespaceHelper::isFullyQualifiedName($name)) {
-				continue;
-			}
-
-			if (NamespaceHelper::hasNamespace($name)) {
-				continue;
-			}
-
-			if (array_key_exists($canonicalName, $useStatements)) {
-				continue;
-			}
-
-			if (array_key_exists($canonicalName, $exclude)) {
-				continue;
-			}
-
-			$fix = $phpcsFile->addFixableError(sprintf('Function %s() should be referenced via a fully qualified name.', $tokens[$referenceNamePointer]['content']), $referenceNamePointer, self::CODE_NON_FULLY_QUALIFIED);
-			if ($fix) {
-				$phpcsFile->fixer->beginChangeset();
-				$phpcsFile->fixer->addContentBefore($referenceNamePointer, NamespaceHelper::NAMESPACE_SEPARATOR);
-				$phpcsFile->fixer->endChangeset();
-			}
-		}
+		return true;
 	}
 
-	/**
-	 * @return string[]
-	 */
-	private function getNormalizedExclude(): array
+	protected function isValidType(ReferencedName $name): bool
 	{
-		if ($this->normalizedExclude === null) {
-			$exclude = array_map(function (string $name): string {
-				return strtolower($name);
-			}, SniffSettingsHelper::normalizeArray($this->exclude));
-
-			$this->normalizedExclude = $exclude;
-		}
-		return $this->normalizedExclude;
+		return $name->isFunction();
 	}
 
 }


### PR DESCRIPTION
This was originally part of my larger PR to support global function/constant uses through `use` and expanding it by forbidding either `use` or `\` + fixability - in order to force all global functions be references in `use function`. I haven't finished it yet though, making such cases auto-fixable is pretty hard. So I'll likely drop the fixability part of those changes for now and only submit the configuration part.

I hope I didn't mess up rebase after f6667fac2306fed1fad6d0aee4f7f32ecc863ddc + 8af6030583afa590fcbcbcd7f52b36376a46186f.