### PR TITLE
Added ForbiddenCommentsSniff

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,17 @@ Sniff provides the following settings:
 
 * `forbiddenAnnotations`: allows to configure which annotations are forbidden to be used.
 
+#### SlevomatCodingStandard.Commenting.ForbiddenComments 🔧
+
+Reports forbidden comments in descriptions. Nothing is forbidden by default, the configuration is completely up to the user. It's recommended to forbid generated or inappropriate messages like:
+
+* `Constructor.`
+* `Created by PhpStorm.`
+
+Sniff provides the following settings:
+
+* `forbiddenCommentPatterns`: allows to configure which comments are forbidden to be used. This is an array of regular expressions (PCRE) with delimiters.
+
 #### SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration 🔧
 
 Reports invalid format of inline phpDocs with `@var`.

--- a/SlevomatCodingStandard/Helpers/Comment.php
+++ b/SlevomatCodingStandard/Helpers/Comment.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Helpers;
+
+class Comment
+{
+
+	/** @var int */
+	private $pointer;
+
+	/** @var string */
+	private $content;
+
+	public function __construct(int $pointer, string $content)
+	{
+		$this->pointer = $pointer;
+		$this->content = $content;
+	}
+
+	public function getPointer(): int
+	{
+		return $this->pointer;
+	}
+
+	public function getContent(): string
+	{
+		return $this->content;
+	}
+
+}

--- a/SlevomatCodingStandard/Helpers/SniffSettingsHelper.php
+++ b/SlevomatCodingStandard/Helpers/SniffSettingsHelper.php
@@ -52,4 +52,10 @@ class SniffSettingsHelper
 		return $normalizedSettings;
 	}
 
+	public static function isValidRegularExpression(string $expression): bool
+	{
+		return preg_match('~^(?:\(.*\)|\{.*\}|\[.*\])[a-z]*\z~i', $expression) > 0
+			|| preg_match('~^([^a-z\s\\\\]).*\\1[a-z]*\z~i', $expression) > 0;
+	}
+
 }

--- a/SlevomatCodingStandard/Sniffs/Commenting/ForbiddenCommentsSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Commenting/ForbiddenCommentsSniff.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Commenting;
+
+use SlevomatCodingStandard\Helpers\DocCommentHelper;
+use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
+
+class ForbiddenCommentsSniff implements \PHP_CodeSniffer\Sniffs\Sniff
+{
+
+	public const CODE_COMMENT_FORBIDDEN = 'CommentForbidden';
+
+	/** @var string[] */
+	public $forbiddenCommentPatterns = [];
+
+	/**
+	 * @return mixed[]
+	 */
+	public function register(): array
+	{
+		return [
+			T_DOC_COMMENT_OPEN_TAG,
+		];
+	}
+
+	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+	 * @param \PHP_CodeSniffer\Files\File $file
+	 * @param int $docCommentOpenPointer
+	 */
+	public function process(\PHP_CodeSniffer\Files\File $file, $docCommentOpenPointer): void
+	{
+		$comments = DocCommentHelper::getDocCommentDescription($file, $docCommentOpenPointer);
+
+		if ($comments === null) {
+			return;
+		}
+
+		foreach (SniffSettingsHelper::normalizeArray($this->forbiddenCommentPatterns) as $forbiddenCommentPattern) {
+			if (!SniffSettingsHelper::isValidRegularExpression($forbiddenCommentPattern)) {
+				continue;
+			}
+
+			foreach ($comments as $comment) {
+				if (preg_match($forbiddenCommentPattern, $comment->getContent()) === 0) {
+					continue;
+				}
+
+				$file->addError(
+					sprintf('Documentation comment contains forbidden comment "%s".', $comment->getContent()),
+					$comment->getPointer(),
+					self::CODE_COMMENT_FORBIDDEN
+				);
+			}
+		}
+	}
+
+}

--- a/tests/Helpers/DocCommentHelperTest.php
+++ b/tests/Helpers/DocCommentHelperTest.php
@@ -102,6 +102,30 @@ class DocCommentHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$this->assertFalse(DocCommentHelper::hasDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), 'withoutDocComment')));
 	}
 
+	public function testConstantGetDocCommentDescription(): void
+	{
+		$this->assertEquals(
+			['Constant WITH_DOC_COMMENT_AND_DESCRIPTION'],
+			$this->stringifyComments(DocCommentHelper::getDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findConstantPointerByName($this->getTestedCodeSnifferFile(), 'WITH_DOC_COMMENT_AND_DESCRIPTION')))
+		);
+	}
+
+	public function testPropertyGetDocCommentDescription(): void
+	{
+		$this->assertSame(
+			['Property with doc comment and description'],
+			$this->stringifyComments(DocCommentHelper::getDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findPropertyPointerByName($this->getTestedCodeSnifferFile(), 'withDocCommentAndDescription')))
+		);
+	}
+
+	public function testFunctionGetDocCommentDescription(): void
+	{
+		$this->assertSame(
+			['Function with doc comment and description', 'And is multi-line'],
+			$this->stringifyComments(DocCommentHelper::getDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), 'withDocCommentAndDescription')))
+		);
+	}
+
 	private function getTestedCodeSnifferFile(): \PHP_CodeSniffer\Files\File
 	{
 		if ($this->testedCodeSnifferFile === null) {
@@ -110,6 +134,17 @@ class DocCommentHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 			);
 		}
 		return $this->testedCodeSnifferFile;
+	}
+
+	/**
+	 * @param \SlevomatCodingStandard\Helpers\Comment[] $comments
+	 * @return string[]
+	 */
+	private function stringifyComments(array $comments): array
+	{
+		return array_map(function (Comment $comment): string {
+			return $comment->getContent();
+		}, $comments);
 	}
 
 }

--- a/tests/Helpers/SniffSettingsHelperTest.php
+++ b/tests/Helpers/SniffSettingsHelperTest.php
@@ -62,4 +62,44 @@ class SniffSettingsHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		]));
 	}
 
+	/**
+	 * @dataProvider validRegularExpressionsProvider
+	 * @dataProvider invalidRegularExpressionsProvider
+	 * @param string $expression
+	 * @param bool $valid
+	 */
+	public function testIsValidRegularExpression(string $expression, bool $valid): void
+	{
+		$this->assertSame($valid, SniffSettingsHelper::isValidRegularExpression($expression));
+	}
+
+	/**
+	 * @return mixed[][]
+	 */
+	public function validRegularExpressionsProvider(): array
+	{
+		return [
+			['~abc~', true],
+			['~abc~Aix', true],
+			['(hello)', true],
+			['{hello}', true],
+			['[hello]', true],
+			['##u', true],
+			['#some(more|coml[ea]?x)pattern#ui', true],
+		];
+	}
+
+	/**
+	 * @return mixed[][]
+	 */
+	public function invalidRegularExpressionsProvider(): array
+	{
+		return [
+			['abc', false],
+			['aregexpa', false],
+			['~abc', false],
+			['\\abc\\', false],
+		];
+	}
+
 }

--- a/tests/Helpers/data/docComment.php
+++ b/tests/Helpers/data/docComment.php
@@ -38,8 +38,11 @@ abstract class WithDocCommentAndDescription
 
 	/**
 	 * Function with doc comment and description
+	 * And is multi-line
 	 *
 	 * @see Whatever
+	 *
+	 * And also nothing here
 	 */
 	final public function withDocCommentAndDescription($d)
 	{

--- a/tests/Sniffs/Commenting/ForbiddenCommentsSniffTest.php
+++ b/tests/Sniffs/Commenting/ForbiddenCommentsSniffTest.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Commenting;
+
+class ForbiddenCommentsSniffTest extends \SlevomatCodingStandard\Sniffs\TestCase
+{
+
+	public function testNoForbiddenComments(): void
+	{
+		$report = $this->checkFile(__DIR__ . '/data/noForbiddenComments.php', [
+			'forbiddenCommentPatterns' => ['~Foo\d+~', '~Not comment\.~'],
+		]);
+		$this->assertNoSniffErrorInFile($report);
+	}
+
+	public function testForbiddenComments(): void
+	{
+		$report = $this->checkFile(__DIR__ . '/data/forbiddenComments.php', [
+			'forbiddenCommentPatterns' => ['~Created by PhpStorm\.~', '~(\S+\s+)?Constructor\.~', '~(blah){3}~'],
+		]);
+
+		$this->assertSame(3, $report->getErrorCount());
+
+		$this->assertSniffError($report, 4, ForbiddenCommentsSniff::CODE_COMMENT_FORBIDDEN);
+		$this->assertSniffError($report, 10, ForbiddenCommentsSniff::CODE_COMMENT_FORBIDDEN);
+		$this->assertSniffError($report, 36, ForbiddenCommentsSniff::CODE_COMMENT_FORBIDDEN);
+	}
+
+}

--- a/tests/Sniffs/Commenting/data/forbiddenComments.php
+++ b/tests/Sniffs/Commenting/data/forbiddenComments.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Created by PhpStorm.
+ */
+class Foo
+{
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		parent::__construct();
+
+	}
+
+	/**
+	 * Foo
+	 * Bar
+	 *
+	 * @throws \Throwable Text text text text
+	 * text text text text text
+	 * @throws \TypeError Text text
+	 * text text text
+	 *
+	 */
+	public function multiline()
+	{
+
+	}
+
+	/**
+	 * Description description description
+	 *  description description
+	 * blahblahblah
+	 *
+	 * @see https://www.slevomat.cz
+	 */
+	public function withDescription()
+	{
+
+	}
+
+}

--- a/tests/Sniffs/Commenting/data/noForbiddenComments.php
+++ b/tests/Sniffs/Commenting/data/noForbiddenComments.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Hello world.
+ *
+ * @author Slevomat
+ */
+class Foo
+{
+
+	/**
+	 * @param string $a
+	 */
+	public function __construct(string $a)
+	{
+	}
+
+	/**
+	 * Test.
+	 */
+	public function get(): int
+	{
+		return 0;
+	}
+
+	/**
+	 * @@return int
+	 *
+	 * Not comment.
+	 */
+	public function notComment(): int
+	{
+		return 0;
+	}
+
+}


### PR DESCRIPTION
Use-case:
* forbid useless comments like `Constructor.`, PhpStorm's favourite
* forbid advertisements like `Created by PhpStorm`, another PhpStorm's crap

Usage:
```xml
<rule ref="SlevomatCodingStandard.Commenting.ForbiddenComments">
    <properties>
        <property name="forbiddenCommentPatterns" type="array" value="
            ~^Constructor\.\z~,
            ~^\S+ constructor\.\z~i,
            ~^Created by PhpStorm\.\z~
        "/>
    </properties>
</rule>
```

Comments are considered per-line up to the first `@foo` tag or end of doc block.
Does not support multi-line comments, that sounds rather like edge case for this sniff and would be more complex to implement. Maybe if anyone requests it.
Patterns are full PCRE regexps.

Didn't manage to fix PHPStan failure even by explicit `@var`, any idea?