### PR TITLE
FullyQualifiedGlobal{Constants,Functions}Sniff: Configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,8 @@ All references to global constants must be referenced via a fully qualified name
 Sniff provides the following settings:
 
 * `exclude`: list of global constants that are allowed not to be referenced via FQN.
+* `allowImported`: whether to allow `use const`
+* `allowFullyQualified`: whether to allow in-place fully qualified references (i.e. `\Foo\BAR`)
 
 #### SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions 🔧
 
@@ -309,6 +311,8 @@ All references to global functions must be referenced via a fully qualified name
 Sniff provides the following settings:
 
 * `exclude`: list of global functions that are allowed not to be referenced via FQN.
+* `allowImported`: whether to allow `use function`
+* `allowFullyQualified`: whether to allow in-place fully qualified references (i.e. `\Foo\bar()`)
 
 #### SlevomatCodingStandard.Namespaces.MultipleUsesPerLine
 

--- a/SlevomatCodingStandard/Sniffs/Namespaces/AbstractFullyQualifiedGlobalReference.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/AbstractFullyQualifiedGlobalReference.php
@@ -13,11 +13,21 @@ abstract class AbstractFullyQualifiedGlobalReference
 
 	public const CODE_NON_FULLY_QUALIFIED = 'NonFullyQualified';
 
+	public const CODE_FULLY_QUALIFIED_NOT_ALLOWED = 'FullyQualifiedNotAllowed';
+
+	public const CODE_IMPORTED_NOT_ALLOWED = 'ImportedNotAllowed';
+
 	/** @var string[] */
 	public $exclude = [];
 
 	/** @var string[]|null */
 	private $normalizedExclude;
+
+	/** @var bool */
+	public $allowFullyQualified = true;
+
+	/** @var bool */
+	public $allowImported = true;
 
 	/**
 	 * @return mixed[]
@@ -36,7 +46,7 @@ abstract class AbstractFullyQualifiedGlobalReference
 	 */
 	public function process(\PHP_CodeSniffer\Files\File $phpcsFile, $openTagPointer): void
 	{
-		$tokens = $phpcsFile->getTokens();
+		assert($this->allowFullyQualified || $this->allowImported, 'At least one check must be enabled.');
 
 		$referencedNames = ReferencedNameHelper::getAllReferencedNames($phpcsFile, $openTagPointer);
 		$useStatements = UseStatementHelper::getUseStatements($phpcsFile, $openTagPointer);
@@ -52,6 +62,9 @@ abstract class AbstractFullyQualifiedGlobalReference
 			}
 
 			if (NamespaceHelper::isFullyQualifiedName($name)) {
+				if (!$this->allowFullyQualified && !NamespaceHelper::hasNamespace($name)) {
+					$phpcsFile->addError(sprintf($this->getFullyQualifiedNotAllowedMessage(), $name), $referenceNamePointer, self::CODE_FULLY_QUALIFIED_NOT_ALLOWED);
+				}
 				continue;
 			}
 
@@ -59,15 +72,19 @@ abstract class AbstractFullyQualifiedGlobalReference
 				continue;
 			}
 
-			if (array_key_exists($canonicalName, $useStatements)) {
-				continue;
-			}
-
 			if (array_key_exists($canonicalName, $exclude)) {
 				continue;
 			}
 
-			$fix = $phpcsFile->addFixableError(sprintf($this->getNotFullyQualifiedMessage(), $tokens[$referenceNamePointer]['content']), $referenceNamePointer, self::CODE_NON_FULLY_QUALIFIED);
+			if (array_key_exists($canonicalName, $useStatements)) {
+				if (!$this->allowImported && !NamespaceHelper::hasNamespace($useStatements[$canonicalName]->getFullyQualifiedTypeName())) {
+					$phpcsFile->addError(sprintf($this->getImportedNotAllowedMessage(), $name), $referenceNamePointer, self::CODE_IMPORTED_NOT_ALLOWED);
+				}
+
+				continue;
+			}
+
+			$fix = $phpcsFile->addFixableError(sprintf($this->getNotFullyQualifiedMessage(), $name), $referenceNamePointer, self::CODE_NON_FULLY_QUALIFIED);
 			if ($fix) {
 				$phpcsFile->fixer->beginChangeset();
 				$phpcsFile->fixer->addContentBefore($referenceNamePointer, NamespaceHelper::NAMESPACE_SEPARATOR);
@@ -96,6 +113,10 @@ abstract class AbstractFullyQualifiedGlobalReference
 	}
 
 	abstract protected function getNotFullyQualifiedMessage(): string;
+
+	abstract protected function getFullyQualifiedNotAllowedMessage(): string;
+
+	abstract protected function getImportedNotAllowedMessage(): string;
 
 	abstract protected function isCaseSensitive(): bool;
 

--- a/SlevomatCodingStandard/Sniffs/Namespaces/FullyQualifiedGlobalConstantsSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/FullyQualifiedGlobalConstantsSniff.php
@@ -13,6 +13,16 @@ class FullyQualifiedGlobalConstantsSniff
 		return 'Constant %s should be referenced via a fully qualified name.';
 	}
 
+	protected function getFullyQualifiedNotAllowedMessage(): string
+	{
+		return 'Constant %s should not be referenced using the backslash.';
+	}
+
+	protected function getImportedNotAllowedMessage(): string
+	{
+		return 'Constant %s should not be referenced using the use statement.';
+	}
+
 	protected function isCaseSensitive(): bool
 	{
 		return true;

--- a/SlevomatCodingStandard/Sniffs/Namespaces/FullyQualifiedGlobalFunctionsSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/FullyQualifiedGlobalFunctionsSniff.php
@@ -13,9 +13,19 @@ class FullyQualifiedGlobalFunctionsSniff
 		return 'Function %s() should be referenced via a fully qualified name.';
 	}
 
+	protected function getFullyQualifiedNotAllowedMessage(): string
+	{
+		return 'Function %s() should not be referenced using the backslash.';
+	}
+
+	protected function getImportedNotAllowedMessage(): string
+	{
+		return 'Function %s() should not be referenced using the use statement.';
+	}
+
 	protected function isCaseSensitive(): bool
 	{
-		return true;
+		return false;
 	}
 
 	protected function isValidType(ReferencedName $name): bool

--- a/tests/Sniffs/Namespaces/FullyQualifiedGlobalConstantsSniffTest.php
+++ b/tests/Sniffs/Namespaces/FullyQualifiedGlobalConstantsSniffTest.php
@@ -36,4 +36,35 @@ class FullyQualifiedGlobalConstantsSniffTest extends \SlevomatCodingStandard\Sni
 		$this->assertAllFixedInFile($report);
 	}
 
+	public function testNoErrorsFullyQualifiedDisabled(): void
+	{
+		$report = $this->checkFile(__DIR__ . '/data/fullyQualifiedGlobalConstantsAllowFullyQualifiedDisabledNoErrors.php', ['allowFullyQualified' => false]);
+		$this->assertNoSniffErrorInFile($report);
+	}
+
+	public function testErrorsFullyQualifiedDisabled(): void
+	{
+		$report = $this->checkFile(__DIR__ . '/data/fullyQualifiedGlobalConstantsAllowFullyQualifiedDisabledErrors.php', ['allowFullyQualified' => false]);
+
+		$this->assertSame(1, $report->getErrorCount());
+
+		$this->assertSniffError($report, 13, FullyQualifiedGlobalConstantsSniff::CODE_FULLY_QUALIFIED_NOT_ALLOWED, 'Constant \FOO should not be referenced using the backslash.');
+	}
+
+	public function testNoErrorsImportedDisabled(): void
+	{
+		$report = $this->checkFile(__DIR__ . '/data/fullyQualifiedGlobalConstantsAllowImportedDisabledNoErrors.php', ['allowImported' => false]);
+		$this->assertNoSniffErrorInFile($report);
+	}
+
+	public function testErrorsImportedDisabled(): void
+	{
+		$report = $this->checkFile(__DIR__ . '/data/fullyQualifiedGlobalConstantsAllowImportedDisabledErrors.php', ['allowImported' => false]);
+
+		$this->assertSame(2, $report->getErrorCount());
+
+		$this->assertSniffError($report, 16, FullyQualifiedGlobalConstantsSniff::CODE_IMPORTED_NOT_ALLOWED, 'Constant X should not be referenced using the use statement.');
+		$this->assertSniffError($report, 17, FullyQualifiedGlobalConstantsSniff::CODE_IMPORTED_NOT_ALLOWED, 'Constant Z should not be referenced using the use statement.');
+	}
+
 }

--- a/tests/Sniffs/Namespaces/FullyQualifiedGlobalFunctionsSniffTest.php
+++ b/tests/Sniffs/Namespaces/FullyQualifiedGlobalFunctionsSniffTest.php
@@ -36,4 +36,35 @@ class FullyQualifiedGlobalFunctionsSniffTest extends \SlevomatCodingStandard\Sni
 		$this->assertAllFixedInFile($report);
 	}
 
+	public function testNoErrorsFullyQualifiedDisabled(): void
+	{
+		$report = $this->checkFile(__DIR__ . '/data/fullyQualifiedGlobalFunctionsAllowFullyQualifiedDisabledNoErrors.php', ['allowFullyQualified' => false]);
+		$this->assertNoSniffErrorInFile($report);
+	}
+
+	public function testErrorsFullyQualifiedDisabled(): void
+	{
+		$report = $this->checkFile(__DIR__ . '/data/fullyQualifiedGlobalFunctionsAllowFullyQualifiedDisabledErrors.php', ['allowFullyQualified' => false]);
+
+		$this->assertSame(1, $report->getErrorCount());
+
+		$this->assertSniffError($report, 10, FullyQualifiedGlobalFunctionsSniff::CODE_FULLY_QUALIFIED_NOT_ALLOWED, 'Function \foo() should not be referenced using the backslash.');
+	}
+
+	public function testNoErrorsImportedDisabled(): void
+	{
+		$report = $this->checkFile(__DIR__ . '/data/fullyQualifiedGlobalFunctionsAllowImportedDisabledNoErrors.php', ['allowImported' => false]);
+		$this->assertNoSniffErrorInFile($report);
+	}
+
+	public function testErrorsImportedDisabled(): void
+	{
+		$report = $this->checkFile(__DIR__ . '/data/fullyQualifiedGlobalFunctionsAllowImportedDisabledErrors.php', ['allowImported' => false]);
+
+		$this->assertSame(2, $report->getErrorCount());
+
+		$this->assertSniffError($report, 15, FullyQualifiedGlobalFunctionsSniff::CODE_IMPORTED_NOT_ALLOWED, 'Function aa() should not be referenced using the use statement.');
+		$this->assertSniffError($report, 16, FullyQualifiedGlobalFunctionsSniff::CODE_IMPORTED_NOT_ALLOWED, 'Function b() should not be referenced using the use statement.');
+	}
+
 }

--- a/tests/Sniffs/Namespaces/data/fullyQualifiedGlobalConstantsAllowFullyQualifiedDisabledErrors.php
+++ b/tests/Sniffs/Namespaces/data/fullyQualifiedGlobalConstantsAllowFullyQualifiedDisabledErrors.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Foo
+{
+
+    use const DOO;
+    use const Name\Spaced;
+
+	class Bar
+	{
+		public function __construct()
+		{
+			\FOO;
+			\BAR\BAZ;
+			DOO;
+			Spaced;
+		}
+	}
+
+}

--- a/tests/Sniffs/Namespaces/data/fullyQualifiedGlobalConstantsAllowFullyQualifiedDisabledNoErrors.php
+++ b/tests/Sniffs/Namespaces/data/fullyQualifiedGlobalConstantsAllowFullyQualifiedDisabledNoErrors.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Foo
+{
+
+	use const FOO;
+	use const BAR as BAZ;
+	use const Boo\DOO;
+
+	class Bar
+	{
+		public function __construct()
+		{
+			FOO;
+			BAZ;
+			DOO;
+			\Fully\QUALIFIED;
+		}
+	}
+
+}

--- a/tests/Sniffs/Namespaces/data/fullyQualifiedGlobalConstantsAllowImportedDisabledErrors.php
+++ b/tests/Sniffs/Namespaces/data/fullyQualifiedGlobalConstantsAllowImportedDisabledErrors.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Foo
+{
+
+    use const X;
+    use const Y as Z;
+	use const Foo\A as AA;
+	use const Foo\B;
+	use const Foo\Doo\BAR;
+
+	class X
+	{
+		public function __construct()
+		{
+		    X;
+		    Z;
+			\Bar\C;
+			AA;
+			B;
+			BAR;
+		}
+	}
+
+}

--- a/tests/Sniffs/Namespaces/data/fullyQualifiedGlobalConstantsAllowImportedDisabledNoErrors.php
+++ b/tests/Sniffs/Namespaces/data/fullyQualifiedGlobalConstantsAllowImportedDisabledNoErrors.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Foo
+{
+
+    use const Name\SPACED;
+
+	class X
+	{
+		public function __construct()
+		{
+			\FOO;
+			\Bar\Baz\Bang;
+			SPACED;
+		}
+	}
+
+}

--- a/tests/Sniffs/Namespaces/data/fullyQualifiedGlobalFunctionsAllowFullyQualifiedDisabledErrors.php
+++ b/tests/Sniffs/Namespaces/data/fullyQualifiedGlobalFunctionsAllowFullyQualifiedDisabledErrors.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Foo
+{
+
+	class Bar
+	{
+		public function __construct()
+		{
+			\foo();
+			\baz\doo();
+		}
+	}
+
+}

--- a/tests/Sniffs/Namespaces/data/fullyQualifiedGlobalFunctionsAllowFullyQualifiedDisabledNoErrors.php
+++ b/tests/Sniffs/Namespaces/data/fullyQualifiedGlobalFunctionsAllowFullyQualifiedDisabledNoErrors.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Foo
+{
+
+	use function foo;
+	use function bar as baz;
+	use function name\spaced;
+
+	class Bar
+	{
+		public function __construct()
+		{
+			foo();
+			baz();
+			spaced();
+		}
+	}
+
+}

--- a/tests/Sniffs/Namespaces/data/fullyQualifiedGlobalFunctionsAllowImportedDisabledErrors.php
+++ b/tests/Sniffs/Namespaces/data/fullyQualifiedGlobalFunctionsAllowImportedDisabledErrors.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Foo
+{
+
+	use function a as aa;
+	use function b;
+	use function Foo\bar as BAZ;
+
+	class X
+	{
+		public function __construct()
+		{
+			\Bar\c();
+			aa();
+			b();
+			BAZ();
+			baz();
+		}
+
+	}
+
+}

--- a/tests/Sniffs/Namespaces/data/fullyQualifiedGlobalFunctionsAllowImportedDisabledNoErrors.php
+++ b/tests/Sniffs/Namespaces/data/fullyQualifiedGlobalFunctionsAllowImportedDisabledNoErrors.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Foo
+{
+
+	class X
+	{
+		public function __construct()
+		{
+			\foo\bar();
+			\Bar\Baz\c();
+			\foo\bar\baz();
+		}
+	}
+
+}


### PR DESCRIPTION
Allow imports and fully qualified references to be configured.

Use case:
* enforce only use-only references:
```php
use function Foo\bar;

bar(); // ok
\Foo\bar(); // not ok
```
* enforce only fully-qualified-only references:
```php
use function Foo\bar;

bar(); // not ok
\Foo\bar(); // ok
```

Default behavior still allows both.