### PR TITLE
Tests: Use static assertions and utility methods

### DIFF
--- a/tests/Helpers/AnnotationHelperTest.php
+++ b/tests/Helpers/AnnotationHelperTest.php
@@ -11,92 +11,92 @@ class AnnotationHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	public function testClassWithAnnotation(): void
 	{
 		$annotations = AnnotationHelper::getAnnotationsByName($this->getTestedCodeSnifferFile(), $this->findClassPointerByName($this->getTestedCodeSnifferFile(), 'WithAnnotation'), '@see');
-		$this->assertCount(1, $annotations);
-		$this->assertSame('@see', $annotations[0]->getName());
-		$this->assertSame(4, $this->getLineByPointer($annotations[0]->getPointer()));
-		$this->assertSame('https://www.slevomat.cz', $annotations[0]->getContent());
+		self::assertCount(1, $annotations);
+		self::assertSame('@see', $annotations[0]->getName());
+		self::assertSame(4, $this->getLineByPointer($annotations[0]->getPointer()));
+		self::assertSame('https://www.slevomat.cz', $annotations[0]->getContent());
 	}
 
 	public function testClassWithoutAnnotation(): void
 	{
-		$this->assertCount(0, AnnotationHelper::getAnnotationsByName($this->getTestedCodeSnifferFile(), $this->findClassPointerByName($this->getTestedCodeSnifferFile(), 'WithoutAnnotation'), '@see'));
+		self::assertCount(0, AnnotationHelper::getAnnotationsByName($this->getTestedCodeSnifferFile(), $this->findClassPointerByName($this->getTestedCodeSnifferFile(), 'WithoutAnnotation'), '@see'));
 	}
 
 	public function testConstantWithAnnotation(): void
 	{
 		$annotations = AnnotationHelper::getAnnotationsByName($this->getTestedCodeSnifferFile(), $this->findConstantPointerByName($this->getTestedCodeSnifferFile(), 'WITH_ANNOTATION'), '@var');
-		$this->assertCount(1, $annotations);
-		$this->assertSame('@var', $annotations[0]->getName());
-		$this->assertSame(10, $this->getLineByPointer($annotations[0]->getPointer()));
-		$this->assertSame('bool', $annotations[0]->getContent());
+		self::assertCount(1, $annotations);
+		self::assertSame('@var', $annotations[0]->getName());
+		self::assertSame(10, $this->getLineByPointer($annotations[0]->getPointer()));
+		self::assertSame('bool', $annotations[0]->getContent());
 	}
 
 	public function testConstantWithoutAnnotation(): void
 	{
-		$this->assertCount(0, AnnotationHelper::getAnnotationsByName($this->getTestedCodeSnifferFile(), $this->findConstantPointerByName($this->getTestedCodeSnifferFile(), 'WITHOUT_ANNOTATION'), '@var'));
+		self::assertCount(0, AnnotationHelper::getAnnotationsByName($this->getTestedCodeSnifferFile(), $this->findConstantPointerByName($this->getTestedCodeSnifferFile(), 'WITHOUT_ANNOTATION'), '@var'));
 	}
 
 	public function testPropertyWithAnnotation(): void
 	{
 		$annotations = AnnotationHelper::getAnnotationsByName($this->getTestedCodeSnifferFile(), $this->findPropertyPointerByName($this->getTestedCodeSnifferFile(), 'withAnnotation'), '@var');
-		$this->assertCount(1, $annotations);
-		$this->assertSame('@var', $annotations[0]->getName());
-		$this->assertSame(17, $this->getLineByPointer($annotations[0]->getPointer()));
-		$this->assertSame('int', $annotations[0]->getContent());
+		self::assertCount(1, $annotations);
+		self::assertSame('@var', $annotations[0]->getName());
+		self::assertSame(17, $this->getLineByPointer($annotations[0]->getPointer()));
+		self::assertSame('int', $annotations[0]->getContent());
 	}
 
 	public function testPropertyWithoutAnnotation(): void
 	{
-		$this->assertCount(0, AnnotationHelper::getAnnotationsByName($this->getTestedCodeSnifferFile(), $this->findPropertyPointerByName($this->getTestedCodeSnifferFile(), 'withoutAnnotation'), '@var'));
+		self::assertCount(0, AnnotationHelper::getAnnotationsByName($this->getTestedCodeSnifferFile(), $this->findPropertyPointerByName($this->getTestedCodeSnifferFile(), 'withoutAnnotation'), '@var'));
 	}
 
 	public function testFunctionWithAnnotation(): void
 	{
 		$annotations = AnnotationHelper::getAnnotationsByName($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), 'withAnnotation'), '@param');
-		$this->assertCount(2, $annotations);
-		$this->assertSame('@param', $annotations[0]->getName());
-		$this->assertSame(29, $this->getLineByPointer($annotations[0]->getPointer()));
-		$this->assertSame('string $a', $annotations[0]->getContent());
-		$this->assertSame('@param', $annotations[1]->getName());
-		$this->assertSame(30, $this->getLineByPointer($annotations[1]->getPointer()));
-		$this->assertSame('string $b', $annotations[1]->getContent());
+		self::assertCount(2, $annotations);
+		self::assertSame('@param', $annotations[0]->getName());
+		self::assertSame(29, $this->getLineByPointer($annotations[0]->getPointer()));
+		self::assertSame('string $a', $annotations[0]->getContent());
+		self::assertSame('@param', $annotations[1]->getName());
+		self::assertSame(30, $this->getLineByPointer($annotations[1]->getPointer()));
+		self::assertSame('string $b', $annotations[1]->getContent());
 	}
 
 	public function testFunctionWithParametrizedAnnotation(): void
 	{
 		$annotations = AnnotationHelper::getAnnotationsByName($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), 'withParametrizedAnnotation'), '@Route');
-		$this->assertCount(1, $annotations);
-		$this->assertSame('"/", name="homepage"', $annotations[0]->getParameters());
-		$this->assertNull($annotations[0]->getContent());
+		self::assertCount(1, $annotations);
+		self::assertSame('"/", name="homepage"', $annotations[0]->getParameters());
+		self::assertNull($annotations[0]->getContent());
 	}
 
 	public function testFunctionWithParametrizedAnnotationContainingParenthesis(): void
 	{
 		$annotations = AnnotationHelper::getAnnotationsByName($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), 'withParametrizedAnnotationContainingParenthesis'), '@Security');
-		$this->assertCount(1, $annotations);
-		$this->assertSame('"is_granted(\'ROLE_ADMIN\')"', $annotations[0]->getParameters());
-		$this->assertNull($annotations[0]->getContent());
+		self::assertCount(1, $annotations);
+		self::assertSame('"is_granted(\'ROLE_ADMIN\')"', $annotations[0]->getParameters());
+		self::assertNull($annotations[0]->getContent());
 	}
 
 	public function testFunctionWithMultilineParametrizedAnnotation(): void
 	{
 		$annotations = AnnotationHelper::getAnnotationsByName($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), 'withMultilineParametrizedAnnotation'), '@Route');
-		$this->assertCount(1, $annotations);
-		$this->assertSame("\"/configs/{config}/domains/{domain}/locales/{locale}/messages\", name=\"jms_translation_update_message\",\ndefaults = {\"id\" = null}, options = {\"i18n\" = false}, methods={\"PUT\"}", $annotations[0]->getParameters());
-		$this->assertNull($annotations[0]->getContent());
+		self::assertCount(1, $annotations);
+		self::assertSame("\"/configs/{config}/domains/{domain}/locales/{locale}/messages\", name=\"jms_translation_update_message\",\ndefaults = {\"id\" = null}, options = {\"i18n\" = false}, methods={\"PUT\"}", $annotations[0]->getParameters());
+		self::assertNull($annotations[0]->getContent());
 	}
 
 	public function testFunctionWithParametrizedAnnotationWithoutParameters(): void
 	{
 		$annotations = AnnotationHelper::getAnnotationsByName($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), 'withParametrizedAnnotationWithoutParameters'), '@Assert\Callback');
-		$this->assertCount(1, $annotations);
-		$this->assertNull($annotations[0]->getParameters());
-		$this->assertNull($annotations[0]->getContent());
+		self::assertCount(1, $annotations);
+		self::assertNull($annotations[0]->getParameters());
+		self::assertNull($annotations[0]->getContent());
 	}
 
 	public function testFunctionWithoutAnnotation(): void
 	{
-		$this->assertCount(0, AnnotationHelper::getAnnotationsByName($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), 'withoutAnnotation'), '@param'));
+		self::assertCount(0, AnnotationHelper::getAnnotationsByName($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), 'withoutAnnotation'), '@param'));
 	}
 
 	private function getTestedCodeSnifferFile(): \PHP_CodeSniffer\Files\File

--- a/tests/Helpers/ClassHelperTest.php
+++ b/tests/Helpers/ClassHelperTest.php
@@ -8,41 +8,41 @@ class ClassHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	public function testNameWithNamespace(): void
 	{
 		$codeSnifferFile = $this->getCodeSnifferFile(__DIR__ . '/data/classWithNamespace.php');
-		$this->assertSame('\FooNamespace\FooClass', ClassHelper::getFullyQualifiedName($codeSnifferFile, $this->findClassPointerByName($codeSnifferFile, 'FooClass')));
-		$this->assertSame('FooClass', ClassHelper::getName($codeSnifferFile, $this->findClassPointerByName($codeSnifferFile, 'FooClass')));
-		$this->assertSame('\FooNamespace\FooInterface', ClassHelper::getFullyQualifiedName($codeSnifferFile, $this->findClassPointerByName($codeSnifferFile, 'FooInterface')));
-		$this->assertSame('FooInterface', ClassHelper::getName($codeSnifferFile, $this->findClassPointerByName($codeSnifferFile, 'FooInterface')));
-		$this->assertSame('\FooNamespace\FooTrait', ClassHelper::getFullyQualifiedName($codeSnifferFile, $this->findClassPointerByName($codeSnifferFile, 'FooTrait')));
-		$this->assertSame('FooTrait', ClassHelper::getName($codeSnifferFile, $this->findClassPointerByName($codeSnifferFile, 'FooTrait')));
+		self::assertSame('\FooNamespace\FooClass', ClassHelper::getFullyQualifiedName($codeSnifferFile, $this->findClassPointerByName($codeSnifferFile, 'FooClass')));
+		self::assertSame('FooClass', ClassHelper::getName($codeSnifferFile, $this->findClassPointerByName($codeSnifferFile, 'FooClass')));
+		self::assertSame('\FooNamespace\FooInterface', ClassHelper::getFullyQualifiedName($codeSnifferFile, $this->findClassPointerByName($codeSnifferFile, 'FooInterface')));
+		self::assertSame('FooInterface', ClassHelper::getName($codeSnifferFile, $this->findClassPointerByName($codeSnifferFile, 'FooInterface')));
+		self::assertSame('\FooNamespace\FooTrait', ClassHelper::getFullyQualifiedName($codeSnifferFile, $this->findClassPointerByName($codeSnifferFile, 'FooTrait')));
+		self::assertSame('FooTrait', ClassHelper::getName($codeSnifferFile, $this->findClassPointerByName($codeSnifferFile, 'FooTrait')));
 	}
 
 	public function testNameWithoutNamespace(): void
 	{
 		$codeSnifferFile = $this->getCodeSnifferFile(__DIR__ . '/data/classWithoutNamespace.php');
-		$this->assertSame('\FooClass', ClassHelper::getFullyQualifiedName($codeSnifferFile, $this->findClassPointerByName($codeSnifferFile, 'FooClass')));
-		$this->assertSame('FooClass', ClassHelper::getName($codeSnifferFile, $this->findClassPointerByName($codeSnifferFile, 'FooClass')));
-		$this->assertSame('\FooInterface', ClassHelper::getFullyQualifiedName($codeSnifferFile, $this->findClassPointerByName($codeSnifferFile, 'FooInterface')));
-		$this->assertSame('FooInterface', ClassHelper::getName($codeSnifferFile, $this->findClassPointerByName($codeSnifferFile, 'FooInterface')));
-		$this->assertSame('\FooTrait', ClassHelper::getFullyQualifiedName($codeSnifferFile, $this->findClassPointerByName($codeSnifferFile, 'FooTrait')));
-		$this->assertSame('FooTrait', ClassHelper::getName($codeSnifferFile, $this->findClassPointerByName($codeSnifferFile, 'FooTrait')));
+		self::assertSame('\FooClass', ClassHelper::getFullyQualifiedName($codeSnifferFile, $this->findClassPointerByName($codeSnifferFile, 'FooClass')));
+		self::assertSame('FooClass', ClassHelper::getName($codeSnifferFile, $this->findClassPointerByName($codeSnifferFile, 'FooClass')));
+		self::assertSame('\FooInterface', ClassHelper::getFullyQualifiedName($codeSnifferFile, $this->findClassPointerByName($codeSnifferFile, 'FooInterface')));
+		self::assertSame('FooInterface', ClassHelper::getName($codeSnifferFile, $this->findClassPointerByName($codeSnifferFile, 'FooInterface')));
+		self::assertSame('\FooTrait', ClassHelper::getFullyQualifiedName($codeSnifferFile, $this->findClassPointerByName($codeSnifferFile, 'FooTrait')));
+		self::assertSame('FooTrait', ClassHelper::getName($codeSnifferFile, $this->findClassPointerByName($codeSnifferFile, 'FooTrait')));
 	}
 
 	public function testGetAllNamesWithNamespace(): void
 	{
 		$codeSnifferFile = $this->getCodeSnifferFile(__DIR__ . '/data/classWithNamespace.php');
-		$this->assertSame(['FooClass', 'FooInterface', 'FooTrait'], ClassHelper::getAllNames($codeSnifferFile));
+		self::assertSame(['FooClass', 'FooInterface', 'FooTrait'], ClassHelper::getAllNames($codeSnifferFile));
 	}
 
 	public function testGetAllNamesWithoutNamespace(): void
 	{
 		$codeSnifferFile = $this->getCodeSnifferFile(__DIR__ . '/data/classWithoutNamespace.php');
-		$this->assertSame(['FooClass', 'FooInterface', 'FooTrait'], ClassHelper::getAllNames($codeSnifferFile));
+		self::assertSame(['FooClass', 'FooInterface', 'FooTrait'], ClassHelper::getAllNames($codeSnifferFile));
 	}
 
 	public function testGetAllNamesWithNoClass(): void
 	{
 		$codeSnifferFile = $this->getCodeSnifferFile(__DIR__ . '/data/namespacedFile.php');
-		$this->assertSame([], ClassHelper::getAllNames($codeSnifferFile));
+		self::assertSame([], ClassHelper::getAllNames($codeSnifferFile));
 	}
 
 }

--- a/tests/Helpers/ConstantHelperTest.php
+++ b/tests/Helpers/ConstantHelperTest.php
@@ -10,8 +10,8 @@ class ConstantHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$codeSnifferFile = $this->getCodeSnifferFile(__DIR__ . '/data/constantWithNamespace.php');
 
 		$constantPointer = $this->findConstantPointerByName($codeSnifferFile, 'FOO');
-		$this->assertSame('\FooNamespace\FOO', ConstantHelper::getFullyQualifiedName($codeSnifferFile, $constantPointer));
-		$this->assertSame('FOO', ConstantHelper::getName($codeSnifferFile, $constantPointer));
+		self::assertSame('\FooNamespace\FOO', ConstantHelper::getFullyQualifiedName($codeSnifferFile, $constantPointer));
+		self::assertSame('FOO', ConstantHelper::getName($codeSnifferFile, $constantPointer));
 	}
 
 	public function testNameWithoutNamespace(): void
@@ -19,14 +19,14 @@ class ConstantHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$codeSnifferFile = $this->getCodeSnifferFile(__DIR__ . '/data/constantWithoutNamespace.php');
 
 		$constantPointer = $this->findConstantPointerByName($codeSnifferFile, 'FOO');
-		$this->assertSame('FOO', ConstantHelper::getFullyQualifiedName($codeSnifferFile, $constantPointer));
-		$this->assertSame('FOO', ConstantHelper::getName($codeSnifferFile, $constantPointer));
+		self::assertSame('FOO', ConstantHelper::getFullyQualifiedName($codeSnifferFile, $constantPointer));
+		self::assertSame('FOO', ConstantHelper::getName($codeSnifferFile, $constantPointer));
 	}
 
 	public function testGetAllNames(): void
 	{
 		$codeSnifferFile = $this->getCodeSnifferFile(__DIR__ . '/data/constantNames.php');
-		$this->assertSame(['FOO', 'BOO'], ConstantHelper::getAllNames($codeSnifferFile));
+		self::assertSame(['FOO', 'BOO'], ConstantHelper::getAllNames($codeSnifferFile));
 	}
 
 }

--- a/tests/Helpers/DocCommentHelperTest.php
+++ b/tests/Helpers/DocCommentHelperTest.php
@@ -10,101 +10,101 @@ class DocCommentHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 
 	public function testClassHasDocComment(): void
 	{
-		$this->assertTrue(DocCommentHelper::hasDocComment($this->getTestedCodeSnifferFile(), $this->findClassPointerByName($this->getTestedCodeSnifferFile(), 'WithDocCommentAndDescription')));
-		$this->assertTrue(DocCommentHelper::hasDocComment($this->getTestedCodeSnifferFile(), $this->findClassPointerByName($this->getTestedCodeSnifferFile(), 'WithDocComment')));
+		self::assertTrue(DocCommentHelper::hasDocComment($this->getTestedCodeSnifferFile(), $this->findClassPointerByName($this->getTestedCodeSnifferFile(), 'WithDocCommentAndDescription')));
+		self::assertTrue(DocCommentHelper::hasDocComment($this->getTestedCodeSnifferFile(), $this->findClassPointerByName($this->getTestedCodeSnifferFile(), 'WithDocComment')));
 	}
 
 	public function testClassGetDocComment(): void
 	{
-		$this->assertSame("* Class WithDocComment\n *\n * @see https://www.slevomat.cz", DocCommentHelper::getDocComment($this->getTestedCodeSnifferFile(), $this->findClassPointerByName($this->getTestedCodeSnifferFile(), 'WithDocCommentAndDescription')));
-		$this->assertNull(DocCommentHelper::getDocComment($this->getTestedCodeSnifferFile(), $this->findClassPointerByName($this->getTestedCodeSnifferFile(), 'WithoutDocComment')));
+		self::assertSame("* Class WithDocComment\n *\n * @see https://www.slevomat.cz", DocCommentHelper::getDocComment($this->getTestedCodeSnifferFile(), $this->findClassPointerByName($this->getTestedCodeSnifferFile(), 'WithDocCommentAndDescription')));
+		self::assertNull(DocCommentHelper::getDocComment($this->getTestedCodeSnifferFile(), $this->findClassPointerByName($this->getTestedCodeSnifferFile(), 'WithoutDocComment')));
 	}
 
 	public function testClassHasNoDocComment(): void
 	{
-		$this->assertFalse(DocCommentHelper::hasDocComment($this->getTestedCodeSnifferFile(), $this->findClassPointerByName($this->getTestedCodeSnifferFile(), 'WithoutDocComment')));
+		self::assertFalse(DocCommentHelper::hasDocComment($this->getTestedCodeSnifferFile(), $this->findClassPointerByName($this->getTestedCodeSnifferFile(), 'WithoutDocComment')));
 	}
 
 	public function testClassHasDocCommentDescription(): void
 	{
-		$this->assertTrue(DocCommentHelper::hasDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findClassPointerByName($this->getTestedCodeSnifferFile(), 'WithDocCommentAndDescription')));
+		self::assertTrue(DocCommentHelper::hasDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findClassPointerByName($this->getTestedCodeSnifferFile(), 'WithDocCommentAndDescription')));
 	}
 
 	public function testClassHasNoDocCommentDescription(): void
 	{
-		$this->assertFalse(DocCommentHelper::hasDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findClassPointerByName($this->getTestedCodeSnifferFile(), 'WithDocComment')));
-		$this->assertFalse(DocCommentHelper::hasDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findClassPointerByName($this->getTestedCodeSnifferFile(), 'WithoutDocComment')));
+		self::assertFalse(DocCommentHelper::hasDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findClassPointerByName($this->getTestedCodeSnifferFile(), 'WithDocComment')));
+		self::assertFalse(DocCommentHelper::hasDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findClassPointerByName($this->getTestedCodeSnifferFile(), 'WithoutDocComment')));
 	}
 
 	public function testConstantHasDocComment(): void
 	{
-		$this->assertTrue(DocCommentHelper::hasDocComment($this->getTestedCodeSnifferFile(), $this->findConstantPointerByName($this->getTestedCodeSnifferFile(), 'WITH_DOC_COMMENT_AND_DESCRIPTION')));
-		$this->assertTrue(DocCommentHelper::hasDocComment($this->getTestedCodeSnifferFile(), $this->findConstantPointerByName($this->getTestedCodeSnifferFile(), 'WITH_DOC_COMMENT')));
+		self::assertTrue(DocCommentHelper::hasDocComment($this->getTestedCodeSnifferFile(), $this->findConstantPointerByName($this->getTestedCodeSnifferFile(), 'WITH_DOC_COMMENT_AND_DESCRIPTION')));
+		self::assertTrue(DocCommentHelper::hasDocComment($this->getTestedCodeSnifferFile(), $this->findConstantPointerByName($this->getTestedCodeSnifferFile(), 'WITH_DOC_COMMENT')));
 	}
 
 	public function testConstantHasNoDocComment(): void
 	{
-		$this->assertFalse(DocCommentHelper::hasDocComment($this->getTestedCodeSnifferFile(), $this->findConstantPointerByName($this->getTestedCodeSnifferFile(), 'WITHOUT_DOC_COMMENT')));
+		self::assertFalse(DocCommentHelper::hasDocComment($this->getTestedCodeSnifferFile(), $this->findConstantPointerByName($this->getTestedCodeSnifferFile(), 'WITHOUT_DOC_COMMENT')));
 	}
 
 	public function testConstantHasDocCommentDescription(): void
 	{
-		$this->assertTrue(DocCommentHelper::hasDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findConstantPointerByName($this->getTestedCodeSnifferFile(), 'WITH_DOC_COMMENT_AND_DESCRIPTION')));
+		self::assertTrue(DocCommentHelper::hasDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findConstantPointerByName($this->getTestedCodeSnifferFile(), 'WITH_DOC_COMMENT_AND_DESCRIPTION')));
 	}
 
 	public function testConstantHasNoDocCommentDescription(): void
 	{
-		$this->assertFalse(DocCommentHelper::hasDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findConstantPointerByName($this->getTestedCodeSnifferFile(), 'WITH_DOC_COMMENT')));
-		$this->assertFalse(DocCommentHelper::hasDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findConstantPointerByName($this->getTestedCodeSnifferFile(), 'WITHOUT_DOC_COMMENT')));
+		self::assertFalse(DocCommentHelper::hasDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findConstantPointerByName($this->getTestedCodeSnifferFile(), 'WITH_DOC_COMMENT')));
+		self::assertFalse(DocCommentHelper::hasDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findConstantPointerByName($this->getTestedCodeSnifferFile(), 'WITHOUT_DOC_COMMENT')));
 	}
 
 	public function testPropertyHasDocComment(): void
 	{
-		$this->assertTrue(DocCommentHelper::hasDocComment($this->getTestedCodeSnifferFile(), $this->findPropertyPointerByName($this->getTestedCodeSnifferFile(), 'withDocCommentAndDescription')));
-		$this->assertTrue(DocCommentHelper::hasDocComment($this->getTestedCodeSnifferFile(), $this->findPropertyPointerByName($this->getTestedCodeSnifferFile(), 'withDocComment')));
+		self::assertTrue(DocCommentHelper::hasDocComment($this->getTestedCodeSnifferFile(), $this->findPropertyPointerByName($this->getTestedCodeSnifferFile(), 'withDocCommentAndDescription')));
+		self::assertTrue(DocCommentHelper::hasDocComment($this->getTestedCodeSnifferFile(), $this->findPropertyPointerByName($this->getTestedCodeSnifferFile(), 'withDocComment')));
 	}
 
 	public function testPropertyHasNoDocComment(): void
 	{
-		$this->assertFalse(DocCommentHelper::hasDocComment($this->getTestedCodeSnifferFile(), $this->findPropertyPointerByName($this->getTestedCodeSnifferFile(), 'withoutDocComment')));
+		self::assertFalse(DocCommentHelper::hasDocComment($this->getTestedCodeSnifferFile(), $this->findPropertyPointerByName($this->getTestedCodeSnifferFile(), 'withoutDocComment')));
 	}
 
 	public function testPropertyHasDocCommentDescription(): void
 	{
-		$this->assertTrue(DocCommentHelper::hasDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findPropertyPointerByName($this->getTestedCodeSnifferFile(), 'withDocCommentAndDescription')));
+		self::assertTrue(DocCommentHelper::hasDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findPropertyPointerByName($this->getTestedCodeSnifferFile(), 'withDocCommentAndDescription')));
 	}
 
 	public function testPropertyHasNoDocCommentDescription(): void
 	{
-		$this->assertFalse(DocCommentHelper::hasDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findPropertyPointerByName($this->getTestedCodeSnifferFile(), 'withDocComment')));
-		$this->assertFalse(DocCommentHelper::hasDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findPropertyPointerByName($this->getTestedCodeSnifferFile(), 'withoutDocComment')));
+		self::assertFalse(DocCommentHelper::hasDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findPropertyPointerByName($this->getTestedCodeSnifferFile(), 'withDocComment')));
+		self::assertFalse(DocCommentHelper::hasDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findPropertyPointerByName($this->getTestedCodeSnifferFile(), 'withoutDocComment')));
 	}
 
 	public function testFunctionHasDocComment(): void
 	{
-		$this->assertTrue(DocCommentHelper::hasDocComment($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), 'withDocCommentAndDescription')));
-		$this->assertTrue(DocCommentHelper::hasDocComment($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), 'withDocComment')));
+		self::assertTrue(DocCommentHelper::hasDocComment($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), 'withDocCommentAndDescription')));
+		self::assertTrue(DocCommentHelper::hasDocComment($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), 'withDocComment')));
 	}
 
 	public function testFunctionHasNoDocComment(): void
 	{
-		$this->assertFalse(DocCommentHelper::hasDocComment($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), 'withoutDocComment')));
+		self::assertFalse(DocCommentHelper::hasDocComment($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), 'withoutDocComment')));
 	}
 
 	public function testFunctionHasDocCommentDescription(): void
 	{
-		$this->assertTrue(DocCommentHelper::hasDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), 'withDocCommentAndDescription')));
+		self::assertTrue(DocCommentHelper::hasDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), 'withDocCommentAndDescription')));
 	}
 
 	public function testFunctionHasNoDocCommentDescription(): void
 	{
-		$this->assertFalse(DocCommentHelper::hasDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), 'withDocComment')));
-		$this->assertFalse(DocCommentHelper::hasDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), 'withoutDocComment')));
+		self::assertFalse(DocCommentHelper::hasDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), 'withDocComment')));
+		self::assertFalse(DocCommentHelper::hasDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), 'withoutDocComment')));
 	}
 
 	public function testConstantGetDocCommentDescription(): void
 	{
-		$this->assertEquals(
+		self::assertEquals(
 			['Constant WITH_DOC_COMMENT_AND_DESCRIPTION'],
 			$this->stringifyComments(DocCommentHelper::getDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findConstantPointerByName($this->getTestedCodeSnifferFile(), 'WITH_DOC_COMMENT_AND_DESCRIPTION')))
 		);
@@ -112,7 +112,7 @@ class DocCommentHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 
 	public function testPropertyGetDocCommentDescription(): void
 	{
-		$this->assertSame(
+		self::assertSame(
 			['Property with doc comment and description'],
 			$this->stringifyComments(DocCommentHelper::getDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findPropertyPointerByName($this->getTestedCodeSnifferFile(), 'withDocCommentAndDescription')))
 		);
@@ -120,7 +120,7 @@ class DocCommentHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 
 	public function testFunctionGetDocCommentDescription(): void
 	{
-		$this->assertSame(
+		self::assertSame(
 			['Function with doc comment and description', 'And is multi-line'],
 			$this->stringifyComments(DocCommentHelper::getDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), 'withDocCommentAndDescription')))
 		);

--- a/tests/Helpers/FunctionHelperTest.php
+++ b/tests/Helpers/FunctionHelperTest.php
@@ -8,41 +8,41 @@ class FunctionHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	public function testNameWithNamespace(): void
 	{
 		$codeSnifferFile = $this->getCodeSnifferFile(__DIR__ . '/data/functionWithNamespace.php');
-		$this->assertSame('\FooNamespace\fooFunction', FunctionHelper::getFullyQualifiedName($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooFunction')));
-		$this->assertSame('fooFunction', FunctionHelper::getName($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooFunction')));
-		$this->assertSame('\FooNamespace\FooClass::fooMethod', FunctionHelper::getFullyQualifiedName($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooMethod')));
-		$this->assertSame('fooMethod', FunctionHelper::getName($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooMethod')));
+		self::assertSame('\FooNamespace\fooFunction', FunctionHelper::getFullyQualifiedName($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooFunction')));
+		self::assertSame('fooFunction', FunctionHelper::getName($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooFunction')));
+		self::assertSame('\FooNamespace\FooClass::fooMethod', FunctionHelper::getFullyQualifiedName($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooMethod')));
+		self::assertSame('fooMethod', FunctionHelper::getName($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooMethod')));
 	}
 
 	public function testNameWithoutNamespace(): void
 	{
 		$codeSnifferFile = $this->getCodeSnifferFile(__DIR__ . '/data/functionWithoutNamespace.php');
-		$this->assertSame('fooFunction', FunctionHelper::getFullyQualifiedName($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooFunction')));
-		$this->assertSame('fooFunction', FunctionHelper::getName($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooFunction')));
-		$this->assertSame('\FooClass::fooMethod', FunctionHelper::getFullyQualifiedName($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooMethod')));
-		$this->assertSame('fooMethod', FunctionHelper::getName($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooMethod')));
+		self::assertSame('fooFunction', FunctionHelper::getFullyQualifiedName($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooFunction')));
+		self::assertSame('fooFunction', FunctionHelper::getName($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooFunction')));
+		self::assertSame('\FooClass::fooMethod', FunctionHelper::getFullyQualifiedName($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooMethod')));
+		self::assertSame('fooMethod', FunctionHelper::getName($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooMethod')));
 	}
 
 	public function testNameInAnonymousClass(): void
 	{
 		$codeSnifferFile = $this->getCodeSnifferFile(__DIR__ . '/data/functionInAnonymousClass.php');
-		$this->assertSame('class@anonymous::fooMethod', FunctionHelper::getFullyQualifiedName($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooMethod')));
-		$this->assertSame('fooMethod', FunctionHelper::getName($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooMethod')));
+		self::assertSame('class@anonymous::fooMethod', FunctionHelper::getFullyQualifiedName($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooMethod')));
+		self::assertSame('fooMethod', FunctionHelper::getName($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooMethod')));
 	}
 
 	public function testAbstractOrNot(): void
 	{
 		$codeSnifferFile = $this->getCodeSnifferFile(__DIR__ . '/data/functionAbstractOrNot.php');
-		$this->assertFalse(FunctionHelper::isAbstract($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooMethod')));
-		$this->assertTrue(FunctionHelper::isAbstract($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooAbstractMethod')));
-		$this->assertTrue(FunctionHelper::isAbstract($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooInterfaceMethod')));
+		self::assertFalse(FunctionHelper::isAbstract($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooMethod')));
+		self::assertTrue(FunctionHelper::isAbstract($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooAbstractMethod')));
+		self::assertTrue(FunctionHelper::isAbstract($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooInterfaceMethod')));
 	}
 
 	public function testFunctionOrMethod(): void
 	{
 		$codeSnifferFile = $this->getCodeSnifferFile(__DIR__ . '/data/functionOrMethod.php');
-		$this->assertTrue(FunctionHelper::isMethod($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooMethod')));
-		$this->assertFalse(FunctionHelper::isMethod($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooFunction')));
+		self::assertTrue(FunctionHelper::isMethod($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooMethod')));
+		self::assertFalse(FunctionHelper::isMethod($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, 'fooFunction')));
 	}
 
 	/**
@@ -91,7 +91,7 @@ class FunctionHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$codeSnifferFile = $this->getCodeSnifferFile(__DIR__ . '/data/functionParametersNames.php');
 
 		$functionPointer = $this->findFunctionPointerByName($codeSnifferFile, $functionName);
-		$this->assertSame($expectedParametersNames, FunctionHelper::getParametersNames($codeSnifferFile, $functionPointer));
+		self::assertSame($expectedParametersNames, FunctionHelper::getParametersNames($codeSnifferFile, $functionPointer));
 	}
 
 	/**
@@ -233,18 +233,18 @@ class FunctionHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$functionPointer = $this->findFunctionPointerByName($codeSnifferFile, $functionName);
 		$parametersTypeHints = FunctionHelper::getParametersTypeHints($codeSnifferFile, $functionPointer);
 		foreach ($expectedParametersTypeHints as $expectedParameterName => $expectedParameterTypeHint) {
-			$this->assertArrayHasKey($expectedParameterName, $parametersTypeHints);
+			self::assertArrayHasKey($expectedParameterName, $parametersTypeHints);
 			$parameterTypeHint = $parametersTypeHints[$expectedParameterName];
 			if ($expectedParameterTypeHint === null) {
-				$this->assertNull($parameterTypeHint);
+				self::assertNull($parameterTypeHint);
 			} else {
-				$this->assertNotNull($parameterTypeHint);
-				$this->assertSame($expectedParameterTypeHint->getTypeHint(), $parameterTypeHint->getTypeHint());
-				$this->assertSame($expectedParameterTypeHint->isNullable(), $parameterTypeHint->isNullable());
-				$this->assertSame($expectedParameterTypeHint->isOptional(), $parameterTypeHint->isOptional());
+				self::assertNotNull($parameterTypeHint);
+				self::assertSame($expectedParameterTypeHint->getTypeHint(), $parameterTypeHint->getTypeHint());
+				self::assertSame($expectedParameterTypeHint->isNullable(), $parameterTypeHint->isNullable());
+				self::assertSame($expectedParameterTypeHint->isOptional(), $parameterTypeHint->isOptional());
 			}
 		}
-		$this->assertSame($expectedParametersWithoutTypeHints, FunctionHelper::getParametersWithoutTypeHint($codeSnifferFile, $functionPointer));
+		self::assertSame($expectedParametersWithoutTypeHints, FunctionHelper::getParametersWithoutTypeHint($codeSnifferFile, $functionPointer));
 	}
 
 	/**
@@ -262,12 +262,12 @@ class FunctionHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$functionPointer = $this->findFunctionPointerByName($codeSnifferFile, $functionName);
 		$parametersTypeHints = FunctionHelper::getParametersTypeHints($codeSnifferFile, $functionPointer);
 		foreach ($expectedParametersTypeHints as $expectedParameterName => $expectedParameterTypeHint) {
-			$this->assertArrayHasKey($expectedParameterName, $parametersTypeHints);
+			self::assertArrayHasKey($expectedParameterName, $parametersTypeHints);
 			$parameterTypeHint = $parametersTypeHints[$expectedParameterName];
-			$this->assertNotNull($parameterTypeHint);
-			$this->assertSame($expectedParameterTypeHint->getTypeHint(), $parameterTypeHint->getTypeHint(), $parameterTypeHint->getTypeHint());
-			$this->assertSame($expectedParameterTypeHint->isNullable(), $parameterTypeHint->isNullable(), $parameterTypeHint->getTypeHint());
-			$this->assertSame($expectedParameterTypeHint->isOptional(), $parameterTypeHint->isOptional(), $parameterTypeHint->getTypeHint());
+			self::assertNotNull($parameterTypeHint);
+			self::assertSame($expectedParameterTypeHint->getTypeHint(), $parameterTypeHint->getTypeHint(), $parameterTypeHint->getTypeHint());
+			self::assertSame($expectedParameterTypeHint->isNullable(), $parameterTypeHint->isNullable(), $parameterTypeHint->getTypeHint());
+			self::assertSame($expectedParameterTypeHint->isOptional(), $parameterTypeHint->isOptional(), $parameterTypeHint->getTypeHint());
 		}
 	}
 
@@ -302,7 +302,7 @@ class FunctionHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	): void
 	{
 		$codeSnifferFile = $this->getCodeSnifferFile(__DIR__ . '/data/functionReturnsValueOrNot.php');
-		$this->assertSame($returnsValue, FunctionHelper::returnsValue($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, $functionName)));
+		self::assertSame($returnsValue, FunctionHelper::returnsValue($codeSnifferFile, $this->findFunctionPointerByName($codeSnifferFile, $functionName)));
 	}
 
 	public function testReturnTypeHint(): void
@@ -310,24 +310,24 @@ class FunctionHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$codeSnifferFile = $this->getCodeSnifferFile(__DIR__ . '/data/functionReturnTypeHint.php');
 
 		$functionPointer = $this->findFunctionPointerByName($codeSnifferFile, 'withReturnTypeHint');
-		$this->assertTrue(FunctionHelper::hasReturnTypeHint($codeSnifferFile, $functionPointer));
+		self::assertTrue(FunctionHelper::hasReturnTypeHint($codeSnifferFile, $functionPointer));
 		$returnTypeHint = FunctionHelper::findReturnTypeHint($codeSnifferFile, $functionPointer);
-		$this->assertSame('\FooNamespace\FooInterface', $returnTypeHint->getTypeHint());
-		$this->assertFalse($returnTypeHint->isNullable());
+		self::assertSame('\FooNamespace\FooInterface', $returnTypeHint->getTypeHint());
+		self::assertFalse($returnTypeHint->isNullable());
 
 		$functionPointer = $this->findFunctionPointerByName($codeSnifferFile, 'withoutReturnTypeHint');
-		$this->assertFalse(FunctionHelper::hasReturnTypeHint($codeSnifferFile, $functionPointer));
-		$this->assertNull(FunctionHelper::findReturnTypeHint($codeSnifferFile, $functionPointer));
+		self::assertFalse(FunctionHelper::hasReturnTypeHint($codeSnifferFile, $functionPointer));
+		self::assertNull(FunctionHelper::findReturnTypeHint($codeSnifferFile, $functionPointer));
 
 		$functionPointer = $this->findFunctionPointerByName($codeSnifferFile, 'abstractWithReturnTypeHint');
-		$this->assertTrue(FunctionHelper::hasReturnTypeHint($codeSnifferFile, $functionPointer));
+		self::assertTrue(FunctionHelper::hasReturnTypeHint($codeSnifferFile, $functionPointer));
 		$returnTypeHint = FunctionHelper::findReturnTypeHint($codeSnifferFile, $functionPointer);
-		$this->assertSame('bool', $returnTypeHint->getTypeHint());
-		$this->assertFalse($returnTypeHint->isNullable());
+		self::assertSame('bool', $returnTypeHint->getTypeHint());
+		self::assertFalse($returnTypeHint->isNullable());
 
 		$functionPointer = $this->findFunctionPointerByName($codeSnifferFile, 'abstractWithoutReturnTypeHint');
-		$this->assertFalse(FunctionHelper::hasReturnTypeHint($codeSnifferFile, $functionPointer));
-		$this->assertNull(FunctionHelper::findReturnTypeHint($codeSnifferFile, $functionPointer));
+		self::assertFalse(FunctionHelper::hasReturnTypeHint($codeSnifferFile, $functionPointer));
+		self::assertNull(FunctionHelper::findReturnTypeHint($codeSnifferFile, $functionPointer));
 	}
 
 	public function testReturnNullableTypeHint(): void
@@ -335,16 +335,16 @@ class FunctionHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$codeSnifferFile = $this->getCodeSnifferFile(__DIR__ . '/data/functionReturnsNullableTypeHint.php');
 
 		$functionPointer = $this->findFunctionPointerByName($codeSnifferFile, 'withReturnNullableTypeHint');
-		$this->assertTrue(FunctionHelper::hasReturnTypeHint($codeSnifferFile, $functionPointer));
+		self::assertTrue(FunctionHelper::hasReturnTypeHint($codeSnifferFile, $functionPointer));
 		$returnTypeHint = FunctionHelper::findReturnTypeHint($codeSnifferFile, $functionPointer);
-		$this->assertSame('\FooNamespace\FooInterface', $returnTypeHint->getTypeHint());
-		$this->assertTrue($returnTypeHint->isNullable());
+		self::assertSame('\FooNamespace\FooInterface', $returnTypeHint->getTypeHint());
+		self::assertTrue($returnTypeHint->isNullable());
 
 		$functionPointer = $this->findFunctionPointerByName($codeSnifferFile, 'abstractWithReturnNullableTypeHint');
-		$this->assertTrue(FunctionHelper::hasReturnTypeHint($codeSnifferFile, $functionPointer));
+		self::assertTrue(FunctionHelper::hasReturnTypeHint($codeSnifferFile, $functionPointer));
 		$returnTypeHint = FunctionHelper::findReturnTypeHint($codeSnifferFile, $functionPointer);
-		$this->assertSame('bool', $returnTypeHint->getTypeHint());
-		$this->assertTrue($returnTypeHint->isNullable());
+		self::assertSame('bool', $returnTypeHint->getTypeHint());
+		self::assertTrue($returnTypeHint->isNullable());
 	}
 
 	public function testAnnotations(): void
@@ -356,21 +356,21 @@ class FunctionHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$parametersAnnotations = array_map(function (Annotation $annotation) {
 			return $annotation->getContent();
 		}, FunctionHelper::getParametersAnnotations($codeSnifferFile, $functionPointer));
-		$this->assertSame([
+		self::assertSame([
 			'string $a',
 			'int $b',
 		], $parametersAnnotations);
-		$this->assertSame('bool', FunctionHelper::findReturnAnnotation($codeSnifferFile, $functionPointer)->getContent());
+		self::assertSame('bool', FunctionHelper::findReturnAnnotation($codeSnifferFile, $functionPointer)->getContent());
 
 		$functionPointer = $this->findFunctionPointerByName($codeSnifferFile, 'withoutAnnotations');
-		$this->assertCount(0, FunctionHelper::getParametersAnnotations($codeSnifferFile, $functionPointer));
-		$this->assertNull(FunctionHelper::findReturnAnnotation($codeSnifferFile, $functionPointer));
+		self::assertCount(0, FunctionHelper::getParametersAnnotations($codeSnifferFile, $functionPointer));
+		self::assertNull(FunctionHelper::findReturnAnnotation($codeSnifferFile, $functionPointer));
 	}
 
 	public function testGetAllFunctionNames(): void
 	{
 		$codeSnifferFile = $this->getCodeSnifferFile(__DIR__ . '/data/functionNames.php');
-		$this->assertSame(['foo', 'boo'], FunctionHelper::getAllFunctionNames($codeSnifferFile));
+		self::assertSame(['foo', 'boo'], FunctionHelper::getAllFunctionNames($codeSnifferFile));
 	}
 
 }

--- a/tests/Helpers/NamespaceHelperTest.php
+++ b/tests/Helpers/NamespaceHelperTest.php
@@ -24,7 +24,7 @@ class NamespaceHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	 */
 	public function testIsFullyQualifiedName(string $typeName): void
 	{
-		$this->assertTrue(NamespaceHelper::isFullyQualifiedName($typeName));
+		self::assertTrue(NamespaceHelper::isFullyQualifiedName($typeName));
 	}
 
 	/**
@@ -46,7 +46,7 @@ class NamespaceHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	 */
 	public function testIsNotFullyQualifiedName(string $typeName): void
 	{
-		$this->assertFalse(NamespaceHelper::isFullyQualifiedName($typeName));
+		self::assertFalse(NamespaceHelper::isFullyQualifiedName($typeName));
 	}
 
 	/**
@@ -68,7 +68,7 @@ class NamespaceHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	 */
 	public function testHasNamespace(string $typeName): void
 	{
-		$this->assertTrue(NamespaceHelper::hasNamespace($typeName));
+		self::assertTrue(NamespaceHelper::hasNamespace($typeName));
 	}
 
 	/**
@@ -90,7 +90,7 @@ class NamespaceHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	 */
 	public function testDoesNotHaveNamespace(string $typeName): void
 	{
-		$this->assertFalse(NamespaceHelper::hasNamespace($typeName));
+		self::assertFalse(NamespaceHelper::hasNamespace($typeName));
 	}
 
 	/**
@@ -125,7 +125,7 @@ class NamespaceHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	 */
 	public function testGetNameParts(string $namespace, array $parts): void
 	{
-		$this->assertSame($parts, NamespaceHelper::getNameParts($namespace));
+		self::assertSame($parts, NamespaceHelper::getNameParts($namespace));
 	}
 
 	public function testFindCurrentNamespaceName(): void
@@ -137,7 +137,7 @@ class NamespaceHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 			$codeSnifferFile,
 			TokenHelper::getLastTokenPointer($codeSnifferFile)
 		);
-		$this->assertSame('Foo\Bar', $namespace);
+		self::assertSame('Foo\Bar', $namespace);
 	}
 
 	public function testFindCurrentNamespaceNameInFileWithoutNamespace(): void
@@ -145,7 +145,7 @@ class NamespaceHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$codeSnifferFile = $this->getCodeSnifferFile(
 			__DIR__ . '/data/fileWithoutNamespace.php'
 		);
-		$this->assertNull(
+		self::assertNull(
 			NamespaceHelper::findCurrentNamespaceName(
 				$codeSnifferFile,
 				TokenHelper::getLastTokenPointer($codeSnifferFile)
@@ -162,7 +162,7 @@ class NamespaceHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 			$codeSnifferFile,
 			TokenHelper::getLastTokenPointer($codeSnifferFile)
 		);
-		$this->assertSame('Lorem\Ipsum', $namespace);
+		self::assertSame('Lorem\Ipsum', $namespace);
 	}
 
 	/**
@@ -197,7 +197,7 @@ class NamespaceHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	 */
 	public function testGetUnqualifiedNameFromFullyQualifiedName(string $unqualifiedName, string $fullyQualifiedName): void
 	{
-		$this->assertSame($unqualifiedName, NamespaceHelper::getUnqualifiedNameFromFullyQualifiedName($fullyQualifiedName));
+		self::assertSame($unqualifiedName, NamespaceHelper::getUnqualifiedNameFromFullyQualifiedName($fullyQualifiedName));
 	}
 
 	/**
@@ -218,7 +218,7 @@ class NamespaceHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	 */
 	public function testIsQualifiedName(string $name): void
 	{
-		$this->assertTrue(NamespaceHelper::isQualifiedName($name));
+		self::assertTrue(NamespaceHelper::isQualifiedName($name));
 	}
 
 	/**
@@ -237,7 +237,7 @@ class NamespaceHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	 */
 	public function testIsNotQualifiedName(string $name): void
 	{
-		$this->assertFalse(NamespaceHelper::isQualifiedName($name));
+		self::assertFalse(NamespaceHelper::isQualifiedName($name));
 	}
 
 	/**
@@ -272,7 +272,7 @@ class NamespaceHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	 */
 	public function testNormalizeToCanonicalName(string $normalizedName, string $originalName): void
 	{
-		$this->assertSame($normalizedName, NamespaceHelper::normalizeToCanonicalName($originalName));
+		self::assertSame($normalizedName, NamespaceHelper::normalizeToCanonicalName($originalName));
 	}
 
 	/**
@@ -307,7 +307,7 @@ class NamespaceHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	 */
 	public function testTypeIsInNamespace(string $typeName, string $namespace): void
 	{
-		$this->assertTrue(NamespaceHelper::isTypeInNamespace($typeName, $namespace));
+		self::assertTrue(NamespaceHelper::isTypeInNamespace($typeName, $namespace));
 	}
 
 	/**
@@ -350,7 +350,7 @@ class NamespaceHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	 */
 	public function testTypeIsNotInNamespace(string $typeName, string $namespace): void
 	{
-		$this->assertFalse(NamespaceHelper::isTypeInNamespace($typeName, $namespace));
+		self::assertFalse(NamespaceHelper::isTypeInNamespace($typeName, $namespace));
 	}
 
 }

--- a/tests/Helpers/PropertyHelperTest.php
+++ b/tests/Helpers/PropertyHelperTest.php
@@ -47,25 +47,25 @@ class PropertyHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$codeSnifferFile = $this->getTestedCodeSnifferFile();
 
 		$variablePointer = TokenHelper::findNextContent($codeSnifferFile, T_VARIABLE, $variableName, 0);
-		$this->assertSame($isProperty, PropertyHelper::isProperty($codeSnifferFile, $variablePointer));
+		self::assertSame($isProperty, PropertyHelper::isProperty($codeSnifferFile, $variablePointer));
 	}
 
 	public function testNameWithNamespace(): void
 	{
 		$codeSnifferFile = $this->getCodeSnifferFile(__DIR__ . '/data/propertyWithNamespace.php');
-		$this->assertSame('\FooNamespace\FooClass::$fooProperty', PropertyHelper::getFullyQualifiedName($codeSnifferFile, $this->findPropertyPointerByName($codeSnifferFile, 'fooProperty')));
+		self::assertSame('\FooNamespace\FooClass::$fooProperty', PropertyHelper::getFullyQualifiedName($codeSnifferFile, $this->findPropertyPointerByName($codeSnifferFile, 'fooProperty')));
 	}
 
 	public function testNameWithoutsNamespace(): void
 	{
 		$codeSnifferFile = $this->getCodeSnifferFile(__DIR__ . '/data/propertyWithoutNamespace.php');
-		$this->assertSame('\FooClass::$fooProperty', PropertyHelper::getFullyQualifiedName($codeSnifferFile, $this->findPropertyPointerByName($codeSnifferFile, 'fooProperty')));
+		self::assertSame('\FooClass::$fooProperty', PropertyHelper::getFullyQualifiedName($codeSnifferFile, $this->findPropertyPointerByName($codeSnifferFile, 'fooProperty')));
 	}
 
 	public function testNameInAnonymousClass(): void
 	{
 		$codeSnifferFile = $this->getCodeSnifferFile(__DIR__ . '/data/propertyInAnonymousClass.php');
-		$this->assertSame('class@anonymous::$fooProperty', PropertyHelper::getFullyQualifiedName($codeSnifferFile, $this->findPropertyPointerByName($codeSnifferFile, 'fooProperty')));
+		self::assertSame('class@anonymous::$fooProperty', PropertyHelper::getFullyQualifiedName($codeSnifferFile, $this->findPropertyPointerByName($codeSnifferFile, 'fooProperty')));
 	}
 
 	private function getTestedCodeSnifferFile(): \PHP_CodeSniffer\Files\File

--- a/tests/Helpers/ReferencedNameHelperTest.php
+++ b/tests/Helpers/ReferencedNameHelperTest.php
@@ -47,13 +47,13 @@ class ReferencedNameHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		];
 
 		$names = ReferencedNameHelper::getAllReferencedNames($codeSnifferFile, 0);
-		$this->assertCount(count($foundTypes), $names);
+		self::assertCount(count($foundTypes), $names);
 		foreach ($names as $i => $referencedName) {
 			[$type, $isFunction, $isConstant] = $foundTypes[$i];
 
-			$this->assertSame($type, $referencedName->getNameAsReferencedInFile());
-			$this->assertSame($isFunction, $referencedName->isFunction(), $type);
-			$this->assertSame($isConstant, $referencedName->isConstant(), $type);
+			self::assertSame($type, $referencedName->getNameAsReferencedInFile());
+			self::assertSame($isFunction, $referencedName->isFunction(), $type);
+			self::assertSame($isConstant, $referencedName->isConstant(), $type);
 		}
 	}
 
@@ -69,13 +69,13 @@ class ReferencedNameHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		];
 
 		$names = ReferencedNameHelper::getAllReferencedNames($codeSnifferFile, 0);
-		$this->assertCount(count($foundTypes), $names);
+		self::assertCount(count($foundTypes), $names);
 		foreach ($names as $i => $referencedName) {
 			[$type, $isFunction, $isConstant] = $foundTypes[$i];
 
-			$this->assertSame($type, $referencedName->getNameAsReferencedInFile());
-			$this->assertSame($isFunction, $referencedName->isFunction(), $type);
-			$this->assertSame($isConstant, $referencedName->isConstant(), $type);
+			self::assertSame($type, $referencedName->getNameAsReferencedInFile());
+			self::assertSame($isFunction, $referencedName->isFunction(), $type);
+			self::assertSame($isConstant, $referencedName->isConstant(), $type);
 		}
 	}
 
@@ -84,7 +84,7 @@ class ReferencedNameHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$codeSnifferFile = $this->getCodeSnifferFile(
 			__DIR__ . '/data/fileWithoutReferencedName.php'
 		);
-		$this->assertCount(0, ReferencedNameHelper::getAllReferencedNames($codeSnifferFile, 0));
+		self::assertCount(0, ReferencedNameHelper::getAllReferencedNames($codeSnifferFile, 0));
 	}
 
 	public function testMultipleExceptionsCatch(): void
@@ -103,13 +103,13 @@ class ReferencedNameHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		];
 
 		$names = ReferencedNameHelper::getAllReferencedNames($codeSnifferFile, 0);
-		$this->assertCount(count($foundTypes), $names);
+		self::assertCount(count($foundTypes), $names);
 		foreach ($names as $i => $referencedName) {
 			[$type, $isFunction, $isConstant] = $foundTypes[$i];
 
-			$this->assertSame($type, $referencedName->getNameAsReferencedInFile());
-			$this->assertSame($isFunction, $referencedName->isFunction(), $type);
-			$this->assertSame($isConstant, $referencedName->isConstant(), $type);
+			self::assertSame($type, $referencedName->getNameAsReferencedInFile());
+			self::assertSame($isFunction, $referencedName->isFunction(), $type);
+			self::assertSame($isConstant, $referencedName->isConstant(), $type);
 		}
 	}
 
@@ -120,7 +120,7 @@ class ReferencedNameHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		);
 		$backslashTokenPointer = TokenHelper::findNext($codeSnifferFile, T_NS_SEPARATOR, 0);
 		$endTokenPointer = ReferencedNameHelper::getReferencedNameEndPointer($codeSnifferFile, $backslashTokenPointer);
-		$this->assertTokenPointer(T_STRING, 3, $codeSnifferFile, $endTokenPointer);
+		self::assertTokenPointer(T_STRING, 3, $codeSnifferFile, $endTokenPointer);
 	}
 
 	public function testReturnTypeHint(): void
@@ -129,9 +129,9 @@ class ReferencedNameHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 			__DIR__ . '/data/return-typehint.php'
 		);
 		$names = ReferencedNameHelper::getAllReferencedNames($codeSnifferFile, 0);
-		$this->assertCount(2, $names);
-		$this->assertSame('Bar', $names[0]->getNameAsReferencedInFile());
-		$this->assertSame('\OtherNamespace\Lorem', $names[1]->getNameAsReferencedInFile());
+		self::assertCount(2, $names);
+		self::assertSame('Bar', $names[0]->getNameAsReferencedInFile());
+		self::assertSame('\OtherNamespace\Lorem', $names[1]->getNameAsReferencedInFile());
 	}
 
 	public function testConstantIsNotReferencedName(): void
@@ -140,7 +140,7 @@ class ReferencedNameHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 			__DIR__ . '/data/classConstant.php'
 		);
 		$names = ReferencedNameHelper::getAllReferencedNames($codeSnifferFile, 0);
-		$this->assertCount(0, $names);
+		self::assertCount(0, $names);
 	}
 
 	public function testMethodReturningReferenceIsNotReferencedName(): void
@@ -149,7 +149,7 @@ class ReferencedNameHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 			__DIR__ . '/data/methodReturnsReference.php'
 		);
 		$names = ReferencedNameHelper::getAllReferencedNames($codeSnifferFile, 0);
-		$this->assertCount(0, $names);
+		self::assertCount(0, $names);
 	}
 
 }

--- a/tests/Helpers/SniffSettingsHelperTest.php
+++ b/tests/Helpers/SniffSettingsHelperTest.php
@@ -7,14 +7,14 @@ class SniffSettingsHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 
 	public function testNormalizeInteger(): void
 	{
-		$this->assertSame(2, SniffSettingsHelper::normalizeInteger(2));
-		$this->assertSame(2, SniffSettingsHelper::normalizeInteger('2'));
-		$this->assertSame(2, SniffSettingsHelper::normalizeInteger('  2  '));
+		self::assertSame(2, SniffSettingsHelper::normalizeInteger(2));
+		self::assertSame(2, SniffSettingsHelper::normalizeInteger('2'));
+		self::assertSame(2, SniffSettingsHelper::normalizeInteger('  2  '));
 	}
 
 	public function testNormalizeArray(): void
 	{
-		$this->assertSame([
+		self::assertSame([
 			'Foo\Bar\BarException',
 			'Foo\Bar\BazException',
 		], SniffSettingsHelper::normalizeArray([
@@ -29,7 +29,7 @@ class SniffSettingsHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 
 	public function testNormalizeAssociativeArray(): void
 	{
-		$this->assertSame([
+		self::assertSame([
 			'app/ui' => 'Slevomat\UI',
 			'app' => 'Slevomat',
 			'build/SlevomatSniffs/Sniffs' => 'SlevomatSniffs\Sniffs',
@@ -52,7 +52,7 @@ class SniffSettingsHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 
 	public function testNormalizeAssociativeArrayWithIntegerKeys(): void
 	{
-		$this->assertSame([
+		self::assertSame([
 			'app/ui' => 'Slevomat\UI',
 			'app' => 'Slevomat',
 		], SniffSettingsHelper::normalizeAssociativeArray([
@@ -70,7 +70,7 @@ class SniffSettingsHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	 */
 	public function testIsValidRegularExpression(string $expression, bool $valid): void
 	{
-		$this->assertSame($valid, SniffSettingsHelper::isValidRegularExpression($expression));
+		self::assertSame($valid, SniffSettingsHelper::isValidRegularExpression($expression));
 	}
 
 	/**

--- a/tests/Helpers/StringHelperTest.php
+++ b/tests/Helpers/StringHelperTest.php
@@ -33,7 +33,7 @@ class StringHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	 */
 	public function testStartsWith(string $haystack, string $needle): void
 	{
-		$this->assertTrue(StringHelper::startsWith($haystack, $needle));
+		self::assertTrue(StringHelper::startsWith($haystack, $needle));
 	}
 
 	/**
@@ -68,7 +68,7 @@ class StringHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	 */
 	public function testNotStartsWith(string $haystack, string $needle): void
 	{
-		$this->assertFalse(StringHelper::startsWith($haystack, $needle));
+		self::assertFalse(StringHelper::startsWith($haystack, $needle));
 	}
 
 	/**
@@ -99,7 +99,7 @@ class StringHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	 */
 	public function testEndsWith(string $haystack, string $needle): void
 	{
-		$this->assertTrue(StringHelper::endsWith($haystack, $needle));
+		self::assertTrue(StringHelper::endsWith($haystack, $needle));
 	}
 
 	/**
@@ -134,7 +134,7 @@ class StringHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	 */
 	public function testNotEndsWith(string $haystack, string $needle): void
 	{
-		$this->assertFalse(StringHelper::endsWith($haystack, $needle));
+		self::assertFalse(StringHelper::endsWith($haystack, $needle));
 	}
 
 }

--- a/tests/Helpers/SuppressHelperTest.php
+++ b/tests/Helpers/SuppressHelperTest.php
@@ -12,32 +12,32 @@ class SuppressHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 
 	public function testClassIsSuppressed(): void
 	{
-		$this->assertTrue(SuppressHelper::isSniffSuppressed($this->getTestedCodeSnifferFile(), $this->findClassPointerByName($this->getTestedCodeSnifferFile(), 'IsSuppressed'), self::CHECK_NAME));
+		self::assertTrue(SuppressHelper::isSniffSuppressed($this->getTestedCodeSnifferFile(), $this->findClassPointerByName($this->getTestedCodeSnifferFile(), 'IsSuppressed'), self::CHECK_NAME));
 	}
 
 	public function testClassIsNotSuppressed(): void
 	{
-		$this->assertFalse(SuppressHelper::isSniffSuppressed($this->getTestedCodeSnifferFile(), $this->findClassPointerByName($this->getTestedCodeSnifferFile(), 'IsNotSuppressed'), self::CHECK_NAME));
+		self::assertFalse(SuppressHelper::isSniffSuppressed($this->getTestedCodeSnifferFile(), $this->findClassPointerByName($this->getTestedCodeSnifferFile(), 'IsNotSuppressed'), self::CHECK_NAME));
 	}
 
 	public function testConstantIsSuppressed(): void
 	{
-		$this->assertTrue(SuppressHelper::isSniffSuppressed($this->getTestedCodeSnifferFile(), $this->findConstantPointerByName($this->getTestedCodeSnifferFile(), 'IS_SUPPRESSED'), self::CHECK_NAME));
+		self::assertTrue(SuppressHelper::isSniffSuppressed($this->getTestedCodeSnifferFile(), $this->findConstantPointerByName($this->getTestedCodeSnifferFile(), 'IS_SUPPRESSED'), self::CHECK_NAME));
 	}
 
 	public function testConstantIsNotSuppressed(): void
 	{
-		$this->assertFalse(SuppressHelper::isSniffSuppressed($this->getTestedCodeSnifferFile(), $this->findConstantPointerByName($this->getTestedCodeSnifferFile(), 'IS_NOT_SUPPRESSED'), self::CHECK_NAME));
+		self::assertFalse(SuppressHelper::isSniffSuppressed($this->getTestedCodeSnifferFile(), $this->findConstantPointerByName($this->getTestedCodeSnifferFile(), 'IS_NOT_SUPPRESSED'), self::CHECK_NAME));
 	}
 
 	public function testPropertyIsSuppressed(): void
 	{
-		$this->assertTrue(SuppressHelper::isSniffSuppressed($this->getTestedCodeSnifferFile(), $this->findPropertyPointerByName($this->getTestedCodeSnifferFile(), 'isSuppressed'), self::CHECK_NAME));
+		self::assertTrue(SuppressHelper::isSniffSuppressed($this->getTestedCodeSnifferFile(), $this->findPropertyPointerByName($this->getTestedCodeSnifferFile(), 'isSuppressed'), self::CHECK_NAME));
 	}
 
 	public function testPropertyIsNotSuppressed(): void
 	{
-		$this->assertFalse(SuppressHelper::isSniffSuppressed($this->getTestedCodeSnifferFile(), $this->findPropertyPointerByName($this->getTestedCodeSnifferFile(), 'isNotSuppressed'), self::CHECK_NAME));
+		self::assertFalse(SuppressHelper::isSniffSuppressed($this->getTestedCodeSnifferFile(), $this->findPropertyPointerByName($this->getTestedCodeSnifferFile(), 'isNotSuppressed'), self::CHECK_NAME));
 	}
 
 	/**
@@ -58,7 +58,7 @@ class SuppressHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	 */
 	public function testFunctionIsSuppressed(string $name): void
 	{
-		$this->assertTrue(SuppressHelper::isSniffSuppressed($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), $name), self::CHECK_NAME));
+		self::assertTrue(SuppressHelper::isSniffSuppressed($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), $name), self::CHECK_NAME));
 	}
 
 	/**
@@ -79,7 +79,7 @@ class SuppressHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	 */
 	public function testFunctionIsNotSuppressed(string $name): void
 	{
-		$this->assertFalse(SuppressHelper::isSniffSuppressed($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), $name), self::CHECK_NAME));
+		self::assertFalse(SuppressHelper::isSniffSuppressed($this->getTestedCodeSnifferFile(), $this->findFunctionPointerByName($this->getTestedCodeSnifferFile(), $name), self::CHECK_NAME));
 	}
 
 	private function getTestedCodeSnifferFile(): \PHP_CodeSniffer\Files\File

--- a/tests/Helpers/TestCase.php
+++ b/tests/Helpers/TestCase.php
@@ -17,12 +17,12 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 	{
 		$token = $this->getTokenFromPointer($codeSnifferFile, $tokenPointer);
 		$expectedTokenName = $this->findTokenName($code);
-		$this->assertSame(
+		self::assertSame(
 			$code,
 			$token['code'],
 			$expectedTokenName !== null ? sprintf('Expected %s, actual token is %s', $expectedTokenName, $token['type']) : ''
 		);
-		$this->assertSame($line, $token['line']);
+		self::assertSame($line, $token['line']);
 	}
 
 	protected function findClassPointerByName(\PHP_CodeSniffer\Files\File $codeSnifferFile, string $name): ?int

--- a/tests/Helpers/TestCaseChecksTokenBoundsTest.php
+++ b/tests/Helpers/TestCaseChecksTokenBoundsTest.php
@@ -11,12 +11,12 @@ class TestCaseChecksTokenBoundsTest extends \SlevomatCodingStandard\Helpers\Test
 			$codeSnifferFile = $this->getCodeSnifferFile(
 				__DIR__ . '/data/emptyPhpFile.php'
 			);
-			$this->assertTokenPointer(T_OPEN_TAG, 1, $codeSnifferFile, 5);
+			self::assertTokenPointer(T_OPEN_TAG, 1, $codeSnifferFile, 5);
 			$this->fail();
 		} catch (\SlevomatCodingStandard\Helpers\TokenPointerOutOfBoundsException $e) {
-			$this->assertSame('Attempted access to token pointer 5, last token pointer is 0', $e->getMessage());
-			$this->assertSame(5, $e->getPointer());
-			$this->assertSame(0, $e->getLastTokenPointer());
+			self::assertSame('Attempted access to token pointer 5, last token pointer is 0', $e->getMessage());
+			self::assertSame(5, $e->getPointer());
+			self::assertSame(0, $e->getLastTokenPointer());
 		}
 	}
 

--- a/tests/Helpers/TokenHelperTest.php
+++ b/tests/Helpers/TokenHelperTest.php
@@ -10,7 +10,7 @@ class TokenHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$codeSnifferFile = $this->getCodeSnifferFile(
 			__DIR__ . '/data/emptyPhpFile.php'
 		);
-		$this->assertTokenPointer(T_OPEN_TAG, 1, $codeSnifferFile, TokenHelper::findNextEffective($codeSnifferFile, 0));
+		self::assertTokenPointer(T_OPEN_TAG, 1, $codeSnifferFile, TokenHelper::findNextEffective($codeSnifferFile, 0));
 	}
 
 	public function testFindNextEffectiveAtEndOfFile(): void
@@ -19,8 +19,8 @@ class TokenHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 			__DIR__ . '/data/emptyPhpFile.php'
 		);
 		$openTagPointer = TokenHelper::findNext($codeSnifferFile, T_OPEN_TAG, 0);
-		$this->assertTokenPointer(T_OPEN_TAG, 1, $codeSnifferFile, $openTagPointer);
-		$this->assertNull(TokenHelper::findNextEffective($codeSnifferFile, $openTagPointer + 1));
+		self::assertTokenPointer(T_OPEN_TAG, 1, $codeSnifferFile, $openTagPointer);
+		self::assertNull(TokenHelper::findNextEffective($codeSnifferFile, $openTagPointer + 1));
 	}
 
 	public function testFindNextEffectiveWithComment(): void
@@ -28,7 +28,7 @@ class TokenHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$codeSnifferFile = $this->getCodeSnifferFile(
 			__DIR__ . '/data/effectiveCodeWithComment.php'
 		);
-		$this->assertTokenPointer(T_CLASS, 5, $codeSnifferFile, TokenHelper::findNextEffective($codeSnifferFile, 1));
+		self::assertTokenPointer(T_CLASS, 5, $codeSnifferFile, TokenHelper::findNextEffective($codeSnifferFile, 1));
 	}
 
 	public function testFindNextEffectiveWithDocComment(): void
@@ -36,7 +36,7 @@ class TokenHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$codeSnifferFile = $this->getCodeSnifferFile(
 			__DIR__ . '/data/effectiveCodeWithDocComment.php'
 		);
-		$this->assertTokenPointer(T_CLASS, 8, $codeSnifferFile, TokenHelper::findNextEffective($codeSnifferFile, 1));
+		self::assertTokenPointer(T_CLASS, 8, $codeSnifferFile, TokenHelper::findNextEffective($codeSnifferFile, 1));
 	}
 
 	public function testFindNothingNextExcluding(): void
@@ -44,7 +44,7 @@ class TokenHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$codeSnifferFile = $this->getCodeSnifferFile(
 			__DIR__ . '/data/sampleOne.php'
 		);
-		$this->assertNull(TokenHelper::findNextExcluding($codeSnifferFile, [
+		self::assertNull(TokenHelper::findNextExcluding($codeSnifferFile, [
 			T_OPEN_TAG,
 			T_WHITESPACE,
 			T_VARIABLE,
@@ -61,7 +61,7 @@ class TokenHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$codeSnifferFile = $this->getCodeSnifferFile(
 			__DIR__ . '/data/sampleOne.php'
 		);
-		$this->assertTokenPointer(T_VARIABLE, 3, $codeSnifferFile, TokenHelper::findNextExcluding($codeSnifferFile, [
+		self::assertTokenPointer(T_VARIABLE, 3, $codeSnifferFile, TokenHelper::findNextExcluding($codeSnifferFile, [
 			T_OPEN_TAG,
 			T_WHITESPACE,
 		], 0));
@@ -73,8 +73,8 @@ class TokenHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 			__DIR__ . '/data/sampleOne.php'
 		);
 		$variableTokenPointer = TokenHelper::findNext($codeSnifferFile, T_VARIABLE, 0);
-		$this->assertTokenPointer(T_VARIABLE, 3, $codeSnifferFile, $variableTokenPointer);
-		$this->assertNull(TokenHelper::findNextExcluding($codeSnifferFile, [
+		self::assertTokenPointer(T_VARIABLE, 3, $codeSnifferFile, $variableTokenPointer);
+		self::assertNull(TokenHelper::findNextExcluding($codeSnifferFile, [
 			T_OPEN_TAG,
 			T_WHITESPACE,
 		], 0, $variableTokenPointer));
@@ -86,8 +86,8 @@ class TokenHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 			__DIR__ . '/data/sampleOne.php'
 		);
 		$variableTokenPointer = TokenHelper::findNext($codeSnifferFile, T_VARIABLE, 0);
-		$this->assertTokenPointer(T_VARIABLE, 3, $codeSnifferFile, $variableTokenPointer);
-		$this->assertTokenPointer(T_VARIABLE, 3, $codeSnifferFile, TokenHelper::findNextAnyToken($codeSnifferFile, $variableTokenPointer));
+		self::assertTokenPointer(T_VARIABLE, 3, $codeSnifferFile, $variableTokenPointer);
+		self::assertTokenPointer(T_VARIABLE, 3, $codeSnifferFile, TokenHelper::findNextAnyToken($codeSnifferFile, $variableTokenPointer));
 	}
 
 	public function testFindPreviousEffective(): void
@@ -97,7 +97,7 @@ class TokenHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		);
 		$barTokenPointer = TokenHelper::findNext($codeSnifferFile, T_STRING, 1);
 		$assignmentTokenPointer = TokenHelper::findPreviousEffective($codeSnifferFile, $barTokenPointer - 1);
-		$this->assertTokenPointer(T_EQUAL, 3, $codeSnifferFile, $assignmentTokenPointer);
+		self::assertTokenPointer(T_EQUAL, 3, $codeSnifferFile, $assignmentTokenPointer);
 	}
 
 	public function testFindPreviousEffectiveWithComment(): void
@@ -105,7 +105,7 @@ class TokenHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$codeSnifferFile = $this->getCodeSnifferFile(
 			__DIR__ . '/data/effectiveCodeWithComment.php'
 		);
-		$this->assertTokenPointer(T_OPEN_TAG, 1, $codeSnifferFile, TokenHelper::findPreviousEffective($codeSnifferFile, TokenHelper::findNext($codeSnifferFile, T_CLASS, 0) - 1));
+		self::assertTokenPointer(T_OPEN_TAG, 1, $codeSnifferFile, TokenHelper::findPreviousEffective($codeSnifferFile, TokenHelper::findNext($codeSnifferFile, T_CLASS, 0) - 1));
 	}
 
 	public function testFindPreviousEffectiveWithDocComment(): void
@@ -113,7 +113,7 @@ class TokenHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$codeSnifferFile = $this->getCodeSnifferFile(
 			__DIR__ . '/data/effectiveCodeWithDocComment.php'
 		);
-		$this->assertTokenPointer(T_OPEN_TAG, 1, $codeSnifferFile, TokenHelper::findPreviousEffective($codeSnifferFile, TokenHelper::findNext($codeSnifferFile, T_CLASS, 0) - 1));
+		self::assertTokenPointer(T_OPEN_TAG, 1, $codeSnifferFile, TokenHelper::findPreviousEffective($codeSnifferFile, TokenHelper::findNext($codeSnifferFile, T_CLASS, 0) - 1));
 	}
 
 	public function testFindNothingPreviousExcluding(): void
@@ -121,7 +121,7 @@ class TokenHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$codeSnifferFile = $this->getCodeSnifferFile(
 			__DIR__ . '/data/sampleOne.php'
 		);
-		$this->assertNull(TokenHelper::findPreviousExcluding($codeSnifferFile, [
+		self::assertNull(TokenHelper::findPreviousExcluding($codeSnifferFile, [
 			T_OPEN_TAG,
 			T_WHITESPACE,
 			T_VARIABLE,
@@ -138,7 +138,7 @@ class TokenHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$codeSnifferFile = $this->getCodeSnifferFile(
 			__DIR__ . '/data/sampleOne.php'
 		);
-		$this->assertTokenPointer(T_OPEN_PARENTHESIS, 3, $codeSnifferFile, TokenHelper::findPreviousExcluding($codeSnifferFile, [
+		self::assertTokenPointer(T_OPEN_PARENTHESIS, 3, $codeSnifferFile, TokenHelper::findPreviousExcluding($codeSnifferFile, [
 			T_WHITESPACE,
 			T_CLOSE_PARENTHESIS,
 			T_SEMICOLON,
@@ -153,8 +153,8 @@ class TokenHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 
 		$lastTokenPointer = TokenHelper::getLastTokenPointer($codeSnifferFile);
 		$stringTokenPointer = TokenHelper::findNext($codeSnifferFile, T_STRING, 0);
-		$this->assertTokenPointer(T_STRING, 3, $codeSnifferFile, $stringTokenPointer);
-		$this->assertTokenPointer(T_STRING, 3, $codeSnifferFile, TokenHelper::findPreviousExcluding($codeSnifferFile, [
+		self::assertTokenPointer(T_STRING, 3, $codeSnifferFile, $stringTokenPointer);
+		self::assertTokenPointer(T_STRING, 3, $codeSnifferFile, TokenHelper::findPreviousExcluding($codeSnifferFile, [
 			T_WHITESPACE,
 			T_OPEN_PARENTHESIS,
 			T_CLOSE_PARENTHESIS,
@@ -170,8 +170,8 @@ class TokenHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 
 		$lastTokenPointer = TokenHelper::getLastTokenPointer($codeSnifferFile);
 		$openParenthesisTokenPointer = TokenHelper::findNext($codeSnifferFile, T_OPEN_PARENTHESIS, 0);
-		$this->assertTokenPointer(T_OPEN_PARENTHESIS, 3, $codeSnifferFile, $openParenthesisTokenPointer);
-		$this->assertNull(TokenHelper::findPreviousExcluding($codeSnifferFile, [
+		self::assertTokenPointer(T_OPEN_PARENTHESIS, 3, $codeSnifferFile, $openParenthesisTokenPointer);
+		self::assertNull(TokenHelper::findPreviousExcluding($codeSnifferFile, [
 			T_WHITESPACE,
 			T_OPEN_PARENTHESIS,
 			T_CLOSE_PARENTHESIS,
@@ -185,8 +185,8 @@ class TokenHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 			__DIR__ . '/data/sampleTwo.php'
 		);
 		$variableTokenPointer = TokenHelper::findNext($codeSnifferFile, T_VARIABLE, 0);
-		$this->assertTokenPointer(T_VARIABLE, 3, $codeSnifferFile, $variableTokenPointer);
-		$this->assertTokenPointer(T_STRING, 4, $codeSnifferFile, TokenHelper::findFirstTokenOnNextLine($codeSnifferFile, $variableTokenPointer));
+		self::assertTokenPointer(T_VARIABLE, 3, $codeSnifferFile, $variableTokenPointer);
+		self::assertTokenPointer(T_STRING, 4, $codeSnifferFile, TokenHelper::findFirstTokenOnNextLine($codeSnifferFile, $variableTokenPointer));
 	}
 
 	public function testFindFirstTokenOnIndentedNextLine(): void
@@ -197,11 +197,11 @@ class TokenHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$tokens = $codeSnifferFile->getTokens();
 		$forTokenPointer = TokenHelper::findNext($codeSnifferFile, T_FOR, 0);
 		$nextLineTokenPointer = TokenHelper::findFirstTokenOnNextLine($codeSnifferFile, $forTokenPointer);
-		$this->assertTokenPointer(T_WHITESPACE, 4, $codeSnifferFile, $nextLineTokenPointer);
-		$this->assertSame("\t", $tokens[$nextLineTokenPointer]['content']);
+		self::assertTokenPointer(T_WHITESPACE, 4, $codeSnifferFile, $nextLineTokenPointer);
+		self::assertSame("\t", $tokens[$nextLineTokenPointer]['content']);
 		$fooTokenPointer = TokenHelper::findNextAnyToken($codeSnifferFile, $nextLineTokenPointer + 1);
-		$this->assertTokenPointer(T_STRING, 4, $codeSnifferFile, $fooTokenPointer);
-		$this->assertSame('foo', $tokens[$fooTokenPointer]['content']);
+		self::assertTokenPointer(T_STRING, 4, $codeSnifferFile, $fooTokenPointer);
+		self::assertSame('foo', $tokens[$fooTokenPointer]['content']);
 	}
 
 	public function testFindFirstTokenOnNonExistentNextLine(): void
@@ -209,7 +209,7 @@ class TokenHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$codeSnifferFile = $this->getCodeSnifferFile(
 			__DIR__ . '/data/sampleTwo.php'
 		);
-		$this->assertNull(TokenHelper::findFirstTokenOnNextLine($codeSnifferFile, TokenHelper::getLastTokenPointer($codeSnifferFile)));
+		self::assertNull(TokenHelper::findFirstTokenOnNextLine($codeSnifferFile, TokenHelper::getLastTokenPointer($codeSnifferFile)));
 	}
 
 	public function testFindFirstTokenOnNonExistentNextLineAfterLastTokenInFile(): void
@@ -217,7 +217,7 @@ class TokenHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$codeSnifferFile = $this->getCodeSnifferFile(
 			__DIR__ . '/data/sampleTwo.php'
 		);
-		$this->assertNull(TokenHelper::findFirstTokenOnNextLine($codeSnifferFile, TokenHelper::getLastTokenPointer($codeSnifferFile) + 1));
+		self::assertNull(TokenHelper::findFirstTokenOnNextLine($codeSnifferFile, TokenHelper::getLastTokenPointer($codeSnifferFile) + 1));
 	}
 
 	public function testGetContent(): void
@@ -226,11 +226,11 @@ class TokenHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 			__DIR__ . '/data/sampleTwo.php'
 		);
 		$variableTokenPointer = TokenHelper::findNext($codeSnifferFile, T_VARIABLE, 0);
-		$this->assertTokenPointer(T_VARIABLE, 3, $codeSnifferFile, $variableTokenPointer);
+		self::assertTokenPointer(T_VARIABLE, 3, $codeSnifferFile, $variableTokenPointer);
 		$openParenthesisTokenPointer = TokenHelper::findNext($codeSnifferFile, T_OPEN_PARENTHESIS, 0);
-		$this->assertTokenPointer(T_OPEN_PARENTHESIS, 4, $codeSnifferFile, $openParenthesisTokenPointer);
+		self::assertTokenPointer(T_OPEN_PARENTHESIS, 4, $codeSnifferFile, $openParenthesisTokenPointer);
 		$content = TokenHelper::getContent($codeSnifferFile, $variableTokenPointer, $openParenthesisTokenPointer);
-		$this->assertSame(sprintf('$i++;%sfoo(', $codeSnifferFile->eolChar), $content);
+		self::assertSame(sprintf('$i++;%sfoo(', $codeSnifferFile->eolChar), $content);
 	}
 
 	public function testGetLastTokenPointer(): void
@@ -239,10 +239,10 @@ class TokenHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 			__DIR__ . '/data/sampleOne.php'
 		);
 		$semicolonTokenPointer = TokenHelper::findNext($codeSnifferFile, T_SEMICOLON, 0);
-		$this->assertTokenPointer(T_SEMICOLON, 3, $codeSnifferFile, $semicolonTokenPointer);
+		self::assertTokenPointer(T_SEMICOLON, 3, $codeSnifferFile, $semicolonTokenPointer);
 		$lastWhitespaceTokenPointer = TokenHelper::findNext($codeSnifferFile, T_WHITESPACE, $semicolonTokenPointer + 1);
-		$this->assertTokenPointer(T_WHITESPACE, 3, $codeSnifferFile, $lastWhitespaceTokenPointer);
-		$this->assertSame($lastWhitespaceTokenPointer, TokenHelper::getLastTokenPointer($codeSnifferFile));
+		self::assertTokenPointer(T_WHITESPACE, 3, $codeSnifferFile, $lastWhitespaceTokenPointer);
+		self::assertSame($lastWhitespaceTokenPointer, TokenHelper::getLastTokenPointer($codeSnifferFile));
 	}
 
 	public function testGetLastTokenPointerInEmptyFile(): void
@@ -254,8 +254,8 @@ class TokenHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 			TokenHelper::getLastTokenPointer($codeSnifferFile);
 			$this->fail();
 		} catch (\SlevomatCodingStandard\Helpers\EmptyFileException $e) {
-			$this->assertContains('emptyFile.php is empty', $e->getMessage());
-			$this->assertContains('emptyFile.php', $e->getFilename());
+			self::assertContains('emptyFile.php is empty', $e->getMessage());
+			self::assertContains('emptyFile.php', $e->getFilename());
 		}
 	}
 

--- a/tests/Helpers/TypeHelperTest.php
+++ b/tests/Helpers/TypeHelperTest.php
@@ -31,7 +31,7 @@ class TypeHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	 */
 	public function testValidTypeName(string $typeName): void
 	{
-		$this->assertTrue(TypeHelper::isTypeName($typeName));
+		self::assertTrue(TypeHelper::isTypeName($typeName));
 	}
 
 	/**
@@ -54,7 +54,7 @@ class TypeHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	 */
 	public function testNotValidTypeName(string $typeName): void
 	{
-		$this->assertFalse(TypeHelper::isTypeName($typeName));
+		self::assertFalse(TypeHelper::isTypeName($typeName));
 	}
 
 }

--- a/tests/Helpers/TypeHintHelperTest.php
+++ b/tests/Helpers/TypeHintHelperTest.php
@@ -38,7 +38,7 @@ class TypeHintHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	 */
 	public function testIsSimpleTypeHint(string $typeHint, bool $isSimple): void
 	{
-		$this->assertSame($isSimple, TypeHintHelper::isSimpleTypeHint($typeHint));
+		self::assertSame($isSimple, TypeHintHelper::isSimpleTypeHint($typeHint));
 	}
 
 	/**
@@ -62,7 +62,7 @@ class TypeHintHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	 */
 	public function testIsSimpleIterableTypeHint(string $typeHint, bool $isSimple): void
 	{
-		$this->assertSame($isSimple, TypeHintHelper::isSimpleIterableTypeHint($typeHint));
+		self::assertSame($isSimple, TypeHintHelper::isSimpleIterableTypeHint($typeHint));
 	}
 
 	/**
@@ -94,7 +94,7 @@ class TypeHintHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	 */
 	public function testIsSimpleUnofficialTypeHint(string $typeHint, bool $isSimple): void
 	{
-		$this->assertSame($isSimple, TypeHintHelper::isSimpleUnofficialTypeHints($typeHint));
+		self::assertSame($isSimple, TypeHintHelper::isSimpleUnofficialTypeHints($typeHint));
 	}
 
 	/**
@@ -120,7 +120,7 @@ class TypeHintHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 	 */
 	public function testConvertLongSimpleTypeHintToShort(string $long, string $short): void
 	{
-		$this->assertSame($short, TypeHintHelper::convertLongSimpleTypeHintToShort($long));
+		self::assertSame($short, TypeHintHelper::convertLongSimpleTypeHintToShort($long));
 	}
 
 	public function testFunctionReturnAnnotationWithNamespace(): void
@@ -129,7 +129,7 @@ class TypeHintHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 
 		$functionPointer = $this->findFunctionPointerByName($codeSnifferFile, 'fooFunctionWithReturnAnnotation');
 		$returnAnnotation = FunctionHelper::findReturnAnnotation($codeSnifferFile, $functionPointer);
-		$this->assertSame('void', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $functionPointer, $returnAnnotation->getContent()));
+		self::assertSame('void', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $functionPointer, $returnAnnotation->getContent()));
 	}
 
 	public function testFunctionReturnTypeHintWithNamespace(): void
@@ -138,7 +138,7 @@ class TypeHintHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 
 		$functionPointer = $this->findFunctionPointerByName($codeSnifferFile, 'fooFunctionWithReturnTypeHint');
 		$returnTypeHint = FunctionHelper::findReturnTypeHint($codeSnifferFile, $functionPointer);
-		$this->assertSame('\FooNamespace\FooClass', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $functionPointer, $returnTypeHint->getTypeHint()));
+		self::assertSame('\FooNamespace\FooClass', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $functionPointer, $returnTypeHint->getTypeHint()));
 	}
 
 	public function testFunctionParameterAnnotationWithNamespace(): void
@@ -148,7 +148,7 @@ class TypeHintHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$functionPointer = $this->findFunctionPointerByName($codeSnifferFile, 'fooFunctionWithParameterAnnotation');
 		$parameterAnnotation = FunctionHelper::getParametersAnnotations($codeSnifferFile, $functionPointer)[0];
 		$parameterTypeHint = preg_split('~\\s+~', $parameterAnnotation->getContent())[0];
-		$this->assertSame('\Doctrine\Common\Collections\ArrayCollection', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $functionPointer, $parameterTypeHint));
+		self::assertSame('\Doctrine\Common\Collections\ArrayCollection', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $functionPointer, $parameterTypeHint));
 	}
 
 	public function testFunctionParameterTypeHintWithNamespace(): void
@@ -157,7 +157,7 @@ class TypeHintHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 
 		$functionPointer = $this->findFunctionPointerByName($codeSnifferFile, 'fooFunctionWithParameterTypeHint');
 		$parameterTypeHint = FunctionHelper::getParametersTypeHints($codeSnifferFile, $functionPointer)['$parameter'];
-		$this->assertSame('\Doctrine\Common\Collections\ArrayCollection', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $functionPointer, $parameterTypeHint->getTypeHint()));
+		self::assertSame('\Doctrine\Common\Collections\ArrayCollection', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $functionPointer, $parameterTypeHint->getTypeHint()));
 	}
 
 	public function testMethodReturnAnnotationWithNamespace(): void
@@ -166,7 +166,7 @@ class TypeHintHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 
 		$methodPointer = $this->findFunctionPointerByName($codeSnifferFile, 'fooMethodWithReturnAnnotation');
 		$returnAnnotation = FunctionHelper::findReturnAnnotation($codeSnifferFile, $methodPointer);
-		$this->assertSame('\FooNamespace\FooClass', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $methodPointer, $returnAnnotation->getContent()));
+		self::assertSame('\FooNamespace\FooClass', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $methodPointer, $returnAnnotation->getContent()));
 	}
 
 	public function testMethodReturnTypeHintWithNamespace(): void
@@ -175,7 +175,7 @@ class TypeHintHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 
 		$methodPointer = $this->findFunctionPointerByName($codeSnifferFile, 'fooMethodWithReturnTypeHint');
 		$returnTypeHint = FunctionHelper::findReturnTypeHint($codeSnifferFile, $methodPointer);
-		$this->assertSame('bool', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $methodPointer, $returnTypeHint->getTypeHint()));
+		self::assertSame('bool', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $methodPointer, $returnTypeHint->getTypeHint()));
 	}
 
 	public function testMethodParameterAnnotationWithNamespace(): void
@@ -185,7 +185,7 @@ class TypeHintHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$methodPointer = $this->findFunctionPointerByName($codeSnifferFile, 'fooMethodWithParameterAnnotation');
 		$parameterAnnotation = FunctionHelper::getParametersAnnotations($codeSnifferFile, $methodPointer)[0];
 		$parameterTypeHint = preg_split('~\\s+~', $parameterAnnotation->getContent())[0];
-		$this->assertSame('\Doctrine\ORM\Mapping\Id', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $methodPointer, $parameterTypeHint));
+		self::assertSame('\Doctrine\ORM\Mapping\Id', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $methodPointer, $parameterTypeHint));
 	}
 
 	public function testMethodParameterTypeHintWithNamespace(): void
@@ -194,7 +194,7 @@ class TypeHintHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 
 		$methodPointer = $this->findFunctionPointerByName($codeSnifferFile, 'fooMethodWithParameterTypeHint');
 		$parameterTypeHint = FunctionHelper::getParametersTypeHints($codeSnifferFile, $methodPointer)['$parameter'];
-		$this->assertSame('\Doctrine\ORM\Mapping\Id', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $methodPointer, $parameterTypeHint->getTypeHint()));
+		self::assertSame('\Doctrine\ORM\Mapping\Id', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $methodPointer, $parameterTypeHint->getTypeHint()));
 	}
 
 	public function testFunctionReturnAnnotationWithoutNamespace(): void
@@ -203,7 +203,7 @@ class TypeHintHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 
 		$functionPointer = $this->findFunctionPointerByName($codeSnifferFile, 'fooFunctionWithReturnAnnotation');
 		$returnAnnotation = FunctionHelper::findReturnAnnotation($codeSnifferFile, $functionPointer);
-		$this->assertSame('void', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $functionPointer, $returnAnnotation->getContent()));
+		self::assertSame('void', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $functionPointer, $returnAnnotation->getContent()));
 	}
 
 	public function testFunctionReturnTypeHintWithoutNamespace(): void
@@ -212,7 +212,7 @@ class TypeHintHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 
 		$functionPointer = $this->findFunctionPointerByName($codeSnifferFile, 'fooFunctionWithReturnTypeHint');
 		$returnTypeHint = FunctionHelper::findReturnTypeHint($codeSnifferFile, $functionPointer);
-		$this->assertSame('\FooClass', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $functionPointer, $returnTypeHint->getTypeHint()));
+		self::assertSame('\FooClass', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $functionPointer, $returnTypeHint->getTypeHint()));
 	}
 
 	public function testFunctionParameterAnnotationWithoutNamespace(): void
@@ -222,7 +222,7 @@ class TypeHintHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$functionPointer = $this->findFunctionPointerByName($codeSnifferFile, 'fooFunctionWithParameterAnnotation');
 		$parameterAnnotation = FunctionHelper::getParametersAnnotations($codeSnifferFile, $functionPointer)[0];
 		$parameterTypeHint = preg_split('~\\s+~', $parameterAnnotation->getContent())[0];
-		$this->assertSame('\Doctrine\Common\Collections\ArrayCollection', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $functionPointer, $parameterTypeHint));
+		self::assertSame('\Doctrine\Common\Collections\ArrayCollection', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $functionPointer, $parameterTypeHint));
 	}
 
 	public function testFunctionParameterTypeHintWithoutNamespace(): void
@@ -231,7 +231,7 @@ class TypeHintHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 
 		$functionPointer = $this->findFunctionPointerByName($codeSnifferFile, 'fooFunctionWithParameterTypeHint');
 		$parameterTypeHint = FunctionHelper::getParametersTypeHints($codeSnifferFile, $functionPointer)['$parameter'];
-		$this->assertSame('\Doctrine\Common\Collections\ArrayCollection', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $functionPointer, $parameterTypeHint->getTypeHint()));
+		self::assertSame('\Doctrine\Common\Collections\ArrayCollection', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $functionPointer, $parameterTypeHint->getTypeHint()));
 	}
 
 	public function testMethodReturnAnnotationWithoutNamespace(): void
@@ -240,7 +240,7 @@ class TypeHintHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 
 		$methodPointer = $this->findFunctionPointerByName($codeSnifferFile, 'fooMethodWithReturnAnnotation');
 		$returnAnnotation = FunctionHelper::findReturnAnnotation($codeSnifferFile, $methodPointer);
-		$this->assertSame('\FooClass', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $methodPointer, $returnAnnotation->getContent()));
+		self::assertSame('\FooClass', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $methodPointer, $returnAnnotation->getContent()));
 	}
 
 	public function testMethodReturnTypeHintWithoutNamespace(): void
@@ -249,7 +249,7 @@ class TypeHintHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 
 		$methodPointer = $this->findFunctionPointerByName($codeSnifferFile, 'fooMethodWithReturnTypeHint');
 		$returnTypeHint = FunctionHelper::findReturnTypeHint($codeSnifferFile, $methodPointer);
-		$this->assertSame('bool', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $methodPointer, $returnTypeHint->getTypeHint()));
+		self::assertSame('bool', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $methodPointer, $returnTypeHint->getTypeHint()));
 	}
 
 	public function testMethodParameterAnnotationWithoutNamespace(): void
@@ -259,7 +259,7 @@ class TypeHintHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		$methodPointer = $this->findFunctionPointerByName($codeSnifferFile, 'fooMethodWithParameterAnnotation');
 		$parameterAnnotation = FunctionHelper::getParametersAnnotations($codeSnifferFile, $methodPointer)[0];
 		$parameterTypeHint = preg_split('~\\s+~', $parameterAnnotation->getContent())[0];
-		$this->assertSame('\Doctrine\ORM\Mapping\Id', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $methodPointer, $parameterTypeHint));
+		self::assertSame('\Doctrine\ORM\Mapping\Id', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $methodPointer, $parameterTypeHint));
 	}
 
 	public function testMethodParameterTypeHintWithoutNamespace(): void
@@ -268,7 +268,7 @@ class TypeHintHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 
 		$methodPointer = $this->findFunctionPointerByName($codeSnifferFile, 'fooMethodWithParameterTypeHint');
 		$parameterTypeHint = FunctionHelper::getParametersTypeHints($codeSnifferFile, $methodPointer)['$parameter'];
-		$this->assertSame('\Doctrine\ORM\Mapping\Id', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $methodPointer, $parameterTypeHint->getTypeHint()));
+		self::assertSame('\Doctrine\ORM\Mapping\Id', TypeHintHelper::getFullyQualifiedTypeHint($codeSnifferFile, $methodPointer, $parameterTypeHint->getTypeHint()));
 	}
 
 }

--- a/tests/Helpers/UseStatementHelperTest.php
+++ b/tests/Helpers/UseStatementHelperTest.php
@@ -11,7 +11,7 @@ class UseStatementHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 			__DIR__ . '/data/anonymousFunction.php'
 		);
 		$usePointer = TokenHelper::findNext($codeSnifferFile, T_USE, 0);
-		$this->assertTrue(UseStatementHelper::isAnonymousFunctionUse($codeSnifferFile, $usePointer));
+		self::assertTrue(UseStatementHelper::isAnonymousFunctionUse($codeSnifferFile, $usePointer));
 	}
 
 	public function testIsNotAnonymousFunctionUse(): void
@@ -20,7 +20,7 @@ class UseStatementHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 			__DIR__ . '/data/useStatements.php'
 		);
 		$usePointer = TokenHelper::findNext($codeSnifferFile, T_USE, 0);
-		$this->assertFalse(UseStatementHelper::isAnonymousFunctionUse($codeSnifferFile, $usePointer));
+		self::assertFalse(UseStatementHelper::isAnonymousFunctionUse($codeSnifferFile, $usePointer));
 	}
 
 	public function testIsTraitUse(): void
@@ -29,7 +29,7 @@ class UseStatementHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 			__DIR__ . '/data/classWithTrait.php'
 		);
 		$usePointer = TokenHelper::findNext($codeSnifferFile, T_USE, 0);
-		$this->assertTrue(UseStatementHelper::isTraitUse($codeSnifferFile, $usePointer));
+		self::assertTrue(UseStatementHelper::isTraitUse($codeSnifferFile, $usePointer));
 	}
 
 	public function testIsTraitUseInAnonymousClass(): void
@@ -38,7 +38,7 @@ class UseStatementHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 			__DIR__ . '/data/anonymousClassWithTrait.php'
 		);
 		$usePointer = TokenHelper::findNext($codeSnifferFile, T_USE, 0);
-		$this->assertTrue(UseStatementHelper::isTraitUse($codeSnifferFile, $usePointer));
+		self::assertTrue(UseStatementHelper::isTraitUse($codeSnifferFile, $usePointer));
 	}
 
 	public function testIsNotTraitUse(): void
@@ -47,7 +47,7 @@ class UseStatementHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 			__DIR__ . '/data/useStatements.php'
 		);
 		$usePointer = TokenHelper::findNext($codeSnifferFile, T_USE, 0);
-		$this->assertFalse(UseStatementHelper::isTraitUse($codeSnifferFile, $usePointer));
+		self::assertFalse(UseStatementHelper::isTraitUse($codeSnifferFile, $usePointer));
 	}
 
 	public function testGetNameAsReferencedInClassFromUse(): void
@@ -56,13 +56,13 @@ class UseStatementHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 			__DIR__ . '/data/useStatements.php'
 		);
 		$bazUsePointer = TokenHelper::findNext($codeSnifferFile, T_USE, 0);
-		$this->assertSame('Baz', UseStatementHelper::getNameAsReferencedInClassFromUse($codeSnifferFile, $bazUsePointer));
+		self::assertSame('Baz', UseStatementHelper::getNameAsReferencedInClassFromUse($codeSnifferFile, $bazUsePointer));
 
 		$fooUsePointer = TokenHelper::findNext($codeSnifferFile, T_USE, $bazUsePointer + 1);
-		$this->assertSame('Foo', UseStatementHelper::getNameAsReferencedInClassFromUse($codeSnifferFile, $fooUsePointer));
+		self::assertSame('Foo', UseStatementHelper::getNameAsReferencedInClassFromUse($codeSnifferFile, $fooUsePointer));
 
 		$loremIpsumUsePointer = TokenHelper::findNext($codeSnifferFile, T_USE, $fooUsePointer + 1);
-		$this->assertSame('LoremIpsum', UseStatementHelper::getNameAsReferencedInClassFromUse($codeSnifferFile, $loremIpsumUsePointer));
+		self::assertSame('LoremIpsum', UseStatementHelper::getNameAsReferencedInClassFromUse($codeSnifferFile, $loremIpsumUsePointer));
 	}
 
 	public function testGetFullyQualifiedTypeNameFromUse(): void
@@ -71,25 +71,25 @@ class UseStatementHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 			__DIR__ . '/data/useStatements.php'
 		);
 		$bazUsePointer = TokenHelper::findNext($codeSnifferFile, T_USE, 0);
-		$this->assertSame('Bar\Baz', UseStatementHelper::getFullyQualifiedTypeNameFromUse($codeSnifferFile, $bazUsePointer));
+		self::assertSame('Bar\Baz', UseStatementHelper::getFullyQualifiedTypeNameFromUse($codeSnifferFile, $bazUsePointer));
 
 		$fooUsePointer = TokenHelper::findNext($codeSnifferFile, T_USE, $bazUsePointer + 1);
-		$this->assertSame('Foo', UseStatementHelper::getFullyQualifiedTypeNameFromUse($codeSnifferFile, $fooUsePointer));
+		self::assertSame('Foo', UseStatementHelper::getFullyQualifiedTypeNameFromUse($codeSnifferFile, $fooUsePointer));
 
 		$loremIpsumUsePointer = TokenHelper::findNext($codeSnifferFile, T_USE, $fooUsePointer + 1);
-		$this->assertSame('Lorem\Ipsum', UseStatementHelper::getFullyQualifiedTypeNameFromUse($codeSnifferFile, $loremIpsumUsePointer));
+		self::assertSame('Lorem\Ipsum', UseStatementHelper::getFullyQualifiedTypeNameFromUse($codeSnifferFile, $loremIpsumUsePointer));
 
 		$lerdorfIsBarConstantUsePointer = TokenHelper::findNext($codeSnifferFile, T_USE, $loremIpsumUsePointer + 1);
-		$this->assertSame('Lerdorf\IS_BAR', UseStatementHelper::getFullyQualifiedTypeNameFromUse($codeSnifferFile, $lerdorfIsBarConstantUsePointer));
+		self::assertSame('Lerdorf\IS_BAR', UseStatementHelper::getFullyQualifiedTypeNameFromUse($codeSnifferFile, $lerdorfIsBarConstantUsePointer));
 
 		$rasmusFooConstantUsePointer = TokenHelper::findNext($codeSnifferFile, T_USE, $lerdorfIsBarConstantUsePointer + 1);
-		$this->assertSame('Rasmus\FOO', UseStatementHelper::getFullyQualifiedTypeNameFromUse($codeSnifferFile, $rasmusFooConstantUsePointer));
+		self::assertSame('Rasmus\FOO', UseStatementHelper::getFullyQualifiedTypeNameFromUse($codeSnifferFile, $rasmusFooConstantUsePointer));
 
 		$lerdorfIsBarFunctionUsePointer = TokenHelper::findNext($codeSnifferFile, T_USE, $rasmusFooConstantUsePointer + 1);
-		$this->assertSame('Lerdorf\isBar', UseStatementHelper::getFullyQualifiedTypeNameFromUse($codeSnifferFile, $lerdorfIsBarFunctionUsePointer));
+		self::assertSame('Lerdorf\isBar', UseStatementHelper::getFullyQualifiedTypeNameFromUse($codeSnifferFile, $lerdorfIsBarFunctionUsePointer));
 
 		$rasmusFooFunctionUsePointer = TokenHelper::findNext($codeSnifferFile, T_USE, $lerdorfIsBarFunctionUsePointer + 1);
-		$this->assertSame('Rasmus\foo', UseStatementHelper::getFullyQualifiedTypeNameFromUse($codeSnifferFile, $rasmusFooFunctionUsePointer));
+		self::assertSame('Rasmus\foo', UseStatementHelper::getFullyQualifiedTypeNameFromUse($codeSnifferFile, $rasmusFooFunctionUsePointer));
 	}
 
 	public function testGetUseStatements(): void
@@ -98,24 +98,24 @@ class UseStatementHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 			__DIR__ . '/data/useStatements.php'
 		);
 		$useStatements = UseStatementHelper::getUseStatements($codeSnifferFile, 0);
-		$this->assertCount(8, $useStatements);
-		$this->assertSame(2, $useStatements[UseStatement::getUniqueId(UseStatement::TYPE_DEFAULT, 'Baz')]->getPointer());
-		$this->assertUseStatement('Bar\Baz', 'Baz', $useStatements[UseStatement::getUniqueId(UseStatement::TYPE_DEFAULT, 'Baz')], false, false);
-		$this->assertUseStatement('Foo', 'Foo', $useStatements[UseStatement::getUniqueId(UseStatement::TYPE_DEFAULT, 'Foo')], false, false);
-		$this->assertUseStatement('Lorem\Ipsum', 'LoremIpsum', $useStatements[UseStatement::getUniqueId(UseStatement::TYPE_DEFAULT, 'LoremIpsum')], false, false);
-		$this->assertUseStatement('Zero', 'Zero', $useStatements[UseStatement::getUniqueId(UseStatement::TYPE_DEFAULT, 'Zero')], false, false);
-		$this->assertUseStatement('Rasmus\FOO', 'FOO', $useStatements[UseStatement::getUniqueId(UseStatement::TYPE_CONSTANT, 'FOO')], false, true);
-		$this->assertUseStatement('Rasmus\foo', 'foo', $useStatements[UseStatement::getUniqueId(UseStatement::TYPE_FUNCTION, 'foo')], true, false);
-		$this->assertUseStatement('Lerdorf\IS_BAR', 'IS_BAR', $useStatements[UseStatement::getUniqueId(UseStatement::TYPE_CONSTANT, 'IS_BAR')], false, true);
-		$this->assertUseStatement('Lerdorf\isBar', 'isBar', $useStatements[UseStatement::getUniqueId(UseStatement::TYPE_FUNCTION, 'isBar')], true, false);
+		self::assertCount(8, $useStatements);
+		self::assertSame(2, $useStatements[UseStatement::getUniqueId(UseStatement::TYPE_DEFAULT, 'Baz')]->getPointer());
+		self::assertUseStatement('Bar\Baz', 'Baz', $useStatements[UseStatement::getUniqueId(UseStatement::TYPE_DEFAULT, 'Baz')], false, false);
+		self::assertUseStatement('Foo', 'Foo', $useStatements[UseStatement::getUniqueId(UseStatement::TYPE_DEFAULT, 'Foo')], false, false);
+		self::assertUseStatement('Lorem\Ipsum', 'LoremIpsum', $useStatements[UseStatement::getUniqueId(UseStatement::TYPE_DEFAULT, 'LoremIpsum')], false, false);
+		self::assertUseStatement('Zero', 'Zero', $useStatements[UseStatement::getUniqueId(UseStatement::TYPE_DEFAULT, 'Zero')], false, false);
+		self::assertUseStatement('Rasmus\FOO', 'FOO', $useStatements[UseStatement::getUniqueId(UseStatement::TYPE_CONSTANT, 'FOO')], false, true);
+		self::assertUseStatement('Rasmus\foo', 'foo', $useStatements[UseStatement::getUniqueId(UseStatement::TYPE_FUNCTION, 'foo')], true, false);
+		self::assertUseStatement('Lerdorf\IS_BAR', 'IS_BAR', $useStatements[UseStatement::getUniqueId(UseStatement::TYPE_CONSTANT, 'IS_BAR')], false, true);
+		self::assertUseStatement('Lerdorf\isBar', 'isBar', $useStatements[UseStatement::getUniqueId(UseStatement::TYPE_FUNCTION, 'isBar')], true, false);
 	}
 
 	private function assertUseStatement(string $fullyQualifiedTypeName, string $referencedName, UseStatement $useStatement, bool $isFunction, bool $isConstant): void
 	{
-		$this->assertSame($fullyQualifiedTypeName, $useStatement->getFullyQualifiedTypeName());
-		$this->assertSame($referencedName, $useStatement->getNameAsReferencedInFile());
-		$this->assertSame($isFunction, $useStatement->isFunction());
-		$this->assertSame($isConstant, $useStatement->isConstant());
+		self::assertSame($fullyQualifiedTypeName, $useStatement->getFullyQualifiedTypeName());
+		self::assertSame($referencedName, $useStatement->getNameAsReferencedInFile());
+		self::assertSame($isFunction, $useStatement->isFunction());
+		self::assertSame($isConstant, $useStatement->isConstant());
 	}
 
 }

--- a/tests/Sniffs/Arrays/TrailingArrayCommaSniffTest.php
+++ b/tests/Sniffs/Arrays/TrailingArrayCommaSniffTest.php
@@ -7,18 +7,18 @@ class TrailingArrayCommaSniffTest extends \SlevomatCodingStandard\Sniffs\TestCas
 
 	public function testCheckFile(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/trailingCommas.php');
+		$report = self::checkFile(__DIR__ . '/data/trailingCommas.php');
 
-		$this->assertSame(2, $report->getErrorCount());
+		self::assertSame(2, $report->getErrorCount());
 
-		$this->assertSniffError($report, 18, TrailingArrayCommaSniff::CODE_MISSING_TRAILING_COMMA);
-		$this->assertSniffError($report, 26, TrailingArrayCommaSniff::CODE_MISSING_TRAILING_COMMA);
+		self::assertSniffError($report, 18, TrailingArrayCommaSniff::CODE_MISSING_TRAILING_COMMA);
+		self::assertSniffError($report, 26, TrailingArrayCommaSniff::CODE_MISSING_TRAILING_COMMA);
 	}
 
 	public function testFixable(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableTrailingCommas.php', [], [TrailingArrayCommaSniff::CODE_MISSING_TRAILING_COMMA]);
-		$this->assertAllFixedInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/fixableTrailingCommas.php', [], [TrailingArrayCommaSniff::CODE_MISSING_TRAILING_COMMA]);
+		self::assertAllFixedInFile($report);
 	}
 
 }

--- a/tests/Sniffs/Classes/ClassConstantVisibilitySniffTest.php
+++ b/tests/Sniffs/Classes/ClassConstantVisibilitySniffTest.php
@@ -7,17 +7,17 @@ class ClassConstantVisibilitySniffTest extends \SlevomatCodingStandard\Sniffs\Te
 
 	public function testErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/classWithConstants.php', [
+		$report = self::checkFile(__DIR__ . '/data/classWithConstants.php', [
 			'enabled' => true,
 		]);
 
-		$this->assertSame(1, $report->getErrorCount());
+		self::assertSame(1, $report->getErrorCount());
 
-		$this->assertNoSniffError($report, 7);
-		$this->assertNoSniffError($report, 9);
-		$this->assertNoSniffError($report, 10);
+		self::assertNoSniffError($report, 7);
+		self::assertNoSniffError($report, 9);
+		self::assertNoSniffError($report, 10);
 
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			6,
 			ClassConstantVisibilitySniff::CODE_MISSING_CONSTANT_VISIBILITY,
@@ -27,46 +27,46 @@ class ClassConstantVisibilitySniffTest extends \SlevomatCodingStandard\Sniffs\Te
 
 	public function testNoClassConstants(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/noClassConstants.php', [
+		$report = self::checkFile(__DIR__ . '/data/noClassConstants.php', [
 			'enabled' => true,
 		]);
-		$this->assertNoSniffErrorInFile($report);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testNoClassConstantsWithNamespace(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/noClassConstantsWithNamespace.php', [
+		$report = self::checkFile(__DIR__ . '/data/noClassConstantsWithNamespace.php', [
 			'enabled' => true,
 		]);
-		$this->assertNoSniffErrorInFile($report);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testDisabledSniff(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/classWithConstants.php', [
+		$report = self::checkFile(__DIR__ . '/data/classWithConstants.php', [
 			'enabled' => false,
 		]);
-		$this->assertNoSniffErrorInFile($report);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testFixableEnabled(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/fixableMissingClassConstantVisibility.php',
 			['fixable' => true],
 			[ClassConstantVisibilitySniff::CODE_MISSING_CONSTANT_VISIBILITY]
 		);
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableDisabled(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/fixableMissingClassConstantVisibilityFixableDisabled.php',
 			['fixable' => false],
 			[ClassConstantVisibilitySniff::CODE_MISSING_CONSTANT_VISIBILITY]
 		);
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 }

--- a/tests/Sniffs/Classes/UnusedPrivateElementsSniffTest.php
+++ b/tests/Sniffs/Classes/UnusedPrivateElementsSniffTest.php
@@ -7,7 +7,7 @@ class UnusedPrivateElementsSniffTest extends \SlevomatCodingStandard\Sniffs\Test
 
 	public function testErrors(): void
 	{
-		$resultFile = $this->checkFile(__DIR__ . '/data/classWithSomeUnusedElements.php', [
+		$resultFile = self::checkFile(__DIR__ . '/data/classWithSomeUnusedElements.php', [
 			'alwaysUsedPropertiesAnnotations' => [
 				'@get',
 				'@set',
@@ -18,143 +18,143 @@ class UnusedPrivateElementsSniffTest extends \SlevomatCodingStandard\Sniffs\Test
 				'Timestamp',
 			],
 		]);
-		$this->assertNoSniffError($resultFile, 6);
-		$this->assertNoSniffError($resultFile, 8);
-		$this->assertNoSniffError($resultFile, 10);
-		$this->assertNoSniffError($resultFile, 15);
-		$this->assertNoSniffError($resultFile, 20);
-		$this->assertNoSniffError($resultFile, 22);
-		$this->assertNoSniffError($resultFile, 24);
-		$this->assertSniffError(
+		self::assertNoSniffError($resultFile, 6);
+		self::assertNoSniffError($resultFile, 8);
+		self::assertNoSniffError($resultFile, 10);
+		self::assertNoSniffError($resultFile, 15);
+		self::assertNoSniffError($resultFile, 20);
+		self::assertNoSniffError($resultFile, 22);
+		self::assertNoSniffError($resultFile, 24);
+		self::assertSniffError(
 			$resultFile,
 			26,
 			UnusedPrivateElementsSniff::CODE_UNUSED_PROPERTY,
 			'Class ClassWithSomeUnusedProperties contains unused property $unusedProperty.'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$resultFile,
 			28,
 			UnusedPrivateElementsSniff::CODE_UNUSED_PROPERTY,
 			'Class ClassWithSomeUnusedProperties contains unused property $unusedPropertyWhichNameIsAlsoAFunction.'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$resultFile,
 			30,
 			UnusedPrivateElementsSniff::CODE_WRITE_ONLY_PROPERTY,
 			'Class ClassWithSomeUnusedProperties contains write-only property $writeOnlyProperty.'
 		);
-		$this->assertNoSniffError($resultFile, 33);
-		$this->assertSniffError(
+		self::assertNoSniffError($resultFile, 33);
+		self::assertSniffError(
 			$resultFile,
 			48,
 			UnusedPrivateElementsSniff::CODE_UNUSED_METHOD,
 			'Class ClassWithSomeUnusedProperties contains unused private method unusedPrivateMethod().'
 		);
-		$this->assertNoSniffError($resultFile, 51);
-		$this->assertNoSniffError($resultFile, 58);
-		$this->assertNoSniffError($resultFile, 63);
-		$this->assertSniffError(
+		self::assertNoSniffError($resultFile, 51);
+		self::assertNoSniffError($resultFile, 58);
+		self::assertNoSniffError($resultFile, 63);
+		self::assertSniffError(
 			$resultFile,
 			68,
 			UnusedPrivateElementsSniff::CODE_UNUSED_METHOD,
 			'Class ClassWithSomeUnusedProperties contains unused private method unusedStaticPrivateMethod().'
 		);
-		$this->assertNoSniffError($resultFile, 73);
+		self::assertNoSniffError($resultFile, 73);
 
-		$this->assertNoSniffError($resultFile, 81);
-		$this->assertNoSniffError($resultFile, 86);
-		$this->assertNoSniffError($resultFile, 91);
+		self::assertNoSniffError($resultFile, 81);
+		self::assertNoSniffError($resultFile, 86);
+		self::assertNoSniffError($resultFile, 91);
 
-		$this->assertSniffError(
+		self::assertSniffError(
 			$resultFile,
 			96,
 			UnusedPrivateElementsSniff::CODE_UNUSED_METHOD,
 			'Class ClassWithSomeUnusedProperties contains unused private method unusedMethodReturningReference().'
 		);
 
-		$this->assertSniffError(
+		self::assertSniffError(
 			$resultFile,
 			101,
 			UnusedPrivateElementsSniff::CODE_UNUSED_PROPERTY,
 			'Class ClassWithSomeUnusedProperties contains unused property $unusedPropertyWithWeirdDefinition.'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$resultFile,
 			103,
 			UnusedPrivateElementsSniff::CODE_WRITE_ONLY_PROPERTY,
 			'Class ClassWithSomeUnusedProperties contains write-only property $unusedWriteOnlyPropertyWithWeirdDefinition.'
 		);
 
-		$this->assertNoSniffError($resultFile, 110);
+		self::assertNoSniffError($resultFile, 110);
 
-		$this->assertSniffError(
+		self::assertSniffError(
 			$resultFile,
 			120,
 			UnusedPrivateElementsSniff::CODE_UNUSED_PROPERTY,
 			'Class ClassWithSomeUnusedProperties contains unused property $unusedStaticProperty1.'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$resultFile,
 			121,
 			UnusedPrivateElementsSniff::CODE_UNUSED_PROPERTY,
 			'Class ClassWithSomeUnusedProperties contains unused property $unusedStaticProperty2.'
 		);
 
-		$this->assertNoSniffError($resultFile, 123);
+		self::assertNoSniffError($resultFile, 123);
 	}
 
 	public function testOnlyPublicElements(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/classWithOnlyPublicElements.php'));
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/classWithOnlyPublicElements.php'));
 	}
 
 	public function testClassWithSpecialThis(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/classWithSpecialThis.php'));
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/classWithSpecialThis.php'));
 	}
 
 	public function testClassWithSpecialSelf(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/classWithSpecialSelf.php'));
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/classWithSpecialSelf.php'));
 	}
 
 	public function testClassWithPrivateElementsUsedOnSelfInstance(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/classWithPrivateElementsUsedOnSelfInstance.php');
-		$this->assertNoSniffErrorInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/classWithPrivateElementsUsedOnSelfInstance.php');
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testClassWithPrivateElementsUsedOnStaticInstance(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/classWithPrivateElementsUsedOnStaticInstance.php');
-		$this->assertNoSniffErrorInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/classWithPrivateElementsUsedOnStaticInstance.php');
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testClassWithPrivateElementsUsedOnSameClass(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/classWithPrivateElementsUsedOnSameClass.php');
-		$this->assertNoSniffErrorInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/classWithPrivateElementsUsedOnSameClass.php');
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testClassWithChainedPrivateMethods(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/classWithChainedPrivateMethods.php');
-		$this->assertNoSniffErrorInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/classWithChainedPrivateMethods.php');
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testClassWithConstants(): void
 	{
-		$resultFile = $this->checkFile(__DIR__ . '/data/classWithConstants.php');
+		$resultFile = self::checkFile(__DIR__ . '/data/classWithConstants.php');
 
-		$this->assertSame(1, $resultFile->getErrorCount());
+		self::assertSame(1, $resultFile->getErrorCount());
 
-		$this->assertNoSniffError($resultFile, 6);
-		$this->assertNoSniffError($resultFile, 7);
-		$this->assertNoSniffError($resultFile, 9);
-		$this->assertNoSniffError($resultFile, 11);
-		$this->assertNoSniffError($resultFile, 12);
+		self::assertNoSniffError($resultFile, 6);
+		self::assertNoSniffError($resultFile, 7);
+		self::assertNoSniffError($resultFile, 9);
+		self::assertNoSniffError($resultFile, 11);
+		self::assertNoSniffError($resultFile, 12);
 
-		$this->assertSniffError(
+		self::assertSniffError(
 			$resultFile,
 			10,
 			UnusedPrivateElementsSniff::CODE_UNUSED_CONSTANT,
@@ -164,11 +164,11 @@ class UnusedPrivateElementsSniffTest extends \SlevomatCodingStandard\Sniffs\Test
 
 	public function testClassWithPropertyUsedInString(): void
 	{
-		$resultFile = $this->checkFile(__DIR__ . '/data/classWithPropertyUsedInString.php');
+		$resultFile = self::checkFile(__DIR__ . '/data/classWithPropertyUsedInString.php');
 
-		$this->assertSame(1, $resultFile->getErrorCount());
+		self::assertSame(1, $resultFile->getErrorCount());
 
-		$this->assertSniffError(
+		self::assertSniffError(
 			$resultFile,
 			8,
 			UnusedPrivateElementsSniff::CODE_WRITE_ONLY_PROPERTY,
@@ -178,11 +178,11 @@ class UnusedPrivateElementsSniffTest extends \SlevomatCodingStandard\Sniffs\Test
 
 	public function testClassWithMethodUsedInString(): void
 	{
-		$resultFile = $this->checkFile(__DIR__ . '/data/classWithMethodUsedInString.php');
+		$resultFile = self::checkFile(__DIR__ . '/data/classWithMethodUsedInString.php');
 
-		$this->assertSame(1, $resultFile->getErrorCount());
+		self::assertSame(1, $resultFile->getErrorCount());
 
-		$this->assertSniffError(
+		self::assertSniffError(
 			$resultFile,
 			10,
 			UnusedPrivateElementsSniff::CODE_UNUSED_METHOD,
@@ -192,12 +192,12 @@ class UnusedPrivateElementsSniffTest extends \SlevomatCodingStandard\Sniffs\Test
 
 	public function testClassWithWriteOnlyProperties(): void
 	{
-		$resultFile = $this->checkFile(__DIR__ . '/data/classWithWriteOnlyProperties.php');
+		$resultFile = self::checkFile(__DIR__ . '/data/classWithWriteOnlyProperties.php');
 
-		$this->assertSame(13, $resultFile->getErrorCount());
+		self::assertSame(13, $resultFile->getErrorCount());
 
 		foreach (range(6, 18) as $line) {
-			$this->assertSniffError($resultFile, $line, UnusedPrivateElementsSniff::CODE_WRITE_ONLY_PROPERTY);
+			self::assertSniffError($resultFile, $line, UnusedPrivateElementsSniff::CODE_WRITE_ONLY_PROPERTY);
 		}
 	}
 

--- a/tests/Sniffs/Commenting/ForbiddenAnnotationsSniffTest.php
+++ b/tests/Sniffs/Commenting/ForbiddenAnnotationsSniffTest.php
@@ -7,35 +7,35 @@ class ForbiddenAnnotationsSniffTest extends \SlevomatCodingStandard\Sniffs\TestC
 
 	public function testNoForbiddenAnnotations(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/noForbiddenAnnotations.php', [
+		$report = self::checkFile(__DIR__ . '/data/noForbiddenAnnotations.php', [
 			'forbiddenAnnotations' => ['@see', '@throws'],
 		]);
-		$this->assertNoSniffErrorInFile($report);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testForbiddenAnnotations(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/forbiddenAnnotations.php', [
+		$report = self::checkFile(__DIR__ . '/data/forbiddenAnnotations.php', [
 			'forbiddenAnnotations' => ['@see', '@throws', '@Route'],
 		]);
 
-		$this->assertSame(7, $report->getErrorCount());
+		self::assertSame(7, $report->getErrorCount());
 
-		$this->assertSniffError($report, 5, ForbiddenAnnotationsSniff::CODE_ANNOTATION_FORBIDDEN);
-		$this->assertSniffError($report, 6, ForbiddenAnnotationsSniff::CODE_ANNOTATION_FORBIDDEN);
-		$this->assertSniffError($report, 19, ForbiddenAnnotationsSniff::CODE_ANNOTATION_FORBIDDEN);
-		$this->assertSniffError($report, 21, ForbiddenAnnotationsSniff::CODE_ANNOTATION_FORBIDDEN);
-		$this->assertSniffError($report, 30, ForbiddenAnnotationsSniff::CODE_ANNOTATION_FORBIDDEN);
-		$this->assertSniffError($report, 32, ForbiddenAnnotationsSniff::CODE_ANNOTATION_FORBIDDEN);
-		$this->assertSniffError($report, 45, ForbiddenAnnotationsSniff::CODE_ANNOTATION_FORBIDDEN);
+		self::assertSniffError($report, 5, ForbiddenAnnotationsSniff::CODE_ANNOTATION_FORBIDDEN);
+		self::assertSniffError($report, 6, ForbiddenAnnotationsSniff::CODE_ANNOTATION_FORBIDDEN);
+		self::assertSniffError($report, 19, ForbiddenAnnotationsSniff::CODE_ANNOTATION_FORBIDDEN);
+		self::assertSniffError($report, 21, ForbiddenAnnotationsSniff::CODE_ANNOTATION_FORBIDDEN);
+		self::assertSniffError($report, 30, ForbiddenAnnotationsSniff::CODE_ANNOTATION_FORBIDDEN);
+		self::assertSniffError($report, 32, ForbiddenAnnotationsSniff::CODE_ANNOTATION_FORBIDDEN);
+		self::assertSniffError($report, 45, ForbiddenAnnotationsSniff::CODE_ANNOTATION_FORBIDDEN);
 	}
 
 	public function testFixableForbiddenAnnotations(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/forbiddenAnnotations.php', [
+		$report = self::checkFile(__DIR__ . '/data/forbiddenAnnotations.php', [
 			'forbiddenAnnotations' => ['@see', '@throws', '@Route'],
 		], [ForbiddenAnnotationsSniff::CODE_ANNOTATION_FORBIDDEN]);
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 }

--- a/tests/Sniffs/Commenting/ForbiddenCommentsSniffTest.php
+++ b/tests/Sniffs/Commenting/ForbiddenCommentsSniffTest.php
@@ -7,23 +7,23 @@ class ForbiddenCommentsSniffTest extends \SlevomatCodingStandard\Sniffs\TestCase
 
 	public function testNoForbiddenComments(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/noForbiddenComments.php', [
+		$report = self::checkFile(__DIR__ . '/data/noForbiddenComments.php', [
 			'forbiddenCommentPatterns' => ['~Foo\d+~', '~Not comment\.~'],
 		]);
-		$this->assertNoSniffErrorInFile($report);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testForbiddenComments(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/forbiddenComments.php', [
+		$report = self::checkFile(__DIR__ . '/data/forbiddenComments.php', [
 			'forbiddenCommentPatterns' => ['~Created by PhpStorm\.~', '~(\S+\s+)?Constructor\.~', '~(blah){3}~'],
 		]);
 
-		$this->assertSame(3, $report->getErrorCount());
+		self::assertSame(3, $report->getErrorCount());
 
-		$this->assertSniffError($report, 4, ForbiddenCommentsSniff::CODE_COMMENT_FORBIDDEN);
-		$this->assertSniffError($report, 10, ForbiddenCommentsSniff::CODE_COMMENT_FORBIDDEN);
-		$this->assertSniffError($report, 36, ForbiddenCommentsSniff::CODE_COMMENT_FORBIDDEN);
+		self::assertSniffError($report, 4, ForbiddenCommentsSniff::CODE_COMMENT_FORBIDDEN);
+		self::assertSniffError($report, 10, ForbiddenCommentsSniff::CODE_COMMENT_FORBIDDEN);
+		self::assertSniffError($report, 36, ForbiddenCommentsSniff::CODE_COMMENT_FORBIDDEN);
 	}
 
 }

--- a/tests/Sniffs/Commenting/InlineDocCommentDeclarationSniffTest.php
+++ b/tests/Sniffs/Commenting/InlineDocCommentDeclarationSniffTest.php
@@ -7,29 +7,29 @@ class InlineDocCommentDeclarationSniffTest extends \SlevomatCodingStandard\Sniff
 
 	public function testNoInvalidInlineDocCommentDeclarations(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/noInvalidInlineDocCommentDeclarations.php');
-		$this->assertNoSniffErrorInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/noInvalidInlineDocCommentDeclarations.php');
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testInvalidInlineDocCommentDeclarations(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/invalidInlineDocCommentDeclarations.php');
+		$report = self::checkFile(__DIR__ . '/data/invalidInlineDocCommentDeclarations.php');
 
-		$this->assertSame(3, $report->getErrorCount());
+		self::assertSame(3, $report->getErrorCount());
 
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			12,
 			InlineDocCommentDeclarationSniff::CODE_INVALID_FORMAT,
 			'Invalid inline doc comment format "@var $a string[]" for variable $a, expected "@var string[] $a".'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			18,
 			InlineDocCommentDeclarationSniff::CODE_INVALID_FORMAT,
 			'Invalid inline doc comment format "@var $c" for variable $c, expected "@var type $c".'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			21,
 			InlineDocCommentDeclarationSniff::CODE_INVALID_FORMAT,
@@ -39,8 +39,8 @@ class InlineDocCommentDeclarationSniffTest extends \SlevomatCodingStandard\Sniff
 
 	public function testFixableInvalidInlineDocCommentDeclarations(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/invalidInlineDocCommentDeclarations.php', [], [InlineDocCommentDeclarationSniff::CODE_INVALID_FORMAT]);
-		$this->assertAllFixedInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/invalidInlineDocCommentDeclarations.php', [], [InlineDocCommentDeclarationSniff::CODE_INVALID_FORMAT]);
+		self::assertAllFixedInFile($report);
 	}
 
 }

--- a/tests/Sniffs/ControlStructures/AssignmentInConditionSniffTest.php
+++ b/tests/Sniffs/ControlStructures/AssignmentInConditionSniffTest.php
@@ -7,15 +7,15 @@ class AssignmentInConditionSniffTest extends \SlevomatCodingStandard\Sniffs\Test
 
 	public function testCorrectFile(): void
 	{
-		$resultFile = $this->checkFile(__DIR__ . '/data/noAssignmentsInConditions.php');
-		$this->assertNoSniffErrorInFile($resultFile);
+		$resultFile = self::checkFile(__DIR__ . '/data/noAssignmentsInConditions.php');
+		self::assertNoSniffErrorInFile($resultFile);
 	}
 
 	public function testIncorrectFile(): void
 	{
-		$resultFile = $this->checkFile(__DIR__ . '/data/allAssignmentsInConditions.php');
+		$resultFile = self::checkFile(__DIR__ . '/data/allAssignmentsInConditions.php');
 		foreach (range(3, 6) as $lineNumber) {
-			$this->assertSniffError($resultFile, $lineNumber, AssignmentInConditionSniff::CODE_ASSIGNMENT_IN_CONDITION);
+			self::assertSniffError($resultFile, $lineNumber, AssignmentInConditionSniff::CODE_ASSIGNMENT_IN_CONDITION);
 		}
 	}
 

--- a/tests/Sniffs/ControlStructures/DisallowEqualOperatorsSniffTest.php
+++ b/tests/Sniffs/ControlStructures/DisallowEqualOperatorsSniffTest.php
@@ -7,19 +7,19 @@ class DisallowEqualOperatorsSniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 
 	public function testNoErrors(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/disallowEqualOperatorsNoErrors.php'));
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/disallowEqualOperatorsNoErrors.php'));
 	}
 
 	public function testErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/disallowEqualOperatorsErrors.php');
+		$report = self::checkFile(__DIR__ . '/data/disallowEqualOperatorsErrors.php');
 
-		$this->assertSame(4, $report->getErrorCount());
+		self::assertSame(4, $report->getErrorCount());
 
-		$this->assertSniffError($report, 3, DisallowEqualOperatorsSniff::CODE_DISALLOWED_EQUAL_OPERATOR);
-		$this->assertSniffError($report, 4, DisallowEqualOperatorsSniff::CODE_DISALLOWED_EQUAL_OPERATOR);
-		$this->assertSniffError($report, 5, DisallowEqualOperatorsSniff::CODE_DISALLOWED_NOT_EQUAL_OPERATOR);
-		$this->assertSniffError($report, 6, DisallowEqualOperatorsSniff::CODE_DISALLOWED_NOT_EQUAL_OPERATOR);
+		self::assertSniffError($report, 3, DisallowEqualOperatorsSniff::CODE_DISALLOWED_EQUAL_OPERATOR);
+		self::assertSniffError($report, 4, DisallowEqualOperatorsSniff::CODE_DISALLOWED_EQUAL_OPERATOR);
+		self::assertSniffError($report, 5, DisallowEqualOperatorsSniff::CODE_DISALLOWED_NOT_EQUAL_OPERATOR);
+		self::assertSniffError($report, 6, DisallowEqualOperatorsSniff::CODE_DISALLOWED_NOT_EQUAL_OPERATOR);
 
 		$this->assertAllFixedInFile($report);
 	}

--- a/tests/Sniffs/ControlStructures/DisallowYodaComparisonSniffTest.php
+++ b/tests/Sniffs/ControlStructures/DisallowYodaComparisonSniffTest.php
@@ -7,22 +7,22 @@ class DisallowYodaComparisonSniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 
 	public function testNoErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/disallowYodaComparisonNoErrors.php');
-		$this->assertNoSniffErrorInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/disallowYodaComparisonNoErrors.php');
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/disallowYodaComparisonErrors.php');
+		$report = self::checkFile(__DIR__ . '/data/disallowYodaComparisonErrors.php');
 		foreach (range(3, 37) as $lineNumber) {
-			$this->assertSniffError($report, $lineNumber, DisallowYodaComparisonSniff::CODE_DISALLOWED_YODA_COMPARISON);
+			self::assertSniffError($report, $lineNumber, DisallowYodaComparisonSniff::CODE_DISALLOWED_YODA_COMPARISON);
 		}
 	}
 
 	public function testFixable(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableDisallowYodaComparisons.php', [], [DisallowYodaComparisonSniff::CODE_DISALLOWED_YODA_COMPARISON]);
-		$this->assertAllFixedInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/fixableDisallowYodaComparisons.php', [], [DisallowYodaComparisonSniff::CODE_DISALLOWED_YODA_COMPARISON]);
+		self::assertAllFixedInFile($report);
 	}
 
 }

--- a/tests/Sniffs/ControlStructures/EarlyExitSniffTest.php
+++ b/tests/Sniffs/ControlStructures/EarlyExitSniffTest.php
@@ -7,25 +7,23 @@ class EarlyExitSniffTest extends \SlevomatCodingStandard\Sniffs\TestCase
 
 	public function testNoErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/earlyExitNoErrors.php');
-		$this->assertNoSniffErrorInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/earlyExitNoErrors.php');
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/earlyExitErrors.php', [], [EarlyExitSniff::CODE_EARLY_EXIT_NOT_USED]);
+		$report = self::checkFile(__DIR__ . '/data/earlyExitErrors.php', [], [EarlyExitSniff::CODE_EARLY_EXIT_NOT_USED]);
 
-		$this->assertSame(18, $report->getErrorCount());
+		self::assertSame(18, $report->getErrorCount());
 
 		foreach ([6, 15, 24, 33, 42, 50, 58, 66, 74, 82, 90, 98, 108] as $line) {
-			$this->assertSniffError($report, $line, EarlyExitSniff::CODE_EARLY_EXIT_NOT_USED, 'Use early exit instead of else.');
+			self::assertSniffError($report, $line, EarlyExitSniff::CODE_EARLY_EXIT_NOT_USED, 'Use early exit instead of else.');
 		}
 
 		foreach ([115, 122, 129, 135, 141] as $line) {
-			$this->assertSniffError($report, $line, EarlyExitSniff::CODE_EARLY_EXIT_NOT_USED, 'Use early exit to reduce code nesting.');
+			self::assertSniffError($report, $line, EarlyExitSniff::CODE_EARLY_EXIT_NOT_USED, 'Use early exit to reduce code nesting.');
 		}
-
-		$this->assertAllFixedInFile($report);
 	}
 
 }

--- a/tests/Sniffs/ControlStructures/LanguageConstructWithParenthesesSniffTest.php
+++ b/tests/Sniffs/ControlStructures/LanguageConstructWithParenthesesSniffTest.php
@@ -7,30 +7,30 @@ class LanguageConstructWithParenthesesSniffTest extends \SlevomatCodingStandard\
 
 	public function testNoErrors(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/languageConstructWithParenthesesNoErrors.php'));
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/languageConstructWithParenthesesNoErrors.php'));
 	}
 
 	public function testErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/languageConstructWithParenthesesErrors.php', [], [LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES]);
+		$report = self::checkFile(__DIR__ . '/data/languageConstructWithParenthesesErrors.php', [], [LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES]);
 
-		$this->assertSame(13, $report->getErrorCount());
+		self::assertSame(13, $report->getErrorCount());
 
-		$this->assertSniffError($report, 5, LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES, 'Usage of language construct "continue" with parentheses is disallowed.');
-		$this->assertSniffError($report, 8, LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES, 'Usage of language construct "break" with parentheses is disallowed.');
-		$this->assertSniffError($report, 12, LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES, 'Usage of language construct "echo" with parentheses is disallowed.');
-		$this->assertSniffError($report, 13, LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES, 'Usage of language construct "print" with parentheses is disallowed.');
-		$this->assertSniffError($report, 15, LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES, 'Usage of language construct "include" with parentheses is disallowed.');
-		$this->assertSniffError($report, 16, LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES, 'Usage of language construct "include_once" with parentheses is disallowed.');
-		$this->assertSniffError($report, 17, LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES, 'Usage of language construct "require" with parentheses is disallowed.');
-		$this->assertSniffError($report, 18, LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES, 'Usage of language construct "require_once" with parentheses is disallowed.');
-		$this->assertSniffError($report, 22, LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES, 'Usage of language construct "return" with parentheses is disallowed.');
-		$this->assertSniffError($report, 27, LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES, 'Usage of language construct "yield" with parentheses is disallowed.');
-		$this->assertSniffError($report, 31, LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES, 'Usage of language construct "throw" with parentheses is disallowed.');
-		$this->assertSniffError($report, 36, LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES, 'Usage of language construct "die" with parentheses is disallowed.');
-		$this->assertSniffError($report, 37, LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES, 'Usage of language construct "exit" with parentheses is disallowed.');
+		self::assertSniffError($report, 5, LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES, 'Usage of language construct "continue" with parentheses is disallowed.');
+		self::assertSniffError($report, 8, LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES, 'Usage of language construct "break" with parentheses is disallowed.');
+		self::assertSniffError($report, 12, LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES, 'Usage of language construct "echo" with parentheses is disallowed.');
+		self::assertSniffError($report, 13, LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES, 'Usage of language construct "print" with parentheses is disallowed.');
+		self::assertSniffError($report, 15, LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES, 'Usage of language construct "include" with parentheses is disallowed.');
+		self::assertSniffError($report, 16, LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES, 'Usage of language construct "include_once" with parentheses is disallowed.');
+		self::assertSniffError($report, 17, LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES, 'Usage of language construct "require" with parentheses is disallowed.');
+		self::assertSniffError($report, 18, LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES, 'Usage of language construct "require_once" with parentheses is disallowed.');
+		self::assertSniffError($report, 22, LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES, 'Usage of language construct "return" with parentheses is disallowed.');
+		self::assertSniffError($report, 27, LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES, 'Usage of language construct "yield" with parentheses is disallowed.');
+		self::assertSniffError($report, 31, LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES, 'Usage of language construct "throw" with parentheses is disallowed.');
+		self::assertSniffError($report, 36, LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES, 'Usage of language construct "die" with parentheses is disallowed.');
+		self::assertSniffError($report, 37, LanguageConstructWithParenthesesSniff::CODE_USED_WITH_PARENTHESES, 'Usage of language construct "exit" with parentheses is disallowed.');
 
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 }

--- a/tests/Sniffs/ControlStructures/NewWithParenthesesSniffTest.php
+++ b/tests/Sniffs/ControlStructures/NewWithParenthesesSniffTest.php
@@ -7,21 +7,21 @@ class NewWithParenthesesSniffTest extends \SlevomatCodingStandard\Sniffs\TestCas
 
 	public function testNoErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/newWithParenthesesNoErrors.php');
-		$this->assertNoSniffErrorInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/newWithParenthesesNoErrors.php');
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/newWithParenthesesErrors.php', [], [NewWithParenthesesSniff::CODE_MISSING_PARENTHESES]);
+		$report = self::checkFile(__DIR__ . '/data/newWithParenthesesErrors.php', [], [NewWithParenthesesSniff::CODE_MISSING_PARENTHESES]);
 
-		$this->assertSame(19, $report->getErrorCount());
+		self::assertSame(19, $report->getErrorCount());
 
 		foreach ([3, 9, 17, 22, 25, 29, 35, 37, 40, 43, 45, 47, 48, 50, 52, 57] as $line) {
-			$this->assertSniffError($report, $line, NewWithParenthesesSniff::CODE_MISSING_PARENTHESES);
+			self::assertSniffError($report, $line, NewWithParenthesesSniff::CODE_MISSING_PARENTHESES);
 		}
 
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 }

--- a/tests/Sniffs/ControlStructures/RequireNullCoalesceOperatorSniffTest.php
+++ b/tests/Sniffs/ControlStructures/RequireNullCoalesceOperatorSniffTest.php
@@ -7,21 +7,21 @@ class RequireNullCoalesceOperatorSniffTest extends \SlevomatCodingStandard\Sniff
 
 	public function testNoErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/requireNullCoalesceOperatorNoErrors.php');
-		$this->assertNoSniffErrorInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/requireNullCoalesceOperatorNoErrors.php');
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/requireNullCoalesceOperatorErrors.php', [], [RequireNullCoalesceOperatorSniff::CODE_NULL_COALESCE_OPERATOR_NOT_USED]);
+		$report = self::checkFile(__DIR__ . '/data/requireNullCoalesceOperatorErrors.php', [], [RequireNullCoalesceOperatorSniff::CODE_NULL_COALESCE_OPERATOR_NOT_USED]);
 
-		$this->assertSame(3, $report->getErrorCount());
+		self::assertSame(3, $report->getErrorCount());
 
 		foreach ([3, 5, 7] as $line) {
-			$this->assertSniffError($report, $line, RequireNullCoalesceOperatorSniff::CODE_NULL_COALESCE_OPERATOR_NOT_USED);
+			self::assertSniffError($report, $line, RequireNullCoalesceOperatorSniff::CODE_NULL_COALESCE_OPERATOR_NOT_USED);
 		}
 
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 }

--- a/tests/Sniffs/ControlStructures/RequireYodaComparisonSniffTest.php
+++ b/tests/Sniffs/ControlStructures/RequireYodaComparisonSniffTest.php
@@ -7,22 +7,22 @@ class RequireYodaComparisonSniffTest extends \SlevomatCodingStandard\Sniffs\Test
 
 	public function testNoErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/requireYodaComparisonNoErrors.php');
-		$this->assertNoSniffErrorInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/requireYodaComparisonNoErrors.php');
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/requireYodaComparisonErrors.php');
+		$report = self::checkFile(__DIR__ . '/data/requireYodaComparisonErrors.php');
 		foreach (range(3, 37) as $lineNumber) {
-			$this->assertSniffError($report, $lineNumber, RequireYodaComparisonSniff::CODE_REQUIRED_YODA_COMPARISON);
+			self::assertSniffError($report, $lineNumber, RequireYodaComparisonSniff::CODE_REQUIRED_YODA_COMPARISON);
 		}
 	}
 
 	public function testFixable(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableRequireYodaComparisons.php', [], [RequireYodaComparisonSniff::CODE_REQUIRED_YODA_COMPARISON]);
-		$this->assertAllFixedInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/fixableRequireYodaComparisons.php', [], [RequireYodaComparisonSniff::CODE_REQUIRED_YODA_COMPARISON]);
+		self::assertAllFixedInFile($report);
 	}
 
 }

--- a/tests/Sniffs/Exceptions/DeadCatchSniffTest.php
+++ b/tests/Sniffs/Exceptions/DeadCatchSniffTest.php
@@ -7,54 +7,54 @@ class DeadCatchSniffTest extends \SlevomatCodingStandard\Sniffs\TestCase
 
 	public function testNoDeadCatches(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/noDeadCatches.php');
-		$this->assertNoSniffErrorInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/noDeadCatches.php');
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testDeadCatchesWithoutNamespace(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/deadCatchesWithoutNamespace.php');
+		$report = self::checkFile(__DIR__ . '/data/deadCatchesWithoutNamespace.php');
 
-		$this->assertSame(6, $report->getErrorCount());
+		self::assertSame(6, $report->getErrorCount());
 
-		$this->assertSniffError($report, 9, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
-		$this->assertSniffError($report, 11, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
-		$this->assertSniffError($report, 23, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
-		$this->assertSniffError($report, 33, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
-		$this->assertSniffError($report, 35, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
-		$this->assertSniffError($report, 47, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
+		self::assertSniffError($report, 9, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
+		self::assertSniffError($report, 11, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
+		self::assertSniffError($report, 23, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
+		self::assertSniffError($report, 33, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
+		self::assertSniffError($report, 35, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
+		self::assertSniffError($report, 47, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
 	}
 
 	public function testDeadCatchesInNamespace(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/deadCatches.php');
+		$report = self::checkFile(__DIR__ . '/data/deadCatches.php');
 
-		$this->assertSame(4, $report->getErrorCount());
+		self::assertSame(4, $report->getErrorCount());
 
-		$this->assertSniffError($report, 49, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
-		$this->assertSniffError($report, 51, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
-		$this->assertSniffError($report, 61, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
-		$this->assertSniffError($report, 63, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
+		self::assertSniffError($report, 49, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
+		self::assertSniffError($report, 51, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
+		self::assertSniffError($report, 61, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
+		self::assertSniffError($report, 63, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
 	}
 
 	public function testDeadUnionCatches(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/deadUnionCatches.php');
+		$report = self::checkFile(__DIR__ . '/data/deadUnionCatches.php');
 
-		$this->assertSame(2, $report->getErrorCount());
+		self::assertSame(2, $report->getErrorCount());
 
-		$this->assertSniffError($report, 31, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
-		$this->assertSniffError($report, 41, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
+		self::assertSniffError($report, 31, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
+		self::assertSniffError($report, 41, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
 	}
 
 	public function testDeadCatchWeirdDefinition(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/deadCatchesWeirdDefinition.php');
+		$report = self::checkFile(__DIR__ . '/data/deadCatchesWeirdDefinition.php');
 
-		$this->assertSame(2, $report->getErrorCount());
+		self::assertSame(2, $report->getErrorCount());
 
-		$this->assertSniffError($report, 13, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
-		$this->assertSniffError($report, 21, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
+		self::assertSniffError($report, 13, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
+		self::assertSniffError($report, 21, DeadCatchSniff::CODE_CATCH_AFTER_THROWABLE_CATCH);
 	}
 
 }

--- a/tests/Sniffs/Exceptions/ReferenceThrowableOnlySniffTest.php
+++ b/tests/Sniffs/Exceptions/ReferenceThrowableOnlySniffTest.php
@@ -7,75 +7,75 @@ class ReferenceThrowableOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 
 	public function testExceptionReferences(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/exceptionReferences.php');
-		$this->assertNoSniffError($report, 5);
-		$this->assertNoSniffError($report, 6);
-		$this->assertNoSniffError($report, 8);
-		$this->assertSniffError($report, 12, ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION);
-		$this->assertNoSniffError($report, 13);
-		$this->assertNoSniffError($report, 14);
-		$this->assertNoSniffError($report, 17);
-		$this->assertNoSniffError($report, 18);
-		$this->assertNoSniffError($report, 23);
-		$this->assertNoSniffError($report, 25);
-		$this->assertNoSniffError($report, 27);
-		$this->assertSniffError($report, 33, ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION);
-		$this->assertNoSniffError($report, 35);
-		$this->assertSniffError($report, 37, ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION);
+		$report = self::checkFile(__DIR__ . '/data/exceptionReferences.php');
+		self::assertNoSniffError($report, 5);
+		self::assertNoSniffError($report, 6);
+		self::assertNoSniffError($report, 8);
+		self::assertSniffError($report, 12, ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION);
+		self::assertNoSniffError($report, 13);
+		self::assertNoSniffError($report, 14);
+		self::assertNoSniffError($report, 17);
+		self::assertNoSniffError($report, 18);
+		self::assertNoSniffError($report, 23);
+		self::assertNoSniffError($report, 25);
+		self::assertNoSniffError($report, 27);
+		self::assertSniffError($report, 33, ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION);
+		self::assertNoSniffError($report, 35);
+		self::assertSniffError($report, 37, ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION);
 	}
 
 	public function testExceptionReferencesWithoutNamespace(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/exceptionReferencesWithoutNamespace.php');
-		$this->assertNoSniffError($report, 3);
-		$this->assertNoSniffError($report, 5);
-		$this->assertSniffError($report, 9, ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION);
-		$this->assertSniffError($report, 10, ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION);
-		$this->assertNoSniffError($report, 11);
-		$this->assertNoSniffError($report, 14);
-		$this->assertNoSniffError($report, 15);
-		$this->assertNoSniffError($report, 20);
-		$this->assertNoSniffError($report, 22);
-		$this->assertNoSniffError($report, 24);
-		$this->assertSniffError($report, 30, ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION);
-		$this->assertSniffError($report, 32, ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION);
+		$report = self::checkFile(__DIR__ . '/data/exceptionReferencesWithoutNamespace.php');
+		self::assertNoSniffError($report, 3);
+		self::assertNoSniffError($report, 5);
+		self::assertSniffError($report, 9, ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION);
+		self::assertSniffError($report, 10, ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION);
+		self::assertNoSniffError($report, 11);
+		self::assertNoSniffError($report, 14);
+		self::assertNoSniffError($report, 15);
+		self::assertNoSniffError($report, 20);
+		self::assertNoSniffError($report, 22);
+		self::assertNoSniffError($report, 24);
+		self::assertSniffError($report, 30, ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION);
+		self::assertSniffError($report, 32, ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION);
 	}
 
 	public function testExceptionReferencesUnionTypes71(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/exceptionReferences71.php');
-		$this->assertNoSniffError($report, 5);
-		$this->assertNoSniffError($report, 7);
-		$this->assertNoSniffError($report, 9);
-		$this->assertNoSniffError($report, 15);
-		$this->assertNoSniffError($report, 17);
-		$this->assertNoSniffError($report, 19);
-		$this->assertSniffError($report, 25, ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION);
-		$this->assertSniffError($report, 27, ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION);
+		$report = self::checkFile(__DIR__ . '/data/exceptionReferences71.php');
+		self::assertNoSniffError($report, 5);
+		self::assertNoSniffError($report, 7);
+		self::assertNoSniffError($report, 9);
+		self::assertNoSniffError($report, 15);
+		self::assertNoSniffError($report, 17);
+		self::assertNoSniffError($report, 19);
+		self::assertSniffError($report, 25, ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION);
+		self::assertSniffError($report, 27, ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION);
 	}
 
 	public function testFixableExceptionReference(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableExceptionReference.php', [], [ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION]);
-		$this->assertAllFixedInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/fixableExceptionReference.php', [], [ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION]);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableExceptionReferenceWithoutNamespace(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableExceptionReferenceWithoutNamespace.php', [], [ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION]);
-		$this->assertAllFixedInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/fixableExceptionReferenceWithoutNamespace.php', [], [ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION]);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableExceptionReference71(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableExceptionReference71.php', [], [ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION]);
-		$this->assertAllFixedInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/fixableExceptionReference71.php', [], [ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION]);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableExceptionReferenceWithoutNamespace71(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableExceptionReferenceWithoutNamespace71.php', [], [ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION]);
-		$this->assertAllFixedInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/fixableExceptionReferenceWithoutNamespace71.php', [], [ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION]);
+		self::assertAllFixedInFile($report);
 	}
 
 }

--- a/tests/Sniffs/Files/FilepathNamespaceExtractorTest.php
+++ b/tests/Sniffs/Files/FilepathNamespaceExtractorTest.php
@@ -114,7 +114,7 @@ class FilepathNamespaceExtractorTest extends \SlevomatCodingStandard\Sniffs\Test
 			$extensions
 		);
 		$path = str_replace('/', DIRECTORY_SEPARATOR, $path);
-		$this->assertSame($expectedNamespace, $extractor->getTypeNameFromProjectPath($path));
+		self::assertSame($expectedNamespace, $extractor->getTypeNameFromProjectPath($path));
 	}
 
 }

--- a/tests/Sniffs/Files/TypeNameMatchesFileNameSniffTest.php
+++ b/tests/Sniffs/Files/TypeNameMatchesFileNameSniffTest.php
@@ -7,31 +7,31 @@ class TypeNameMatchesFileNameSniffTest extends \SlevomatCodingStandard\Sniffs\Te
 
 	public function testError(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/rootNamespace/boo.php', [
+		$report = self::checkFile(__DIR__ . '/data/rootNamespace/boo.php', [
 			'rootNamespaces' => ['tests/Sniffs/Files/data/rootNamespace' => 'RootNamespace'],
 		]);
 
-		$this->assertSame(1, $report->getErrorCount());
-		$this->assertSniffError($report, 5, TypeNameMatchesFileNameSniff::CODE_NO_MATCH_BETWEEN_TYPE_NAME_AND_FILE_NAME);
+		self::assertSame(1, $report->getErrorCount());
+		self::assertSniffError($report, 5, TypeNameMatchesFileNameSniff::CODE_NO_MATCH_BETWEEN_TYPE_NAME_AND_FILE_NAME);
 
-		$report = $this->checkFile(__DIR__ . '/data/rootNamespace/coo/Foo.php', [
+		$report = self::checkFile(__DIR__ . '/data/rootNamespace/coo/Foo.php', [
 			'rootNamespaces' => ['tests/Sniffs/Files/data/rootNamespace' => 'RootNamespace'],
 		]);
 
-		$this->assertSame(1, $report->getErrorCount());
-		$this->assertSniffError($report, 5, TypeNameMatchesFileNameSniff::CODE_NO_MATCH_BETWEEN_TYPE_NAME_AND_FILE_NAME);
+		self::assertSame(1, $report->getErrorCount());
+		self::assertSniffError($report, 5, TypeNameMatchesFileNameSniff::CODE_NO_MATCH_BETWEEN_TYPE_NAME_AND_FILE_NAME);
 	}
 
 	public function testNoError(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/rootNamespace/Foo.php', [
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/rootNamespace/Foo.php', [
 			'rootNamespaces' => ['tests/Sniffs/Files/data/rootNamespace' => 'RootNamespace'],
 		]));
 	}
 
 	public function testSkippedDir(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/rootNamespace/skippedDir/Bar.php', [
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/rootNamespace/skippedDir/Bar.php', [
 			'rootNamespaces' => ['tests/Sniffs/Files/data/rootNamespace' => 'RootNamespace'],
 			'skipDirs' => ['skippedDir'],
 		]));
@@ -39,14 +39,14 @@ class TypeNameMatchesFileNameSniffTest extends \SlevomatCodingStandard\Sniffs\Te
 
 	public function testIgnoredNamespace(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/ignoredNamespace.php', [
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/ignoredNamespace.php', [
 			'ignoredNamespaces' => ['IgnoredNamespace'],
 		]));
 	}
 
 	public function testNoNamespace(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/noNamespace.php'));
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/noNamespace.php'));
 	}
 
 	public function testRootNamespacesNormalization(): void
@@ -64,11 +64,11 @@ class TypeNameMatchesFileNameSniffTest extends \SlevomatCodingStandard\Sniffs\Te
 			],
 		];
 
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/rootNamespace2/Foo.php', $sniffProperties1));
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/rootNamespace2/Xxx/Boo.php', $sniffProperties1));
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/rootNamespace2/Foo.php', $sniffProperties1));
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/rootNamespace2/Xxx/Boo.php', $sniffProperties1));
 
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/rootNamespace2/Foo.php', $sniffProperties2));
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/rootNamespace2/Xxx/Boo.php', $sniffProperties2));
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/rootNamespace2/Foo.php', $sniffProperties2));
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/rootNamespace2/Xxx/Boo.php', $sniffProperties2));
 	}
 
 }

--- a/tests/Sniffs/Namespaces/AlphabeticallySortedUsesSniffTest.php
+++ b/tests/Sniffs/Namespaces/AlphabeticallySortedUsesSniffTest.php
@@ -7,8 +7,8 @@ class AlphabeticallySortedUsesSniffTest extends \SlevomatCodingStandard\Sniffs\T
 
 	public function testIncorrectOrder(): void
 	{
-		$this->assertSniffError(
-			$this->checkFile(__DIR__ . '/data/incorrectOrder.php'),
+		self::assertSniffError(
+			self::checkFile(__DIR__ . '/data/incorrectOrder.php'),
 			5,
 			AlphabeticallySortedUsesSniff::CODE_INCORRECT_ORDER,
 			'Second\FooObject'
@@ -17,8 +17,8 @@ class AlphabeticallySortedUsesSniffTest extends \SlevomatCodingStandard\Sniffs\T
 
 	public function testIncorrectOrderIntertwinedWithClasses(): void
 	{
-		$this->assertSniffError(
-			$this->checkFile(__DIR__ . '/data/incorrectOrderIntertwinedWithClasses.php'),
+		self::assertSniffError(
+			self::checkFile(__DIR__ . '/data/incorrectOrderIntertwinedWithClasses.php'),
 			18,
 			AlphabeticallySortedUsesSniff::CODE_INCORRECT_ORDER,
 			'Delta'
@@ -27,22 +27,22 @@ class AlphabeticallySortedUsesSniffTest extends \SlevomatCodingStandard\Sniffs\T
 
 	public function testCorrectOrderIgnoresUsesAfterClassesTraitsAndInterfaces(): void
 	{
-		$this->assertNoSniffErrorInFile(
-			$this->checkFile(__DIR__ . '/data/correctOrder.php')
+		self::assertNoSniffErrorInFile(
+			self::checkFile(__DIR__ . '/data/correctOrder.php')
 		);
 	}
 
 	public function testCorrectOrderOfSimilarNamespaces(): void
 	{
-		$this->assertNoSniffErrorInFile(
-			$this->checkFile(__DIR__ . '/data/correctOrderSimilarNamespaces.php')
+		self::assertNoSniffErrorInFile(
+			self::checkFile(__DIR__ . '/data/correctOrderSimilarNamespaces.php')
 		);
 	}
 
 	public function testCorrectOrderOfSimilarNamespacesCaseSensitive(): void
 	{
-		$this->assertNoSniffErrorInFile(
-			$this->checkFile(__DIR__ . '/data/correctOrderSimilarNamespacesCaseSensitive.php', [
+		self::assertNoSniffErrorInFile(
+			self::checkFile(__DIR__ . '/data/correctOrderSimilarNamespacesCaseSensitive.php', [
 				'caseSensitive' => true,
 			])
 		);
@@ -50,8 +50,8 @@ class AlphabeticallySortedUsesSniffTest extends \SlevomatCodingStandard\Sniffs\T
 
 	public function testIncorrectOrderOfSimilarNamespaces(): void
 	{
-		$this->assertSniffError(
-			$this->checkFile(__DIR__ . '/data/incorrectOrderSimilarNamespaces.php'),
+		self::assertSniffError(
+			self::checkFile(__DIR__ . '/data/incorrectOrderSimilarNamespaces.php'),
 			6,
 			AlphabeticallySortedUsesSniff::CODE_INCORRECT_ORDER,
 			'Foo\Bar'
@@ -60,13 +60,13 @@ class AlphabeticallySortedUsesSniffTest extends \SlevomatCodingStandard\Sniffs\T
 
 	public function testPatrikOrder(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/alphabeticalPatrik.php'));
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/alphabeticalPatrik.php'));
 	}
 
 	public function testFixableUnusedUses(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableAlphabeticalSortedUses.php', [], [AlphabeticallySortedUsesSniff::CODE_INCORRECT_ORDER]);
-		$this->assertAllFixedInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/fixableAlphabeticalSortedUses.php', [], [AlphabeticallySortedUsesSniff::CODE_INCORRECT_ORDER]);
+		self::assertAllFixedInFile($report);
 	}
 
 }

--- a/tests/Sniffs/Namespaces/DisallowGroupUseSniffTest.php
+++ b/tests/Sniffs/Namespaces/DisallowGroupUseSniffTest.php
@@ -7,15 +7,15 @@ class DisallowGroupUseSniffTest extends \SlevomatCodingStandard\Sniffs\TestCase
 
 	public function testNoErrors(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/disallowGroupUseNoErrors.php'));
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/disallowGroupUseNoErrors.php'));
 	}
 
 	public function testErrors(): void
 	{
-		$codeSnifferFile = $this->checkFile(__DIR__ . '/data/disallowGroupUseErrors.php');
+		$codeSnifferFile = self::checkFile(__DIR__ . '/data/disallowGroupUseErrors.php');
 
-		$this->assertSniffError($codeSnifferFile, 5, DisallowGroupUseSniff::CODE_DISALLOWED_GROUP_USE);
-		$this->assertSniffError($codeSnifferFile, 9, DisallowGroupUseSniff::CODE_DISALLOWED_GROUP_USE);
+		self::assertSniffError($codeSnifferFile, 5, DisallowGroupUseSniff::CODE_DISALLOWED_GROUP_USE);
+		self::assertSniffError($codeSnifferFile, 9, DisallowGroupUseSniff::CODE_DISALLOWED_GROUP_USE);
 	}
 
 }

--- a/tests/Sniffs/Namespaces/FullyQualifiedClassNameAfterKeywordSniffExtendsTest.php
+++ b/tests/Sniffs/Namespaces/FullyQualifiedClassNameAfterKeywordSniffExtendsTest.php
@@ -5,14 +5,14 @@ namespace SlevomatCodingStandard\Sniffs\Namespaces;
 class FullyQualifiedClassNameAfterKeywordSniffExtendsTest extends \SlevomatCodingStandard\Sniffs\TestCase
 {
 
-	protected function getSniffClassName(): string
+	protected static function getSniffClassName(): string
 	{
 		return FullyQualifiedClassNameAfterKeywordSniff::class;
 	}
 
 	private function getFileReport(): \PHP_CodeSniffer\Files\File
 	{
-		return $this->checkFile(
+		return self::checkFile(
 			__DIR__ . '/data/fullyQualifiedExtends.php',
 			['keywordsToCheck' => ['T_EXTENDS']]
 		);
@@ -20,7 +20,7 @@ class FullyQualifiedClassNameAfterKeywordSniffExtendsTest extends \SlevomatCodin
 
 	public function testNonFullyQualifiedExtends(): void
 	{
-		$this->assertSniffError(
+		self::assertSniffError(
 			$this->getFileReport(),
 			8,
 			FullyQualifiedClassNameAfterKeywordSniff::getErrorCode('extends'),
@@ -30,7 +30,7 @@ class FullyQualifiedClassNameAfterKeywordSniffExtendsTest extends \SlevomatCodin
 
 	public function testFullyQualifiedExtends(): void
 	{
-		$this->assertNoSniffError($this->getFileReport(), 3);
+		self::assertNoSniffError($this->getFileReport(), 3);
 	}
 
 }

--- a/tests/Sniffs/Namespaces/FullyQualifiedClassNameAfterKeywordSniffImplementsTest.php
+++ b/tests/Sniffs/Namespaces/FullyQualifiedClassNameAfterKeywordSniffImplementsTest.php
@@ -5,14 +5,14 @@ namespace SlevomatCodingStandard\Sniffs\Namespaces;
 class FullyQualifiedClassNameAfterKeywordSniffImplementsTest extends \SlevomatCodingStandard\Sniffs\TestCase
 {
 
-	protected function getSniffClassName(): string
+	protected static function getSniffClassName(): string
 	{
 		return FullyQualifiedClassNameAfterKeywordSniff::class;
 	}
 
 	private function getFileReport(): \PHP_CodeSniffer\Files\File
 	{
-		return $this->checkFile(
+		return self::checkFile(
 			__DIR__ . '/data/fullyQualifiedImplements.php',
 			['keywordsToCheck' => ['T_IMPLEMENTS']]
 		);
@@ -20,7 +20,7 @@ class FullyQualifiedClassNameAfterKeywordSniffImplementsTest extends \SlevomatCo
 
 	public function testNonFullyQualifiedImplements(): void
 	{
-		$this->assertSniffError(
+		self::assertSniffError(
 			$this->getFileReport(),
 			8,
 			FullyQualifiedClassNameAfterKeywordSniff::getErrorCode('implements'),
@@ -30,17 +30,17 @@ class FullyQualifiedClassNameAfterKeywordSniffImplementsTest extends \SlevomatCo
 
 	public function testFullyQualifiedImplements(): void
 	{
-		$this->assertNoSniffError($this->getFileReport(), 3);
+		self::assertNoSniffError($this->getFileReport(), 3);
 	}
 
 	public function testMultipleFullyQualifiedImplements(): void
 	{
-		$this->assertNoSniffError($this->getFileReport(), 13);
+		self::assertNoSniffError($this->getFileReport(), 13);
 	}
 
 	public function testMultipleImplementsWithFirstWrong(): void
 	{
-		$this->assertSniffError(
+		self::assertSniffError(
 			$this->getFileReport(),
 			18,
 			FullyQualifiedClassNameAfterKeywordSniff::getErrorCode('implements'),
@@ -51,13 +51,13 @@ class FullyQualifiedClassNameAfterKeywordSniffImplementsTest extends \SlevomatCo
 	public function testMultipleImplementsWithSecondAndThirdWrong(): void
 	{
 		$report = $this->getFileReport();
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			23,
 			FullyQualifiedClassNameAfterKeywordSniff::getErrorCode('implements'),
 			'Amet in implements'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			23,
 			FullyQualifiedClassNameAfterKeywordSniff::getErrorCode('implements'),

--- a/tests/Sniffs/Namespaces/FullyQualifiedClassNameAfterKeywordSniffTest.php
+++ b/tests/Sniffs/Namespaces/FullyQualifiedClassNameAfterKeywordSniffTest.php
@@ -8,32 +8,32 @@ class FullyQualifiedClassNameAfterKeywordSniffTest extends \SlevomatCodingStanda
 	public function testThrowExceptionForUndefinedConstant(): void
 	{
 		try {
-			$this->checkFile(
+			self::checkFile(
 				__DIR__ . '/data/fullyQualifiedExtends.php',
 				['keywordsToCheck' => ['T_FOO']]
 			);
 			$this->fail();
 		} catch (\SlevomatCodingStandard\Sniffs\Namespaces\UndefinedKeywordTokenException $e) {
-			$this->assertContains('T_FOO', $e->getMessage());
-			$this->assertSame('T_FOO', $e->getKeyword());
+			self::assertContains('T_FOO', $e->getMessage());
+			self::assertSame('T_FOO', $e->getKeyword());
 		}
 	}
 
 	public function testCheckNothingWhenNoKeywordsAreConfigured(): void
 	{
-		$fileReport = $this->checkFile(__DIR__ . '/data/fullyQualifiedExtends.php');
-		$this->assertEmpty($fileReport->getErrors());
+		$fileReport = self::checkFile(__DIR__ . '/data/fullyQualifiedExtends.php');
+		self::assertEmpty($fileReport->getErrors());
 	}
 
 	public function testFixableFullyQualified(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableFullyQualifiedClassNameAfterKeyword.php', [
+		$report = self::checkFile(__DIR__ . '/data/fixableFullyQualifiedClassNameAfterKeyword.php', [
 			'keywordsToCheck' => [
 				'T_EXTENDS',
 				'T_IMPLEMENTS',
 			],
 		]);
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 }

--- a/tests/Sniffs/Namespaces/FullyQualifiedClassNameAfterKeywordSniffUseTest.php
+++ b/tests/Sniffs/Namespaces/FullyQualifiedClassNameAfterKeywordSniffUseTest.php
@@ -5,14 +5,14 @@ namespace SlevomatCodingStandard\Sniffs\Namespaces;
 class FullyQualifiedClassNameAfterKeywordSniffUseTest extends \SlevomatCodingStandard\Sniffs\TestCase
 {
 
-	protected function getSniffClassName(): string
+	protected static function getSniffClassName(): string
 	{
 		return FullyQualifiedClassNameAfterKeywordSniff::class;
 	}
 
 	private function getFileReport(): \PHP_CodeSniffer\Files\File
 	{
-		return $this->checkFile(
+		return self::checkFile(
 			__DIR__ . '/data/fullyQualifiedUse.php',
 			['keywordsToCheck' => ['T_USE']]
 		);
@@ -20,17 +20,17 @@ class FullyQualifiedClassNameAfterKeywordSniffUseTest extends \SlevomatCodingSta
 
 	public function testIgnoreUseInClosure(): void
 	{
-		$this->assertNoSniffError($this->getFileReport(), 34);
+		self::assertNoSniffError($this->getFileReport(), 34);
 	}
 
 	public function testIgnoreUseInNamespace(): void
 	{
-		$this->assertNoSniffError($this->getFileReport(), 5);
+		self::assertNoSniffError($this->getFileReport(), 5);
 	}
 
 	public function testIgnoreUseInNamespaceWithParenthesis(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(
+		self::assertNoSniffErrorInFile(self::checkFile(
 			__DIR__ . '/data/fullyQualifiedUseNamespaceWithParenthesis.php',
 			['keywordsToCheck' => ['T_USE']]
 		));
@@ -38,7 +38,7 @@ class FullyQualifiedClassNameAfterKeywordSniffUseTest extends \SlevomatCodingSta
 
 	public function testNonFullyQualifiedUse(): void
 	{
-		$this->assertSniffError(
+		self::assertSniffError(
 			$this->getFileReport(),
 			14,
 			FullyQualifiedClassNameAfterKeywordSniff::getErrorCode('use'),
@@ -48,17 +48,17 @@ class FullyQualifiedClassNameAfterKeywordSniffUseTest extends \SlevomatCodingSta
 
 	public function testFullyQualifiedUse(): void
 	{
-		$this->assertNoSniffError($this->getFileReport(), 9);
+		self::assertNoSniffError($this->getFileReport(), 9);
 	}
 
 	public function testMultipleFullyQualifiedUse(): void
 	{
-		$this->assertNoSniffError($this->getFileReport(), 19);
+		self::assertNoSniffError($this->getFileReport(), 19);
 	}
 
 	public function testMultipleUseWithFirstWrong(): void
 	{
-		$this->assertSniffError(
+		self::assertSniffError(
 			$this->getFileReport(),
 			24,
 			FullyQualifiedClassNameAfterKeywordSniff::getErrorCode('use'),
@@ -69,13 +69,13 @@ class FullyQualifiedClassNameAfterKeywordSniffUseTest extends \SlevomatCodingSta
 	public function testMultipleUseWithSecondAndThirdWrong(): void
 	{
 		$report = $this->getFileReport();
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			29,
 			FullyQualifiedClassNameAfterKeywordSniff::getErrorCode('use'),
 			'Amet in use'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			29,
 			FullyQualifiedClassNameAfterKeywordSniff::getErrorCode('use'),

--- a/tests/Sniffs/Namespaces/FullyQualifiedClassNameInAnnotationSniffTest.php
+++ b/tests/Sniffs/Namespaces/FullyQualifiedClassNameInAnnotationSniffTest.php
@@ -7,33 +7,33 @@ class FullyQualifiedClassNameInAnnotationSniffTest extends \SlevomatCodingStanda
 
 	public function testNoErrors(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/fullyQualifiedClassNameInAnnotationNoErrors.php'));
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/fullyQualifiedClassNameInAnnotationNoErrors.php'));
 	}
 
 	public function testErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fullyQualifiedClassNameInAnnotationErrors.php');
+		$report = self::checkFile(__DIR__ . '/data/fullyQualifiedClassNameInAnnotationErrors.php');
 
-		$this->assertSame(12, $report->getErrorCount());
+		self::assertSame(12, $report->getErrorCount());
 
-		$this->assertSniffError($report, 13, FullyQualifiedClassNameInAnnotationSniff::CODE_NON_FULLY_QUALIFIED_CLASS_NAME);
-		$this->assertSniffError($report, 17, FullyQualifiedClassNameInAnnotationSniff::CODE_NON_FULLY_QUALIFIED_CLASS_NAME);
-		$this->assertSniffError($report, 22, FullyQualifiedClassNameInAnnotationSniff::CODE_NON_FULLY_QUALIFIED_CLASS_NAME);
-		$this->assertSniffError($report, 26, FullyQualifiedClassNameInAnnotationSniff::CODE_NON_FULLY_QUALIFIED_CLASS_NAME);
-		$this->assertSniffError($report, 31, FullyQualifiedClassNameInAnnotationSniff::CODE_NON_FULLY_QUALIFIED_CLASS_NAME);
-		$this->assertSniffError($report, 32, FullyQualifiedClassNameInAnnotationSniff::CODE_NON_FULLY_QUALIFIED_CLASS_NAME);
-		$this->assertSniffError($report, 40, FullyQualifiedClassNameInAnnotationSniff::CODE_NON_FULLY_QUALIFIED_CLASS_NAME);
-		$this->assertSniffError($report, 41, FullyQualifiedClassNameInAnnotationSniff::CODE_NON_FULLY_QUALIFIED_CLASS_NAME);
-		$this->assertSniffError($report, 49, FullyQualifiedClassNameInAnnotationSniff::CODE_NON_FULLY_QUALIFIED_CLASS_NAME);
-		$this->assertSniffError($report, 57, FullyQualifiedClassNameInAnnotationSniff::CODE_NON_FULLY_QUALIFIED_CLASS_NAME, 'Class name \FooNamespace\FooClass in @return should be referenced via a fully qualified name');
-		$this->assertSniffError($report, 57, FullyQualifiedClassNameInAnnotationSniff::CODE_NON_FULLY_QUALIFIED_CLASS_NAME, 'Class name \Iterator in @return should be referenced via a fully qualified name');
-		$this->assertSniffError($report, 61, FullyQualifiedClassNameInAnnotationSniff::CODE_NON_FULLY_QUALIFIED_CLASS_NAME);
+		self::assertSniffError($report, 13, FullyQualifiedClassNameInAnnotationSniff::CODE_NON_FULLY_QUALIFIED_CLASS_NAME);
+		self::assertSniffError($report, 17, FullyQualifiedClassNameInAnnotationSniff::CODE_NON_FULLY_QUALIFIED_CLASS_NAME);
+		self::assertSniffError($report, 22, FullyQualifiedClassNameInAnnotationSniff::CODE_NON_FULLY_QUALIFIED_CLASS_NAME);
+		self::assertSniffError($report, 26, FullyQualifiedClassNameInAnnotationSniff::CODE_NON_FULLY_QUALIFIED_CLASS_NAME);
+		self::assertSniffError($report, 31, FullyQualifiedClassNameInAnnotationSniff::CODE_NON_FULLY_QUALIFIED_CLASS_NAME);
+		self::assertSniffError($report, 32, FullyQualifiedClassNameInAnnotationSniff::CODE_NON_FULLY_QUALIFIED_CLASS_NAME);
+		self::assertSniffError($report, 40, FullyQualifiedClassNameInAnnotationSniff::CODE_NON_FULLY_QUALIFIED_CLASS_NAME);
+		self::assertSniffError($report, 41, FullyQualifiedClassNameInAnnotationSniff::CODE_NON_FULLY_QUALIFIED_CLASS_NAME);
+		self::assertSniffError($report, 49, FullyQualifiedClassNameInAnnotationSniff::CODE_NON_FULLY_QUALIFIED_CLASS_NAME);
+		self::assertSniffError($report, 57, FullyQualifiedClassNameInAnnotationSniff::CODE_NON_FULLY_QUALIFIED_CLASS_NAME, 'Class name \FooNamespace\FooClass in @return should be referenced via a fully qualified name');
+		self::assertSniffError($report, 57, FullyQualifiedClassNameInAnnotationSniff::CODE_NON_FULLY_QUALIFIED_CLASS_NAME, 'Class name \Iterator in @return should be referenced via a fully qualified name');
+		self::assertSniffError($report, 61, FullyQualifiedClassNameInAnnotationSniff::CODE_NON_FULLY_QUALIFIED_CLASS_NAME);
 	}
 
 	public function testFixableFullyQualified(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableFullyQualifiedClassNameInAnnotation.php');
-		$this->assertAllFixedInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/fixableFullyQualifiedClassNameInAnnotation.php');
+		self::assertAllFixedInFile($report);
 	}
 
 }

--- a/tests/Sniffs/Namespaces/FullyQualifiedExceptionsSniffTest.php
+++ b/tests/Sniffs/Namespaces/FullyQualifiedExceptionsSniffTest.php
@@ -7,12 +7,12 @@ class FullyQualifiedExceptionsSniffTest extends \SlevomatCodingStandard\Sniffs\T
 
 	private function getFileReport(): \PHP_CodeSniffer\Files\File
 	{
-		return $this->checkFile(__DIR__ . '/data/fullyQualifiedExceptionNames.php');
+		return self::checkFile(__DIR__ . '/data/fullyQualifiedExceptionNames.php');
 	}
 
 	public function testNonFullyQualifiedExceptionInTypeHint(): void
 	{
-		$this->assertSniffError(
+		self::assertSniffError(
 			$this->getFileReport(),
 			3,
 			FullyQualifiedExceptionsSniff::CODE_NON_FULLY_QUALIFIED_EXCEPTION,
@@ -22,7 +22,7 @@ class FullyQualifiedExceptionsSniffTest extends \SlevomatCodingStandard\Sniffs\T
 
 	public function testNonFullyQualifiedExceptionInThrow(): void
 	{
-		$this->assertSniffError(
+		self::assertSniffError(
 			$this->getFileReport(),
 			6,
 			FullyQualifiedExceptionsSniff::CODE_NON_FULLY_QUALIFIED_EXCEPTION,
@@ -32,19 +32,19 @@ class FullyQualifiedExceptionsSniffTest extends \SlevomatCodingStandard\Sniffs\T
 
 	public function testNonFullyQualifiedExceptionInCatch(): void
 	{
-		$this->assertSniffError(
+		self::assertSniffError(
 			$this->getFileReport(),
 			7,
 			FullyQualifiedExceptionsSniff::CODE_NON_FULLY_QUALIFIED_EXCEPTION,
 			'BarException'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$this->getFileReport(),
 			9,
 			FullyQualifiedExceptionsSniff::CODE_NON_FULLY_QUALIFIED_EXCEPTION,
 			\Throwable::class
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$this->getFileReport(),
 			11,
 			FullyQualifiedExceptionsSniff::CODE_NON_FULLY_QUALIFIED_EXCEPTION,
@@ -54,64 +54,64 @@ class FullyQualifiedExceptionsSniffTest extends \SlevomatCodingStandard\Sniffs\T
 
 	public function testFullyQualifiedExceptionInTypeHint(): void
 	{
-		$this->assertNoSniffError($this->getFileReport(), 16);
+		self::assertNoSniffError($this->getFileReport(), 16);
 	}
 
 	public function testFullyQualifiedExceptionInThrow(): void
 	{
-		$this->assertNoSniffError($this->getFileReport(), 19);
+		self::assertNoSniffError($this->getFileReport(), 19);
 	}
 
 	public function testFullyQualifiedExceptionInCatch(): void
 	{
-		$this->assertNoSniffError($this->getFileReport(), 20);
-		$this->assertNoSniffError($this->getFileReport(), 22);
-		$this->assertNoSniffError($this->getFileReport(), 24);
-		$this->assertNoSniffError($this->getFileReport(), 26);
-		$this->assertNoSniffError($this->getFileReport(), 28);
+		self::assertNoSniffError($this->getFileReport(), 20);
+		self::assertNoSniffError($this->getFileReport(), 22);
+		self::assertNoSniffError($this->getFileReport(), 24);
+		self::assertNoSniffError($this->getFileReport(), 26);
+		self::assertNoSniffError($this->getFileReport(), 28);
 	}
 
 	public function testClassSuffixedErrorOrExceptionIsNotAnExceptionButReported(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/ignoredNames.php');
-		$this->assertSniffError($report, 3, FullyQualifiedExceptionsSniff::CODE_NON_FULLY_QUALIFIED_EXCEPTION);
-		$this->assertSniffError($report, 7, FullyQualifiedExceptionsSniff::CODE_NON_FULLY_QUALIFIED_EXCEPTION);
+		$report = self::checkFile(__DIR__ . '/data/ignoredNames.php');
+		self::assertSniffError($report, 3, FullyQualifiedExceptionsSniff::CODE_NON_FULLY_QUALIFIED_EXCEPTION);
+		self::assertSniffError($report, 7, FullyQualifiedExceptionsSniff::CODE_NON_FULLY_QUALIFIED_EXCEPTION);
 	}
 
 	public function testIgnoredNames(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/ignoredNames.php', [
+		$report = self::checkFile(__DIR__ . '/data/ignoredNames.php', [
 			'ignoredNames' => [
 				'LibXMLError',
 				'LibXMLException',
 			],
 		]);
-		$this->assertNoSniffErrorInFile($report);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testClassSuffixedErrorOrExceptionIsNotAnExceptionButReportedInNamespace(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/ignoredNamesInNamespace.php');
-		$this->assertNoSniffError($report, 5); // *Error names are reported only with a root namespace
-		$this->assertSniffError($report, 9, FullyQualifiedExceptionsSniff::CODE_NON_FULLY_QUALIFIED_EXCEPTION);
-		$this->assertNoSniffError($report, 13); // look like Exception but isn't - handled by ReferenceUsedNamesOnlySniff
-		$this->assertNoSniffError($report, 17); // dtto
+		$report = self::checkFile(__DIR__ . '/data/ignoredNamesInNamespace.php');
+		self::assertNoSniffError($report, 5); // *Error names are reported only with a root namespace
+		self::assertSniffError($report, 9, FullyQualifiedExceptionsSniff::CODE_NON_FULLY_QUALIFIED_EXCEPTION);
+		self::assertNoSniffError($report, 13); // look like Exception but isn't - handled by ReferenceUsedNamesOnlySniff
+		self::assertNoSniffError($report, 17); // dtto
 	}
 
 	public function testIgnoredNamesInNamespace(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/ignoredNamesInNamespace.php', [
+		$report = self::checkFile(__DIR__ . '/data/ignoredNamesInNamespace.php', [
 			'ignoredNames' => [
 				'IgnoredNames\\LibXMLException',
 			],
 		]);
-		$this->assertNoSniffErrorInFile($report);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testFixableFullyQualified(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableFullyQualifiedExceptions.php');
-		$this->assertAllFixedInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/fixableFullyQualifiedExceptions.php');
+		self::assertAllFixedInFile($report);
 	}
 
 }

--- a/tests/Sniffs/Namespaces/FullyQualifiedExceptionsSniffWithSpecialNamesTest.php
+++ b/tests/Sniffs/Namespaces/FullyQualifiedExceptionsSniffWithSpecialNamesTest.php
@@ -5,14 +5,14 @@ namespace SlevomatCodingStandard\Sniffs\Namespaces;
 class FullyQualifiedExceptionsSniffWithSpecialNamesTest extends \SlevomatCodingStandard\Sniffs\TestCase
 {
 
-	protected function getSniffClassName(): string
+	protected static function getSniffClassName(): string
 	{
 		return FullyQualifiedExceptionsSniff::class;
 	}
 
 	private function getFileReport(): \PHP_CodeSniffer\Files\File
 	{
-		return $this->checkFile(
+		return self::checkFile(
 			__DIR__ . '/data/fullyQualifiedSpecialExceptionNames.php',
 			['specialExceptionNames' => [
 				'Foo\SomeError',
@@ -23,7 +23,7 @@ class FullyQualifiedExceptionsSniffWithSpecialNamesTest extends \SlevomatCodingS
 
 	public function testThrowingUsedException(): void
 	{
-		$this->assertSniffError(
+		self::assertSniffError(
 			$this->getFileReport(),
 			12,
 			FullyQualifiedExceptionsSniff::CODE_NON_FULLY_QUALIFIED_EXCEPTION,
@@ -33,7 +33,7 @@ class FullyQualifiedExceptionsSniffWithSpecialNamesTest extends \SlevomatCodingS
 
 	public function testCatchingPartiallyUsedException(): void
 	{
-		$this->assertSniffError(
+		self::assertSniffError(
 			$this->getFileReport(),
 			13,
 			FullyQualifiedExceptionsSniff::CODE_NON_FULLY_QUALIFIED_EXCEPTION,
@@ -43,7 +43,7 @@ class FullyQualifiedExceptionsSniffWithSpecialNamesTest extends \SlevomatCodingS
 
 	public function testThrowingExceptionFromSameNamespace(): void
 	{
-		$this->assertSniffError(
+		self::assertSniffError(
 			$this->getFileReport(),
 			18,
 			FullyQualifiedExceptionsSniff::CODE_NON_FULLY_QUALIFIED_EXCEPTION,
@@ -53,13 +53,13 @@ class FullyQualifiedExceptionsSniffWithSpecialNamesTest extends \SlevomatCodingS
 
 	public function testCatchingFullyQualifiedException(): void
 	{
-		$this->assertNoSniffError($this->getFileReport(), 15);
+		self::assertNoSniffError($this->getFileReport(), 15);
 	}
 
 
 	public function testCatchingFullyQualifiedExceptionFromSameNamespace(): void
 	{
-		$this->assertNoSniffError($this->getFileReport(), 17);
+		self::assertNoSniffError($this->getFileReport(), 17);
 	}
 
 }

--- a/tests/Sniffs/Namespaces/FullyQualifiedGlobalConstantsSniffTest.php
+++ b/tests/Sniffs/Namespaces/FullyQualifiedGlobalConstantsSniffTest.php
@@ -7,33 +7,33 @@ class FullyQualifiedGlobalConstantsSniffTest extends \SlevomatCodingStandard\Sni
 
 	public function testNoErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fullyQualifiedGlobalConstantsNoErrors.php');
-		$this->assertNoSniffErrorInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/fullyQualifiedGlobalConstantsNoErrors.php');
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fullyQualifiedGlobalConstantsErrors.php');
+		$report = self::checkFile(__DIR__ . '/data/fullyQualifiedGlobalConstantsErrors.php');
 
-		$this->assertSame(2, $report->getErrorCount());
+		self::assertSame(2, $report->getErrorCount());
 
-		$this->assertSniffError($report, 17, FullyQualifiedGlobalConstantsSniff::CODE_NON_FULLY_QUALIFIED, 'Constant PHP_VERSION should be referenced via a fully qualified name.');
-		$this->assertSniffError($report, 31, FullyQualifiedGlobalConstantsSniff::CODE_NON_FULLY_QUALIFIED, 'Constant PHP_OS should be referenced via a fully qualified name.');
+		self::assertSniffError($report, 17, FullyQualifiedGlobalConstantsSniff::CODE_NON_FULLY_QUALIFIED, 'Constant PHP_VERSION should be referenced via a fully qualified name.');
+		self::assertSniffError($report, 31, FullyQualifiedGlobalConstantsSniff::CODE_NON_FULLY_QUALIFIED, 'Constant PHP_OS should be referenced via a fully qualified name.');
 
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testExcludeErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fullyQualifiedGlobalConstantsExcludeErrors.php', [
+		$report = self::checkFile(__DIR__ . '/data/fullyQualifiedGlobalConstantsExcludeErrors.php', [
 			'exclude' => ['PHP_VERSION'],
 		]);
 
-		$this->assertSame(1, $report->getErrorCount());
+		self::assertSame(1, $report->getErrorCount());
 
-		$this->assertSniffError($report, 28, FullyQualifiedGlobalConstantsSniff::CODE_NON_FULLY_QUALIFIED, 'Constant PHP_OS should be referenced via a fully qualified name.');
+		self::assertSniffError($report, 28, FullyQualifiedGlobalConstantsSniff::CODE_NON_FULLY_QUALIFIED, 'Constant PHP_OS should be referenced via a fully qualified name.');
 
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 }

--- a/tests/Sniffs/Namespaces/FullyQualifiedGlobalFunctionsSniffTest.php
+++ b/tests/Sniffs/Namespaces/FullyQualifiedGlobalFunctionsSniffTest.php
@@ -7,33 +7,33 @@ class FullyQualifiedGlobalFunctionsSniffTest extends \SlevomatCodingStandard\Sni
 
 	public function testNoErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fullyQualifiedGlobalFunctionsNoErrors.php');
-		$this->assertNoSniffErrorInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/fullyQualifiedGlobalFunctionsNoErrors.php');
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fullyQualifiedGlobalFunctionsErrors.php');
+		$report = self::checkFile(__DIR__ . '/data/fullyQualifiedGlobalFunctionsErrors.php');
 
-		$this->assertSame(2, $report->getErrorCount());
+		self::assertSame(2, $report->getErrorCount());
 
-		$this->assertSniffError($report, 17, FullyQualifiedGlobalFunctionsSniff::CODE_NON_FULLY_QUALIFIED, 'Function min() should be referenced via a fully qualified name.');
-		$this->assertSniffError($report, 31, FullyQualifiedGlobalFunctionsSniff::CODE_NON_FULLY_QUALIFIED, 'Function MaX() should be referenced via a fully qualified name.');
+		self::assertSniffError($report, 17, FullyQualifiedGlobalFunctionsSniff::CODE_NON_FULLY_QUALIFIED, 'Function min() should be referenced via a fully qualified name.');
+		self::assertSniffError($report, 31, FullyQualifiedGlobalFunctionsSniff::CODE_NON_FULLY_QUALIFIED, 'Function MaX() should be referenced via a fully qualified name.');
 
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testExcludeErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fullyQualifiedGlobalFunctionsExcludeErrors.php', [
+		$report = self::checkFile(__DIR__ . '/data/fullyQualifiedGlobalFunctionsExcludeErrors.php', [
 			'exclude' => ['min'],
 		]);
 
-		$this->assertSame(1, $report->getErrorCount());
+		self::assertSame(1, $report->getErrorCount());
 
-		$this->assertSniffError($report, 28, FullyQualifiedGlobalFunctionsSniff::CODE_NON_FULLY_QUALIFIED, 'Function max() should be referenced via a fully qualified name.');
+		self::assertSniffError($report, 28, FullyQualifiedGlobalFunctionsSniff::CODE_NON_FULLY_QUALIFIED, 'Function max() should be referenced via a fully qualified name.');
 
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 }

--- a/tests/Sniffs/Namespaces/MultipleUsesPerLineSniffTest.php
+++ b/tests/Sniffs/Namespaces/MultipleUsesPerLineSniffTest.php
@@ -7,12 +7,12 @@ class MultipleUsesPerLineSniffTest extends \SlevomatCodingStandard\Sniffs\TestCa
 
 	private function getFileReport(): \PHP_CodeSniffer\Files\File
 	{
-		return $this->checkFile(__DIR__ . '/data/multipleUsesPerLine.php');
+		return self::checkFile(__DIR__ . '/data/multipleUsesPerLine.php');
 	}
 
 	public function testMultipleUsesPerLine(): void
 	{
-		$this->assertSniffError(
+		self::assertSniffError(
 			$this->getFileReport(),
 			5,
 			MultipleUsesPerLineSniff::CODE_MULTIPLE_USES_PER_LINE
@@ -21,7 +21,7 @@ class MultipleUsesPerLineSniffTest extends \SlevomatCodingStandard\Sniffs\TestCa
 
 	public function testIgnoreCommasInClosureUse(): void
 	{
-		$this->assertNoSniffError($this->getFileReport(), 7);
+		self::assertNoSniffError($this->getFileReport(), 7);
 	}
 
 }

--- a/tests/Sniffs/Namespaces/ReferenceUsedNamesOnlySniffTest.php
+++ b/tests/Sniffs/Namespaces/ReferenceUsedNamesOnlySniffTest.php
@@ -26,10 +26,10 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 	 */
 	public function testDoNotReportNamespaceName(array $ignoredNames): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/shouldBeInUseStatement.php', [
+		$report = self::checkFile(__DIR__ . '/data/shouldBeInUseStatement.php', [
 			'ignoredNames' => $ignoredNames,
 		]);
-		$this->assertNoSniffError($report, 3);
+		self::assertNoSniffError($report, 3);
 	}
 
 	/**
@@ -38,10 +38,10 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 	 */
 	public function testCreatingNewObjectViaNonFullyQualifiedName(array $ignoredNames): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/shouldBeInUseStatement.php', [
+		$report = self::checkFile(__DIR__ . '/data/shouldBeInUseStatement.php', [
 			'ignoredNames' => $ignoredNames,
 		]);
-		$this->assertNoSniffError($report, 10);
+		self::assertNoSniffError($report, 10);
 	}
 
 	/**
@@ -50,10 +50,10 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 	 */
 	public function testCreatingNewObjectViaFullyQualifiedName(array $ignoredNames): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/shouldBeInUseStatement.php', [
+		$report = self::checkFile(__DIR__ . '/data/shouldBeInUseStatement.php', [
 			'ignoredNames' => $ignoredNames,
 		]);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			12,
 			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME,
@@ -67,10 +67,10 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 	 */
 	public function testReferencingClassConstantViaFullyQualifiedName(array $ignoredNames): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/shouldBeInUseStatement.php', [
+		$report = self::checkFile(__DIR__ . '/data/shouldBeInUseStatement.php', [
 			'ignoredNames' => $ignoredNames,
 		]);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			11,
 			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME,
@@ -80,8 +80,8 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 
 	public function testReferencingConstantViaFullyQualifiedName(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/shouldBeInUseStatement.php');
-		$this->assertSniffError(
+		$report = self::checkFile(__DIR__ . '/data/shouldBeInUseStatement.php');
+		self::assertSniffError(
 			$report,
 			16,
 			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME,
@@ -91,8 +91,8 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 
 	public function testReferencingFunctionViaFullyQualifiedName(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/shouldBeInUseStatement.php');
-		$this->assertSniffError(
+		$report = self::checkFile(__DIR__ . '/data/shouldBeInUseStatement.php');
+		self::assertSniffError(
 			$report,
 			17,
 			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME,
@@ -102,10 +102,10 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 
 	public function testReferencingGlobalFunctionViaFallback(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/shouldBeInUseStatement.php', [
+		$report = self::checkFile(__DIR__ . '/data/shouldBeInUseStatement.php', [
 			'allowFallbackGlobalFunctions' => false,
 		]);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			18,
 			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FALLBACK_GLOBAL_NAME,
@@ -115,10 +115,10 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 
 	public function testReferencingGlobalConstantViaFallback(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/shouldBeInUseStatement.php', [
+		$report = self::checkFile(__DIR__ . '/data/shouldBeInUseStatement.php', [
 			'allowFallbackGlobalConstants' => false,
 		]);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			19,
 			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FALLBACK_GLOBAL_NAME,
@@ -132,7 +132,7 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 	 */
 	public function testCreatingObjectFromSpecialExceptionName(array $ignoredNames): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/shouldBeInUseStatement.php',
 			[
 				'allowFullyQualifiedExceptions' => true,
@@ -142,7 +142,7 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 				'ignoredNames' => $ignoredNames,
 			]
 		);
-		$this->assertNoSniffError($report, 12);
+		self::assertNoSniffError($report, 12);
 	}
 
 	/**
@@ -151,25 +151,25 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 	 */
 	public function testReportFullyQualifiedInFileWithNamespace(array $ignoredNames): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/shouldBeInUseStatement.php',
 			[
 				'ignoredNames' => $ignoredNames,
 			]
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			13,
 			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME,
 			'\Some\CommonException'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			14,
 			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME,
 			'\Exception'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			15,
 			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME,
@@ -183,19 +183,19 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 	 */
 	public function testDoNotAllowFullyQualifiedExtends(array $ignoredNames): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/fullyQualifiedExtends.php',
 			[
 				'ignoredNames' => $ignoredNames,
 			]
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			3,
 			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME,
 			'\Lorem\Dolor'
 		);
-		$this->assertNoSniffError($report, 8);
+		self::assertNoSniffError($report, 8);
 	}
 
 	/**
@@ -204,25 +204,25 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 	 */
 	public function testDoNotAllowFullyQualifiedImplements(array $ignoredNames): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/fullyQualifiedImplements.php',
 			[
 				'ignoredNames' => $ignoredNames,
 			]
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			3,
 			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME_WITHOUT_NAMESPACE,
 			'\SomeClass'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			3,
 			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME,
 			'\Some\OtherClass'
 		);
-		$this->assertNoSniffError($report, 8);
+		self::assertNoSniffError($report, 8);
 	}
 
 	/**
@@ -231,15 +231,15 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 	 */
 	public function testAllowFullyQualifiedExceptions(array $ignoredNames): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/fullyQualifiedExceptionNames.php',
 			[
 				'allowFullyQualifiedExceptions' => true,
 				'ignoredNames' => $ignoredNames,
 			]
 		);
-		$this->assertSame(1, $report->getErrorCount());
-		$this->assertSniffError(
+		self::assertSame(1, $report->getErrorCount());
+		self::assertSniffError(
 			$report,
 			28,
 			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME,
@@ -253,20 +253,20 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 	 */
 	public function testDoNotAllowFullyQualifiedExceptionsInTypeHint(array $ignoredNames): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/fullyQualifiedExceptionNames.php',
 			[
 				'allowFullyQualifiedExceptions' => false,
 				'ignoredNames' => $ignoredNames,
 			]
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			16,
 			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME,
 			'\Some\Exception'
 		);
-		$this->assertNoSniffError($report, 3);
+		self::assertNoSniffError($report, 3);
 	}
 
 	/**
@@ -275,20 +275,20 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 	 */
 	public function testDoNotAllowFullyQualifiedExceptionsInThrow(array $ignoredNames): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/fullyQualifiedExceptionNames.php',
 			[
 				'allowFullyQualifiedExceptions' => false,
 				'ignoredNames' => $ignoredNames,
 			]
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			19,
 			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME,
 			'\Some\Other\Exception'
 		);
-		$this->assertNoSniffError($report, 6);
+		self::assertNoSniffError($report, 6);
 	}
 
 	/**
@@ -297,46 +297,46 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 	 */
 	public function testDoNotAllowFullyQualifiedExceptionsInCatch(array $ignoredNames): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/fullyQualifiedExceptionNames.php',
 			[
 				'allowFullyQualifiedExceptions' => false,
 				'ignoredNames' => $ignoredNames,
 			]
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			20,
 			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME,
 			'\Some\Other\DifferentException'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			22,
 			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME_WITHOUT_NAMESPACE,
 			'\Throwable'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			24,
 			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME_WITHOUT_NAMESPACE,
 			'\Exception'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			26,
 			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME_WITHOUT_NAMESPACE,
 			'\TypeError'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			28,
 			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME,
 			'\Foo\BarError'
 		);
-		$this->assertNoSniffError($report, 7);
-		$this->assertNoSniffError($report, 9);
-		$this->assertNoSniffError($report, 11);
+		self::assertNoSniffError($report, 7);
+		self::assertNoSniffError($report, 9);
+		self::assertNoSniffError($report, 11);
 	}
 
 	/**
@@ -345,20 +345,20 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 	 */
 	public function testDoNotAllowPartialUses(array $ignoredNames): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/partialUses.php',
 			[
 				'allowPartialUses' => false,
 				'ignoredNames' => $ignoredNames,
 			]
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			7,
 			ReferenceUsedNamesOnlySniff::CODE_PARTIAL_USE,
 			'SomeFramework\ObjectPrototype'
 		);
-		$this->assertNoSniffError($report, 6);
+		self::assertNoSniffError($report, 6);
 	}
 
 	/**
@@ -367,15 +367,15 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 	 */
 	public function testAllowPartialUses(array $ignoredNames): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/partialUses.php',
 			[
 				'allowPartialUses' => true,
 				'ignoredNames' => $ignoredNames,
 			]
 		);
-		$this->assertNoSniffError($report, 6);
-		$this->assertNoSniffError($report, 7);
+		self::assertNoSniffError($report, 6);
+		self::assertNoSniffError($report, 7);
 	}
 
 	/**
@@ -384,7 +384,7 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 	 */
 	public function testUseOnlyWhitelistedNamespaces(array $ignoredNames): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/whitelistedNamespaces.php',
 			[
 				'namespacesRequiredToUse' => [
@@ -394,14 +394,14 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 			]
 		);
 
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			3,
 			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME,
 			'\Foo\Bar'
 		);
-		$this->assertNoSniffError($report, 4);
-		$this->assertNoSniffError($report, 5);
+		self::assertNoSniffError($report, 4);
+		self::assertNoSniffError($report, 5);
 	}
 
 	/**
@@ -410,14 +410,14 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 	 */
 	public function testAllowFullyQualifiedImplementsWithMultipleInterfaces(array $ignoredNames): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/multipleFullyQualifiedImplements.php',
 			[
 				'fullyQualifiedKeywords' => ['T_IMPLEMENTS'],
 				'ignoredNames' => $ignoredNames,
 			]
 		);
-		$this->assertNoSniffErrorInFile($report);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	/**
@@ -426,25 +426,25 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 	 */
 	public function testDisallowFullyQualifiedImplementsWithMultipleInterfaces(array $ignoredNames): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/multipleFullyQualifiedImplements.php',
 			[
 				'ignoredNames' => $ignoredNames,
 			]
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			3,
 			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME_WITHOUT_NAMESPACE,
 			'\Bar'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			3,
 			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME_WITHOUT_NAMESPACE,
 			'\Baz'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			3,
 			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME,
@@ -458,20 +458,20 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 	 */
 	public function testDoNotUseTypeInRootNamespaceInFileWithoutNamespace(array $ignoredNames): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/referencingFullyQualifiedNameInFileWithoutNamespace.php',
 			[
 				'ignoredNames' => $ignoredNames,
 			]
 		);
 
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			3,
 			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME_WITHOUT_NAMESPACE,
 			'\Foo'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			4,
 			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME,
@@ -506,26 +506,26 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 	 */
 	public function testIgnoredNames(bool $allowFullyQualifiedExceptions, array $ignoredNames): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/ignoredNames.php',
 			[
 				'allowFullyQualifiedExceptions' => $allowFullyQualifiedExceptions,
 				'ignoredNames' => $ignoredNames,
 			]
 		);
-		$this->assertNoSniffError($report, 3);
-		$this->assertNoSniffError($report, 7);
-		$this->assertSniffError($report, 11, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME_WITHOUT_NAMESPACE);
-		$this->assertSniffError($report, 15, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME_WITHOUT_NAMESPACE);
+		self::assertNoSniffError($report, 3);
+		self::assertNoSniffError($report, 7);
+		self::assertSniffError($report, 11, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME_WITHOUT_NAMESPACE);
+		self::assertSniffError($report, 15, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME_WITHOUT_NAMESPACE);
 	}
 
 	public function testIgnoredNamesWithAllowFullyQualifiedExceptions(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/ignoredNames.php',
 			['allowFullyQualifiedExceptions' => true]
 		);
-		$this->assertNoSniffErrorInFile($report);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	/**
@@ -555,26 +555,26 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 	 */
 	public function testIgnoredNamesInNamespace(bool $allowFullyQualifiedExceptions, array $ignoredNames): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/ignoredNamesInNamespace.php',
 			[
 				'allowFullyQualifiedExceptions' => $allowFullyQualifiedExceptions,
 				'ignoredNames' => $ignoredNames,
 			]
 		);
-		$this->assertNoSniffError($report, 5);
-		$this->assertNoSniffError($report, 9);
-		$this->assertSniffError($report, 13, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
-		$this->assertSniffError($report, 17, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
+		self::assertNoSniffError($report, 5);
+		self::assertNoSniffError($report, 9);
+		self::assertSniffError($report, 13, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
+		self::assertSniffError($report, 17, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
 	}
 
 	public function testIgnoredNamesWithAllowFullyQualifiedExceptionsInNamespace(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/ignoredNamesInNamespace.php',
 			['allowFullyQualifiedExceptions' => true]
 		);
-		$this->assertNoSniffErrorInFile($report);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testThrowExceptionForUndefinedKeyword(): void
@@ -582,7 +582,7 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 		$this->expectException(\SlevomatCodingStandard\Sniffs\Namespaces\UndefinedKeywordTokenException::class);
 		$this->expectExceptionMessage('Value for keyword token not found, constant "T_FOO" is not defined');
 
-		$this->checkFile(
+		self::checkFile(
 			__DIR__ . '/data/unknownKeyword.php',
 			['fullyQualifiedKeywords' => ['T_FOO']]
 		);
@@ -590,7 +590,7 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 
 	public function testAllowingFullyQualifiedGlobalClasses(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/fullyQualifiedGlobalClassesInNamespace.php',
 			[
 				'allowFullyQualifiedGlobalClasses' => true,
@@ -598,12 +598,12 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 				'allowFullyQualifiedGlobalConstants' => false,
 			]
 		);
-		$this->assertNoSniffErrorInFile($report);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testAllowingFullyQualifiedGlobalFunctions(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/fullyQualifiedGlobalFunctionsInNamespace.php',
 			[
 				'allowFullyQualifiedGlobalClasses' => false,
@@ -611,12 +611,12 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 				'allowFullyQualifiedGlobalConstants' => false,
 			]
 		);
-		$this->assertNoSniffErrorInFile($report);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testAllowingFullyQualifiedGlobalConstants(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/fullyQualifiedGlobalConstantsInNamespace.php',
 			[
 				'allowFullyQualifiedGlobalClasses' => false,
@@ -624,160 +624,160 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 				'allowFullyQualifiedGlobalConstants' => true,
 			]
 		);
-		$this->assertNoSniffErrorInFile($report);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testFixableReferenceViaFullyQualifiedOrGlobalFallbackName(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableReferenceViaFullyQualifiedName.php', [
+		$report = self::checkFile(__DIR__ . '/data/fixableReferenceViaFullyQualifiedName.php', [
 			'fullyQualifiedKeywords' => ['T_EXTENDS'],
 			'allowFullyQualifiedExceptions' => true,
 			'allowFallbackGlobalFunctions' => false,
 			'allowFallbackGlobalConstants' => false,
 		], [ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FALLBACK_GLOBAL_NAME]);
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testNotFixableReferenceViaFullyQualifiedName(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/notFixableReferenceViaFullyQualifiedName.php', [], [ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME]);
-		$this->assertAllFixedInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/notFixableReferenceViaFullyQualifiedName.php', [], [ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME]);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testPartlyFixableReferenceViaFullyQualifiedName(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/partlyFixableReferenceViaFullyQualifiedName.php', [], [ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME]);
-		$this->assertAllFixedInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/partlyFixableReferenceViaFullyQualifiedName.php', [], [ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME]);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableReferenceViaFullyQualifiedNameNoUseStatements(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableReferenceViaFullyQualifiedNameNoUseStatements.php', [
+		$report = self::checkFile(__DIR__ . '/data/fixableReferenceViaFullyQualifiedNameNoUseStatements.php', [
 			'fullyQualifiedKeywords' => ['T_EXTENDS', 'T_IMPLEMENTS'],
 		], [ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME]);
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableReferenceViaFullyQualifiedNameWithoutNamespace(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableReferenceViaFullyQualifiedNameWithoutNamespace.php', [
+		$report = self::checkFile(__DIR__ . '/data/fixableReferenceViaFullyQualifiedNameWithoutNamespace.php', [
 			'fullyQualifiedKeywords' => ['T_IMPLEMENTS'],
 			'allowFullyQualifiedExceptions' => false,
 			'specialExceptionNames' => [
 				'BarErrorX',
 			],
 		], [ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME_WITHOUT_NAMESPACE]);
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testCollidingClassNameDifferentNamespacesAllowed(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/collidingClassNameDifferentNamespaces.php',
 			['allowFullyQualifiedNameForCollidingClasses' => true]
 		);
-		$this->assertNoSniffErrorInFile($report);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testCollidingClassNameDifferentNamespacesDisallowed(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/collidingClassNameDifferentNamespaces.php',
 			['allowFullyQualifiedNameForCollidingClasses' => false]
 		);
 
-		$this->assertSame(2, $report->getErrorCount());
+		self::assertSame(2, $report->getErrorCount());
 
-		$this->assertSniffError($report, 14, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
-		$this->assertSniffError($report, 16, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
+		self::assertSniffError($report, 14, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
+		self::assertSniffError($report, 16, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
 	}
 
 	public function testCollidingClassNameDifferentNamespacesMoreClassesAllowed(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/collidingClassNameDifferentNamespacesMoreClasses.php',
 			['allowFullyQualifiedNameForCollidingClasses' => true]
 		);
-		$this->assertNoSniffErrorInFile($report);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testCollidingClassNameDifferentNamespacesMoreClassesDisallowed(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/collidingClassNameDifferentNamespacesMoreClasses.php',
 			['allowFullyQualifiedNameForCollidingClasses' => false]
 		);
 
-		$this->assertSame(4, $report->getErrorCount());
+		self::assertSame(4, $report->getErrorCount());
 
-		$this->assertSniffError($report, 7, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
-		$this->assertSniffError($report, 9, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
-		$this->assertSniffError($report, 12, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
-		$this->assertSniffError($report, 14, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
+		self::assertSniffError($report, 7, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
+		self::assertSniffError($report, 9, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
+		self::assertSniffError($report, 12, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
+		self::assertSniffError($report, 14, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
 	}
 
 	public function testCollidingClassNameExtendsAllowed(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/collidingClassNameExtends.php',
 			['allowFullyQualifiedNameForCollidingClasses' => true]
 		);
-		$this->assertNoSniffErrorInFile($report);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testCollidingClassNameExtendsDisabled(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/collidingClassNameExtends.php',
 			['allowFullyQualifiedNameForCollidingClasses' => false]
 		);
-		$this->assertSame(1, $report->getErrorCount());
-		$this->assertSniffError($report, 5, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
+		self::assertSame(1, $report->getErrorCount());
+		self::assertSniffError($report, 5, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
 	}
 
 	public function testCollidingFullyQualifiedFunctionNameAllowed(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/collidingFullyQualifiedFunctionNames.php',
 			['allowFullyQualifiedNameForCollidingFunctions' => true]
 		);
-		$this->assertNoSniffErrorInFile($report);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testCollidingFullyQualifiedFunctionNameDisallowed(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/collidingFullyQualifiedFunctionNames.php',
 			['allowFullyQualifiedNameForCollidingFunctions' => false]
 		);
 
-		$this->assertSame(1, $report->getErrorCount());
-		$this->assertSniffError($report, 15, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
+		self::assertSame(1, $report->getErrorCount());
+		self::assertSniffError($report, 15, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
 	}
 
 	public function testCollidingFullyQualifiedConstantNameAllowed(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/collidingFullyQualifiedConstantNames.php',
 			['allowFullyQualifiedNameForCollidingConstants' => true]
 		);
-		$this->assertNoSniffErrorInFile($report);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testCollidingFullyQualifiedConstantNameDisallowed(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/collidingFullyQualifiedConstantNames.php',
 			['allowFullyQualifiedNameForCollidingConstants' => false]
 		);
 
-		$this->assertSame(1, $report->getErrorCount());
-		$this->assertSniffError($report, 12, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
+		self::assertSame(1, $report->getErrorCount());
+		self::assertSniffError($report, 12, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
 	}
 
 	public function testReferencingGlobalFunctionViaFallbackErrorsWithMoreComplexSettings(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/referencingGlobalFunctionViaFallbackErrorsWithMoreComplexSettings.php',
 			[
 				'allowFallbackGlobalFunctions' => false,
@@ -786,13 +786,13 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 			]
 		);
 
-		$this->assertSame(1, $report->getErrorCount());
-		$this->assertSniffError($report, 17, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FALLBACK_GLOBAL_NAME);
+		self::assertSame(1, $report->getErrorCount());
+		self::assertSniffError($report, 17, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FALLBACK_GLOBAL_NAME);
 	}
 
 	public function testReferencingGlobalFunctionViaFullyQualifiedWithMoreComplexSettings(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/referencingGlobalFunctionViaFullyQualifiedWithMoreComplexSettings.php',
 			[
 				'allowFallbackGlobalFunctions' => false,
@@ -801,8 +801,8 @@ class ReferenceUsedNamesOnlySniffTest extends \SlevomatCodingStandard\Sniffs\Tes
 			]
 		);
 
-		$this->assertSame(1, $report->getErrorCount());
-		$this->assertSniffError($report, 13, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
+		self::assertSame(1, $report->getErrorCount());
+		self::assertSniffError($report, 13, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
 	}
 
 }

--- a/tests/Sniffs/Namespaces/UnusedUsesSniffTest.php
+++ b/tests/Sniffs/Namespaces/UnusedUsesSniffTest.php
@@ -7,24 +7,24 @@ class UnusedUsesSniffTest extends \SlevomatCodingStandard\Sniffs\TestCase
 
 	private function getFileReport(): \PHP_CodeSniffer\Files\File
 	{
-		return $this->checkFile(__DIR__ . '/data/unusedUses.php');
+		return self::checkFile(__DIR__ . '/data/unusedUses.php');
 	}
 
 	public function testUnusedUse(): void
 	{
-		$this->assertSniffError(
+		self::assertSniffError(
 			$this->getFileReport(),
 			5,
 			UnusedUsesSniff::CODE_UNUSED_USE,
 			'First\ObjectPrototype'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$this->getFileReport(),
 			12,
 			UnusedUsesSniff::CODE_UNUSED_USE,
 			'FooBar\UnusedFunction'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$this->getFileReport(),
 			14,
 			UnusedUsesSniff::CODE_UNUSED_USE,
@@ -34,13 +34,13 @@ class UnusedUsesSniffTest extends \SlevomatCodingStandard\Sniffs\TestCase
 
 	public function testUnusedUseNoNamespaceNoErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/unusedUsesNoNamespaceNoErrors.php');
-		$this->assertNoSniffErrorInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/unusedUsesNoNamespaceNoErrors.php');
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testUnusedUseWithAsPart(): void
 	{
-		$this->assertSniffError(
+		self::assertSniffError(
 			$this->getFileReport(),
 			8,
 			UnusedUsesSniff::CODE_UNUSED_USE,
@@ -50,91 +50,91 @@ class UnusedUsesSniffTest extends \SlevomatCodingStandard\Sniffs\TestCase
 
 	public function testUsedPartialNamespaceUse(): void
 	{
-		$this->assertNoSniffError($this->getFileReport(), 6);
+		self::assertNoSniffError($this->getFileReport(), 6);
 	}
 
 	public function testUsedPartialSubnamespaceUse(): void
 	{
-		$this->assertNoSniffError($this->getFileReport(), 7);
+		self::assertNoSniffError($this->getFileReport(), 7);
 	}
 
 	public function testUsedUseWithAsPart(): void
 	{
-		$this->assertNoSniffError($this->getFileReport(), 9);
+		self::assertNoSniffError($this->getFileReport(), 9);
 	}
 
 	public function testUsedUseInTypeHint(): void
 	{
-		$this->assertNoSniffError($this->getFileReport(), 10);
+		self::assertNoSniffError($this->getFileReport(), 10);
 	}
 
 	public function testUsedUseWithStaticMethodCall(): void
 	{
-		$this->assertNoSniffError($this->getFileReport(), 11);
+		self::assertNoSniffError($this->getFileReport(), 11);
 	}
 
 	public function testUsedFunction(): void
 	{
-		$this->assertNoSniffError($this->getFileReport(), 13);
+		self::assertNoSniffError($this->getFileReport(), 13);
 	}
 
 	public function testUsedConstant(): void
 	{
-		$this->assertNoSniffError($this->getFileReport(), 15);
+		self::assertNoSniffError($this->getFileReport(), 15);
 	}
 
 	public function testUsedClassesInImplements(): void
 	{
-		$this->assertNoSniffError($this->getFileReport(), 17);
-		$this->assertNoSniffError($this->getFileReport(), 18);
+		self::assertNoSniffError($this->getFileReport(), 17);
+		self::assertNoSniffError($this->getFileReport(), 18);
 	}
 
 	public function testReturnTypeHint(): void
 	{
-		$this->assertNoSniffError($this->getFileReport(), 19);
+		self::assertNoSniffError($this->getFileReport(), 19);
 	}
 
 	public function testPartialUses(): void
 	{
-		$this->assertNoSniffError($this->getFileReport(), 20);
-		$this->assertNoSniffError($this->getFileReport(), 21);
-		$this->assertNoSniffError($this->getFileReport(), 22);
-		$this->assertNoSniffError($this->getFileReport(), 23);
+		self::assertNoSniffError($this->getFileReport(), 20);
+		self::assertNoSniffError($this->getFileReport(), 21);
+		self::assertNoSniffError($this->getFileReport(), 22);
+		self::assertNoSniffError($this->getFileReport(), 23);
 	}
 
 	public function testUsedUseInAnnotationWithDisabledSearchAnnotations(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/unusedUsesInAnnotation.php', [
+		$report = self::checkFile(__DIR__ . '/data/unusedUsesInAnnotation.php', [
 			'searchAnnotations' => false,
 		]);
 
-		$this->assertSame(6, $report->getErrorCount());
+		self::assertSame(6, $report->getErrorCount());
 
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			5,
 			UnusedUsesSniff::CODE_UNUSED_USE,
 			'Type Assert is not used in this file.'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			6,
 			UnusedUsesSniff::CODE_UNUSED_USE,
 			'Type Doctrine\ORM\Mapping (as ORM) is not used in this file.'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			8,
 			UnusedUsesSniff::CODE_UNUSED_USE,
 			'Type X is not used in this file.'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			9,
 			UnusedUsesSniff::CODE_UNUSED_USE,
 			'Type XX is not used in this file.'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			10,
 			UnusedUsesSniff::CODE_UNUSED_USE,
@@ -144,13 +144,13 @@ class UnusedUsesSniffTest extends \SlevomatCodingStandard\Sniffs\TestCase
 
 	public function testUsedUseInAnnotationWithEnabledSearchAnnotations(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/unusedUsesInAnnotation.php', [
+		$report = self::checkFile(__DIR__ . '/data/unusedUsesInAnnotation.php', [
 			'searchAnnotations' => true,
 		]);
 
-		$this->assertSame(1, $report->getErrorCount());
+		self::assertSame(1, $report->getErrorCount());
 
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			9,
 			UnusedUsesSniff::CODE_UNUSED_USE,
@@ -160,14 +160,14 @@ class UnusedUsesSniffTest extends \SlevomatCodingStandard\Sniffs\TestCase
 
 	public function testFindCaseInsensitiveUse(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/caseInsensitiveUse.php');
-		$this->assertNoSniffError($report, 3);
+		$report = self::checkFile(__DIR__ . '/data/caseInsensitiveUse.php');
+		self::assertNoSniffError($report, 3);
 	}
 
 	public function testReportCaseInsensitiveUse(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/caseInsensitiveUse.php');
-		$this->assertSniffError(
+		$report = self::checkFile(__DIR__ . '/data/caseInsensitiveUse.php');
+		self::assertSniffError(
 			$report,
 			5,
 			UnusedUsesSniff::CODE_MISMATCHING_CASE,
@@ -177,34 +177,34 @@ class UnusedUsesSniffTest extends \SlevomatCodingStandard\Sniffs\TestCase
 
 	public function testUsedTrait(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/usedTrait.php');
-		$this->assertNoSniffError($report, 5);
+		$report = self::checkFile(__DIR__ . '/data/usedTrait.php');
+		self::assertNoSniffError($report, 5);
 	}
 
 	public function testTypeWithUnderscoresInAnnotation(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/unusedUsesAnnotationUnderscores.php', [
+		$report = self::checkFile(__DIR__ . '/data/unusedUsesAnnotationUnderscores.php', [
 			'searchAnnotations' => true,
 		]);
-		$this->assertNoSniffError($report, 5);
+		self::assertNoSniffError($report, 5);
 	}
 
 	public function testMatchingCaseOfUseAndClassConstant(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/matchingCaseOfUseAndClassConstant.php');
-		$this->assertNoSniffErrorInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/matchingCaseOfUseAndClassConstant.php');
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testMatchingCaseOfUseAndPhpFunction(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/matchingCaseOfUseAndPhpFunction.php');
-		$this->assertNoSniffErrorInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/matchingCaseOfUseAndPhpFunction.php');
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testFixableUnusedUses(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableUnusedUses.php', [], [UnusedUsesSniff::CODE_UNUSED_USE]);
-		$this->assertAllFixedInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/fixableUnusedUses.php', [], [UnusedUsesSniff::CODE_UNUSED_USE]);
+		self::assertAllFixedInFile($report);
 	}
 
 }

--- a/tests/Sniffs/Namespaces/UseDoesNotStartWithBackslashSniffTest.php
+++ b/tests/Sniffs/Namespaces/UseDoesNotStartWithBackslashSniffTest.php
@@ -7,25 +7,25 @@ class UseDoesNotStartWithBackslashSniffTest extends \SlevomatCodingStandard\Snif
 
 	public function testNoErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/useDoesNotStartWithBackslashNoErrors.php');
-		$this->assertNoSniffErrorInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/useDoesNotStartWithBackslashNoErrors.php');
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/useDoesNotStartWithBackslashErrors.php');
+		$report = self::checkFile(__DIR__ . '/data/useDoesNotStartWithBackslashErrors.php');
 
-		$this->assertSame(3, $report->getErrorCount());
+		self::assertSame(3, $report->getErrorCount());
 
-		$this->assertSniffError($report, 3, UseDoesNotStartWithBackslashSniff::CODE_STARTS_WITH_BACKSLASH);
-		$this->assertSniffError($report, 4, UseDoesNotStartWithBackslashSniff::CODE_STARTS_WITH_BACKSLASH);
-		$this->assertSniffError($report, 5, UseDoesNotStartWithBackslashSniff::CODE_STARTS_WITH_BACKSLASH);
+		self::assertSniffError($report, 3, UseDoesNotStartWithBackslashSniff::CODE_STARTS_WITH_BACKSLASH);
+		self::assertSniffError($report, 4, UseDoesNotStartWithBackslashSniff::CODE_STARTS_WITH_BACKSLASH);
+		self::assertSniffError($report, 5, UseDoesNotStartWithBackslashSniff::CODE_STARTS_WITH_BACKSLASH);
 	}
 
 	public function testFixable(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableUseDoesNotStartWithBackslash.php', [], [UseDoesNotStartWithBackslashSniff::CODE_STARTS_WITH_BACKSLASH]);
-		$this->assertAllFixedInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/fixableUseDoesNotStartWithBackslash.php', [], [UseDoesNotStartWithBackslashSniff::CODE_STARTS_WITH_BACKSLASH]);
+		self::assertAllFixedInFile($report);
 	}
 
 }

--- a/tests/Sniffs/Namespaces/UseFromSameNamespaceSniffRootNamespaceTest.php
+++ b/tests/Sniffs/Namespaces/UseFromSameNamespaceSniffRootNamespaceTest.php
@@ -5,21 +5,21 @@ namespace SlevomatCodingStandard\Sniffs\Namespaces;
 class UseFromSameNamespaceSniffRootNamespaceTest extends \SlevomatCodingStandard\Sniffs\TestCase
 {
 
-	protected function getSniffClassName(): string
+	protected static function getSniffClassName(): string
 	{
 		return UseFromSameNamespaceSniff::class;
 	}
 
 	public function testUseFromRootNamespaceInFileWithoutNamespace(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/useFromRootNamespaceWithoutNamespace.php');
-		$this->assertSniffError(
+		$report = self::checkFile(__DIR__ . '/data/useFromRootNamespaceWithoutNamespace.php');
+		self::assertSniffError(
 			$report,
 			3,
 			UseFromSameNamespaceSniff::CODE_USE_FROM_SAME_NAMESPACE,
 			'Foo'
 		);
-		$this->assertNoSniffError($report, 4);
+		self::assertNoSniffError($report, 4);
 	}
 
 }

--- a/tests/Sniffs/Namespaces/UseFromSameNamespaceSniffTest.php
+++ b/tests/Sniffs/Namespaces/UseFromSameNamespaceSniffTest.php
@@ -7,30 +7,30 @@ class UseFromSameNamespaceSniffTest extends \SlevomatCodingStandard\Sniffs\TestC
 
 	private function getFileReport(): \PHP_CodeSniffer\Files\File
 	{
-		return $this->checkFile(__DIR__ . '/data/useFromSameNamespace.php');
+		return self::checkFile(__DIR__ . '/data/useFromSameNamespace.php');
 	}
 
 	public function testUnrelatedNamespaces(): void
 	{
 		$report = $this->getFileReport();
-		$this->assertNoSniffError($report, 5);
-		$this->assertNoSniffError($report, 6);
-		$this->assertNoSniffError($report, 10);
+		self::assertNoSniffError($report, 5);
+		self::assertNoSniffError($report, 6);
+		self::assertNoSniffError($report, 10);
 	}
 
 	public function testUseWithAsPart(): void
 	{
-		$this->assertNoSniffError($this->getFileReport(), 7);
+		self::assertNoSniffError($this->getFileReport(), 7);
 	}
 
 	public function testUseFromSubnamespace(): void
 	{
-		$this->assertNoSniffError($this->getFileReport(), 9);
+		self::assertNoSniffError($this->getFileReport(), 9);
 	}
 
 	public function testUseFromSameNamespace(): void
 	{
-		$this->assertSniffError(
+		self::assertSniffError(
 			$this->getFileReport(),
 			8,
 			UseFromSameNamespaceSniff::CODE_USE_FROM_SAME_NAMESPACE,
@@ -40,25 +40,25 @@ class UseFromSameNamespaceSniffTest extends \SlevomatCodingStandard\Sniffs\TestC
 
 	public function testSkipClosure(): void
 	{
-		$this->assertNoSniffError($this->getFileReport(), 12);
+		self::assertNoSniffError($this->getFileReport(), 12);
 	}
 
 	public function testCheckNearestPreviousNamespaceWithMultipleNamespacesInFile(): void
 	{
 		$report = $this->getFileReport();
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			18,
 			UseFromSameNamespaceSniff::CODE_USE_FROM_SAME_NAMESPACE,
 			'Bar\Baz\Test'
 		);
-		$this->assertNoSniffError($report, 19);
+		self::assertNoSniffError($report, 19);
 	}
 
 	public function testFixableUseFromSameNamespace(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableUseFromSameNamespace.php', [], [UseFromSameNamespaceSniff::CODE_USE_FROM_SAME_NAMESPACE]);
-		$this->assertAllFixedInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/fixableUseFromSameNamespace.php', [], [UseFromSameNamespaceSniff::CODE_USE_FROM_SAME_NAMESPACE]);
+		self::assertAllFixedInFile($report);
 	}
 
 }

--- a/tests/Sniffs/Namespaces/UseOnlyWhitelistedNamespacesSniffTest.php
+++ b/tests/Sniffs/Namespaces/UseOnlyWhitelistedNamespacesSniffTest.php
@@ -7,27 +7,27 @@ class UseOnlyWhitelistedNamespacesSniffTest extends \SlevomatCodingStandard\Snif
 
 	public function testUseOnlyWhitelistedNamespaces(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/whitelistedNamespacesInUses.php',
 			['namespacesRequiredToUse' => [
 				'Foo',
 			]]
 		);
 
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			5,
 			UseOnlyWhitelistedNamespacesSniff::CODE_NON_FULLY_QUALIFIED,
 			'Dolor'
 		);
-		$this->assertNoSniffError($report, 6);
-		$this->assertSniffError(
+		self::assertNoSniffError($report, 6);
+		self::assertSniffError(
 			$report,
 			7,
 			UseOnlyWhitelistedNamespacesSniff::CODE_NON_FULLY_QUALIFIED,
 			'Fooo\Baz'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			8,
 			UseOnlyWhitelistedNamespacesSniff::CODE_NON_FULLY_QUALIFIED,
@@ -37,25 +37,25 @@ class UseOnlyWhitelistedNamespacesSniffTest extends \SlevomatCodingStandard\Snif
 
 	public function testIgnoreUseFromAnonymousFunction(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/whitelistedNamespacesInUses.php'
 		);
-		$this->assertNoSniffError($report, 12);
+		self::assertNoSniffError($report, 12);
 	}
 
 	public function testIgnoreTraitUses(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/whitelistedNamespacesInUses.php'
 		);
-		$this->assertNoSniffError($report, 19);
-		$this->assertNoSniffError($report, 20);
-		$this->assertNoSniffError($report, 21);
+		self::assertNoSniffError($report, 19);
+		self::assertNoSniffError($report, 20);
+		self::assertNoSniffError($report, 21);
 	}
 
 	public function testAllowUseFromRootNamespace(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/whitelistedNamespacesInUses.php',
 			[
 				'namespacesRequiredToUse' => [
@@ -65,15 +65,15 @@ class UseOnlyWhitelistedNamespacesSniffTest extends \SlevomatCodingStandard\Snif
 			]
 		);
 
-		$this->assertNoSniffError($report, 5);
-		$this->assertNoSniffError($report, 6);
-		$this->assertSniffError(
+		self::assertNoSniffError($report, 5);
+		self::assertNoSniffError($report, 6);
+		self::assertSniffError(
 			$report,
 			7,
 			UseOnlyWhitelistedNamespacesSniff::CODE_NON_FULLY_QUALIFIED,
 			'Fooo\Baz'
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			8,
 			UseOnlyWhitelistedNamespacesSniff::CODE_NON_FULLY_QUALIFIED,

--- a/tests/Sniffs/TypeHints/DeclareStrictTypesSniffTest.php
+++ b/tests/Sniffs/TypeHints/DeclareStrictTypesSniffTest.php
@@ -7,7 +7,7 @@ class DeclareStrictTypesSniffTest extends \SlevomatCodingStandard\Sniffs\TestCas
 
 	public function testMultipleOpenTagsInFile(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/declareStrictTypesMultipleOpenTags.php'));
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/declareStrictTypesMultipleOpenTags.php'));
 	}
 
 	/**
@@ -42,8 +42,8 @@ class DeclareStrictTypesSniffTest extends \SlevomatCodingStandard\Sniffs\TestCas
 	 */
 	public function testDeclareStrictTypesMissing(string $file, int $line): void
 	{
-		$report = $this->checkFile($file);
-		$this->assertSniffError(
+		$report = self::checkFile($file);
+		self::assertSniffError(
 			$report,
 			$line,
 			DeclareStrictTypesSniff::CODE_DECLARE_STRICT_TYPES_MISSING
@@ -74,8 +74,8 @@ class DeclareStrictTypesSniffTest extends \SlevomatCodingStandard\Sniffs\TestCas
 	 */
 	public function testDeclareStrictTypesIncorrectFormat(string $file): void
 	{
-		$report = $this->checkFile($file);
-		$this->assertSniffError(
+		$report = self::checkFile($file);
+		self::assertSniffError(
 			$report,
 			1,
 			DeclareStrictTypesSniff::CODE_INCORRECT_STRICT_TYPES_FORMAT
@@ -84,16 +84,16 @@ class DeclareStrictTypesSniffTest extends \SlevomatCodingStandard\Sniffs\TestCas
 
 	public function testEmptyFile(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/declareStrictTypesEmptyFile.php', []);
-		$this->assertNoSniffErrorInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/declareStrictTypesEmptyFile.php', []);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testDeclareStrictTypesIncorrectFormatNoSpaces(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/declareStrictTypesIncorrectFormatNoSpaces.php', [
+		$report = self::checkFile(__DIR__ . '/data/declareStrictTypesIncorrectFormatNoSpaces.php', [
 			'spacesCountAroundEqualsSign' => 0,
 		]);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			1,
 			DeclareStrictTypesSniff::CODE_INCORRECT_STRICT_TYPES_FORMAT
@@ -103,15 +103,15 @@ class DeclareStrictTypesSniffTest extends \SlevomatCodingStandard\Sniffs\TestCas
 	public function testDeclareStrictTwoNewlinesBefore(): void
 	{
 		$file = __DIR__ . '/data/declareStrictTypesTwoNewlinesBefore.php';
-		$this->assertNoSniffErrorInFile($this->checkFile($file, [
+		self::assertNoSniffErrorInFile(self::checkFile($file, [
 			'newlinesCountBetweenOpenTagAndDeclare' => ' 2  ',
 		]));
 	}
 
 	public function testDeclareStrictTwoNewlinesBeforeError(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/declareStrictTypesTwoNewlinesBeforeError.php');
-		$this->assertSniffError(
+		$report = self::checkFile(__DIR__ . '/data/declareStrictTypesTwoNewlinesBeforeError.php');
+		self::assertSniffError(
 			$report,
 			3,
 			DeclareStrictTypesSniff::CODE_INCORRECT_WHITESPACE_BETWEEN_OPEN_TAG_AND_DECLARE,
@@ -122,15 +122,15 @@ class DeclareStrictTypesSniffTest extends \SlevomatCodingStandard\Sniffs\TestCas
 	public function testDeclareStrictTwoNewlinesAfter(): void
 	{
 		$file = __DIR__ . '/data/declareStrictTypesTwoNewlinesAfter.php';
-		$this->assertNoSniffErrorInFile($this->checkFile($file, [
+		self::assertNoSniffErrorInFile(self::checkFile($file, [
 			'newlinesCountAfterDeclare' => ' 2  ',
 		], [DeclareStrictTypesSniff::CODE_INCORRECT_WHITESPACE_AFTER_DECLARE]));
 	}
 
 	public function testDeclareStrictTwoNewlinesAfterError(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/declareStrictTypesTwoNewlinesAfterError.php');
-		$this->assertSniffError(
+		$report = self::checkFile(__DIR__ . '/data/declareStrictTypesTwoNewlinesAfterError.php');
+		self::assertSniffError(
 			$report,
 			3,
 			DeclareStrictTypesSniff::CODE_INCORRECT_WHITESPACE_AFTER_DECLARE,
@@ -140,10 +140,10 @@ class DeclareStrictTypesSniffTest extends \SlevomatCodingStandard\Sniffs\TestCas
 
 	public function testDeclareStrictOneSpaceError(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/declareStrictTypesOneSpaceError.php', [
+		$report = self::checkFile(__DIR__ . '/data/declareStrictTypesOneSpaceError.php', [
 			'newlinesCountBetweenOpenTagAndDeclare' => '2',
 		]);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			1,
 			DeclareStrictTypesSniff::CODE_INCORRECT_WHITESPACE_BETWEEN_OPEN_TAG_AND_DECLARE,
@@ -153,118 +153,118 @@ class DeclareStrictTypesSniffTest extends \SlevomatCodingStandard\Sniffs\TestCas
 
 	public function testDeclareStrictOneSpace(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/declareStrictTypesOneSpace.php'));
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/declareStrictTypesOneSpace.php'));
 	}
 
 	public function testDeclareStrictWithTicks(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/declareStrictTypesWithTicks.php'));
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/declareStrictTypesWithTicks.php'));
 	}
 
 	public function testFixableNoNewLinesBefore(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableDeclareStrictTypesNoNewLinesBefore.php', [
+		$report = self::checkFile(__DIR__ . '/data/fixableDeclareStrictTypesNoNewLinesBefore.php', [
 			'newlinesCountBetweenOpenTagAndDeclare' => 0,
 		], [DeclareStrictTypesSniff::CODE_DECLARE_STRICT_TYPES_MISSING, DeclareStrictTypesSniff::CODE_INCORRECT_WHITESPACE_BETWEEN_OPEN_TAG_AND_DECLARE]);
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableMissingNoNewLines(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableDeclareStrictTypesMissingNoNewLines.php', [
+		$report = self::checkFile(__DIR__ . '/data/fixableDeclareStrictTypesMissingNoNewLines.php', [
 			'newlinesCountBetweenOpenTagAndDeclare' => 0,
 		], [DeclareStrictTypesSniff::CODE_DECLARE_STRICT_TYPES_MISSING, DeclareStrictTypesSniff::CODE_INCORRECT_WHITESPACE_BETWEEN_OPEN_TAG_AND_DECLARE]);
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableOneNewLineBefore(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableDeclareStrictTypesOneNewLineBefore.php', [
+		$report = self::checkFile(__DIR__ . '/data/fixableDeclareStrictTypesOneNewLineBefore.php', [
 			'newlinesCountBetweenOpenTagAndDeclare' => 1,
 		], [DeclareStrictTypesSniff::CODE_DECLARE_STRICT_TYPES_MISSING, DeclareStrictTypesSniff::CODE_INCORRECT_WHITESPACE_BETWEEN_OPEN_TAG_AND_DECLARE]);
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableMissingOneNewLine(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableDeclareStrictTypesMissingOneNewLine.php', [
+		$report = self::checkFile(__DIR__ . '/data/fixableDeclareStrictTypesMissingOneNewLine.php', [
 			'newlinesCountBetweenOpenTagAndDeclare' => 1,
 		], [DeclareStrictTypesSniff::CODE_DECLARE_STRICT_TYPES_MISSING, DeclareStrictTypesSniff::CODE_INCORRECT_WHITESPACE_BETWEEN_OPEN_TAG_AND_DECLARE]);
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableMoreNewLinesBefore(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableDeclareStrictTypesMoreNewLinesBefore.php', [
+		$report = self::checkFile(__DIR__ . '/data/fixableDeclareStrictTypesMoreNewLinesBefore.php', [
 			'newlinesCountBetweenOpenTagAndDeclare' => 4,
 		], [DeclareStrictTypesSniff::CODE_DECLARE_STRICT_TYPES_MISSING, DeclareStrictTypesSniff::CODE_INCORRECT_WHITESPACE_BETWEEN_OPEN_TAG_AND_DECLARE]);
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableMissingMoreNewLines(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableDeclareStrictTypesMissingMoreNewLines.php', [
+		$report = self::checkFile(__DIR__ . '/data/fixableDeclareStrictTypesMissingMoreNewLines.php', [
 			'newlinesCountBetweenOpenTagAndDeclare' => 4,
 		], [DeclareStrictTypesSniff::CODE_DECLARE_STRICT_TYPES_MISSING, DeclareStrictTypesSniff::CODE_INCORRECT_WHITESPACE_BETWEEN_OPEN_TAG_AND_DECLARE]);
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableMissingIncorrectFormatOneSpace(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableDeclareStrictTypesIncorrentFormatOneSpace.php', [], [DeclareStrictTypesSniff::CODE_INCORRECT_STRICT_TYPES_FORMAT]);
-		$this->assertAllFixedInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/fixableDeclareStrictTypesIncorrentFormatOneSpace.php', [], [DeclareStrictTypesSniff::CODE_INCORRECT_STRICT_TYPES_FORMAT]);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableMissingIncorrectFormatNoSpaces(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableDeclareStrictTypesIncorrentFormatNoSpaces.php', [
+		$report = self::checkFile(__DIR__ . '/data/fixableDeclareStrictTypesIncorrentFormatNoSpaces.php', [
 			'spacesCountAroundEqualsSign' => 0,
 		], [DeclareStrictTypesSniff::CODE_INCORRECT_STRICT_TYPES_FORMAT]);
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableMissingIncorrectFormatMoreSpaces(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableDeclareStrictTypesIncorrentFormatMoreSpaces.php', [
+		$report = self::checkFile(__DIR__ . '/data/fixableDeclareStrictTypesIncorrentFormatMoreSpaces.php', [
 			'spacesCountAroundEqualsSign' => 4,
 		], [DeclareStrictTypesSniff::CODE_INCORRECT_STRICT_TYPES_FORMAT]);
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableMissingWithTicks(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableDeclareStrictTypesMissingWithTicks.php', [], [DeclareStrictTypesSniff::CODE_DECLARE_STRICT_TYPES_MISSING]);
-		$this->assertAllFixedInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/fixableDeclareStrictTypesMissingWithTicks.php', [], [DeclareStrictTypesSniff::CODE_DECLARE_STRICT_TYPES_MISSING]);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableDisabled(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableDeclareStrictTypesDisabled.php', [], [DeclareStrictTypesSniff::CODE_DECLARE_STRICT_TYPES_MISSING]);
-		$this->assertAllFixedInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/fixableDeclareStrictTypesDisabled.php', [], [DeclareStrictTypesSniff::CODE_DECLARE_STRICT_TYPES_MISSING]);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableOneNewLineAfter(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableDeclareStrictTypesOneNewLineAfter.php', [
+		$report = self::checkFile(__DIR__ . '/data/fixableDeclareStrictTypesOneNewLineAfter.php', [
 			'newlinesCountAfterDeclare' => 2,
 		], [DeclareStrictTypesSniff::CODE_INCORRECT_WHITESPACE_AFTER_DECLARE]);
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableNoNewLinesAfter(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableDeclareStrictTypesNoNewLinesAfter.php', [
+		$report = self::checkFile(__DIR__ . '/data/fixableDeclareStrictTypesNoNewLinesAfter.php', [
 			'newlinesCountAfterDeclare' => 0,
 		], [DeclareStrictTypesSniff::CODE_INCORRECT_WHITESPACE_AFTER_DECLARE]);
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableMoreNewLinesAfter(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableDeclareStrictTypesMoreNewLinesAfter.php', [
+		$report = self::checkFile(__DIR__ . '/data/fixableDeclareStrictTypesMoreNewLinesAfter.php', [
 			'newlinesCountAfterDeclare' => 4,
 		], [DeclareStrictTypesSniff::CODE_INCORRECT_WHITESPACE_AFTER_DECLARE]);
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 }

--- a/tests/Sniffs/TypeHints/LongTypeHintsSniffTest.php
+++ b/tests/Sniffs/TypeHints/LongTypeHintsSniffTest.php
@@ -7,27 +7,27 @@ class LongTypeHintsSniffTest extends \SlevomatCodingStandard\Sniffs\TestCase
 
 	public function testNoErrors(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/longTypeHintsNoErrors.php'));
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/longTypeHintsNoErrors.php'));
 	}
 
 	public function testErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/longTypeHintsErrors.php');
+		$report = self::checkFile(__DIR__ . '/data/longTypeHintsErrors.php');
 
-		$this->assertSame(10, $report->getErrorCount());
+		self::assertSame(10, $report->getErrorCount());
 
-		$this->assertSniffError($report, 4, LongTypeHintsSniff::CODE_USED_LONG_TYPE_HINT, 'Expected "int" but found "integer" in @param annotation.');
-		$this->assertSniffError($report, 5, LongTypeHintsSniff::CODE_USED_LONG_TYPE_HINT, 'Expected "bool" but found "boolean" in @return annotation.');
-		$this->assertSniffError($report, 15, LongTypeHintsSniff::CODE_USED_LONG_TYPE_HINT, 'Expected "int" but found "integer" in @var annotation.');
-		$this->assertSniffError($report, 24, LongTypeHintsSniff::CODE_USED_LONG_TYPE_HINT, 'Expected "bool" but found "boolean" in @var annotation.');
-		$this->assertSniffError($report, 30, LongTypeHintsSniff::CODE_USED_LONG_TYPE_HINT, 'Expected "bool" but found "boolean" in @var annotation.');
-		$this->assertSniffError($report, 30, LongTypeHintsSniff::CODE_USED_LONG_TYPE_HINT, 'Expected "int" but found "integer" in @var annotation.');
-		$this->assertSniffError($report, 35, LongTypeHintsSniff::CODE_USED_LONG_TYPE_HINT, 'Expected "bool" but found "boolean" in @param annotation.');
-		$this->assertSniffError($report, 36, LongTypeHintsSniff::CODE_USED_LONG_TYPE_HINT, 'Expected "bool" but found "boolean" in @param annotation.');
-		$this->assertSniffError($report, 37, LongTypeHintsSniff::CODE_USED_LONG_TYPE_HINT, 'Expected "int" but found "integer" in @param annotation.');
-		$this->assertSniffError($report, 38, LongTypeHintsSniff::CODE_USED_LONG_TYPE_HINT, 'Expected "int" but found "integer" in @return annotation.');
+		self::assertSniffError($report, 4, LongTypeHintsSniff::CODE_USED_LONG_TYPE_HINT, 'Expected "int" but found "integer" in @param annotation.');
+		self::assertSniffError($report, 5, LongTypeHintsSniff::CODE_USED_LONG_TYPE_HINT, 'Expected "bool" but found "boolean" in @return annotation.');
+		self::assertSniffError($report, 15, LongTypeHintsSniff::CODE_USED_LONG_TYPE_HINT, 'Expected "int" but found "integer" in @var annotation.');
+		self::assertSniffError($report, 24, LongTypeHintsSniff::CODE_USED_LONG_TYPE_HINT, 'Expected "bool" but found "boolean" in @var annotation.');
+		self::assertSniffError($report, 30, LongTypeHintsSniff::CODE_USED_LONG_TYPE_HINT, 'Expected "bool" but found "boolean" in @var annotation.');
+		self::assertSniffError($report, 30, LongTypeHintsSniff::CODE_USED_LONG_TYPE_HINT, 'Expected "int" but found "integer" in @var annotation.');
+		self::assertSniffError($report, 35, LongTypeHintsSniff::CODE_USED_LONG_TYPE_HINT, 'Expected "bool" but found "boolean" in @param annotation.');
+		self::assertSniffError($report, 36, LongTypeHintsSniff::CODE_USED_LONG_TYPE_HINT, 'Expected "bool" but found "boolean" in @param annotation.');
+		self::assertSniffError($report, 37, LongTypeHintsSniff::CODE_USED_LONG_TYPE_HINT, 'Expected "int" but found "integer" in @param annotation.');
+		self::assertSniffError($report, 38, LongTypeHintsSniff::CODE_USED_LONG_TYPE_HINT, 'Expected "int" but found "integer" in @return annotation.');
 
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 }

--- a/tests/Sniffs/TypeHints/NullableTypeForNullDefaultValueSniffTest.php
+++ b/tests/Sniffs/TypeHints/NullableTypeForNullDefaultValueSniffTest.php
@@ -7,14 +7,14 @@ class NullableTypeForNullDefaultValueSniffTest extends \SlevomatCodingStandard\S
 
 	public function testNoErrors(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/nullableTypeForNullDefaultValueNoErrors.php', [
+		$this->assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/nullableTypeForNullDefaultValueNoErrors.php', [
 			'enabled' => true,
 		]));
 	}
 
 	public function testErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/nullableTypeForNullDefaultValueErrors.php', [
+		$report = self::checkFile(__DIR__ . '/data/nullableTypeForNullDefaultValueErrors.php', [
 			'enabled' => true,
 		]);
 
@@ -38,7 +38,7 @@ class NullableTypeForNullDefaultValueSniffTest extends \SlevomatCodingStandard\S
 	public function testFixable(): void
 	{
 		$codes = [NullableTypeForNullDefaultValueSniff::CODE_NULLABILITY_SYMBOL_REQUIRED];
-		$report = $this->checkFile(__DIR__ . '/data/fixableNullableTypeForNullDefaultValue.php', [
+		$report = self::checkFile(__DIR__ . '/data/fixableNullableTypeForNullDefaultValue.php', [
 			'enabled' => true,
 		], $codes);
 		$this->assertAllFixedInFile($report);
@@ -46,7 +46,7 @@ class NullableTypeForNullDefaultValueSniffTest extends \SlevomatCodingStandard\S
 
 	public function testDisabledSniff(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/nullableTypeForNullDefaultValueErrors.php', [
+		$report = self::checkFile(__DIR__ . '/data/nullableTypeForNullDefaultValueErrors.php', [
 			'enabled' => false,
 		]);
 		$this->assertNoSniffErrorInFile($report);

--- a/tests/Sniffs/TypeHints/ParameterTypeHintSpacingSniffTest.php
+++ b/tests/Sniffs/TypeHints/ParameterTypeHintSpacingSniffTest.php
@@ -7,39 +7,39 @@ class ParameterTypeHintSpacingSniffTest extends \SlevomatCodingStandard\Sniffs\T
 
 	public function testNoErrors(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/parameterTypeHintSpacingNoErrors.php'));
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/parameterTypeHintSpacingNoErrors.php'));
 	}
 
 	public function testErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/parameterTypeHintSpacingErrors.php');
+		$report = self::checkFile(__DIR__ . '/data/parameterTypeHintSpacingErrors.php');
 
-		$this->assertSame(6, $report->getErrorCount());
+		self::assertSame(6, $report->getErrorCount());
 
-		$this->assertSniffError($report, 3, ParameterTypeHintSpacingSniff::CODE_WHITESPACE_AFTER_NULLABILITY_SYMBOL, 'There must be no whitespace between parameter type hint nullability symbol and parameter type hint of parameter $a.');
-		$this->assertSniffError($report, 3, ParameterTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_TYPE_HINT_AND_PARAMETER, 'There must be exactly one space between parameter type hint and parameter $a.');
-		$this->assertSniffError($report, 3, ParameterTypeHintSpacingSniff::CODE_WHITESPACE_AFTER_NULLABILITY_SYMBOL, 'There must be no whitespace between parameter type hint nullability symbol and parameter type hint of parameter $b.');
-		$this->assertSniffError($report, 3, ParameterTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_TYPE_HINT_AND_PARAMETER, 'There must be exactly one space between parameter type hint and reference sign of parameter $b.');
-		$this->assertSniffError($report, 3, ParameterTypeHintSpacingSniff::CODE_WHITESPACE_AFTER_NULLABILITY_SYMBOL, 'There must be no whitespace between parameter type hint nullability symbol and parameter type hint of parameter $c.');
-		$this->assertSniffError($report, 3, ParameterTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_TYPE_HINT_AND_PARAMETER, 'There must be exactly one space between parameter type hint and varadic parameter $c.');
+		self::assertSniffError($report, 3, ParameterTypeHintSpacingSniff::CODE_WHITESPACE_AFTER_NULLABILITY_SYMBOL, 'There must be no whitespace between parameter type hint nullability symbol and parameter type hint of parameter $a.');
+		self::assertSniffError($report, 3, ParameterTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_TYPE_HINT_AND_PARAMETER, 'There must be exactly one space between parameter type hint and parameter $a.');
+		self::assertSniffError($report, 3, ParameterTypeHintSpacingSniff::CODE_WHITESPACE_AFTER_NULLABILITY_SYMBOL, 'There must be no whitespace between parameter type hint nullability symbol and parameter type hint of parameter $b.');
+		self::assertSniffError($report, 3, ParameterTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_TYPE_HINT_AND_PARAMETER, 'There must be exactly one space between parameter type hint and reference sign of parameter $b.');
+		self::assertSniffError($report, 3, ParameterTypeHintSpacingSniff::CODE_WHITESPACE_AFTER_NULLABILITY_SYMBOL, 'There must be no whitespace between parameter type hint nullability symbol and parameter type hint of parameter $c.');
+		self::assertSniffError($report, 3, ParameterTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_TYPE_HINT_AND_PARAMETER, 'There must be exactly one space between parameter type hint and varadic parameter $c.');
 	}
 
 	public function testFixableParameterTypeHintSpacingNoSpaceBetweenTypeHintAndParameter(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableParameterTypeHintSpacingNoSpaceBetweenTypeHintAndParameter.php', [], [ParameterTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_TYPE_HINT_AND_PARAMETER]);
-		$this->assertAllFixedInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/fixableParameterTypeHintSpacingNoSpaceBetweenTypeHintAndParameter.php', [], [ParameterTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_TYPE_HINT_AND_PARAMETER]);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableParameterTypeHintSpacingMultipleSpacesBetweenTypeHintAndParameter(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableParameterTypeHintSpacingMultipleSpacesBetweenTypeHintAndParameter.php', [], [ParameterTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_TYPE_HINT_AND_PARAMETER]);
-		$this->assertAllFixedInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/fixableParameterTypeHintSpacingMultipleSpacesBetweenTypeHintAndParameter.php', [], [ParameterTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_TYPE_HINT_AND_PARAMETER]);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableParameterTypeHintSpacingWhitespaceAfterNullabilitySymbol(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableParameterTypeHintSpacingWhitespaceAfterNullabilitySymbol.php', [], [ParameterTypeHintSpacingSniff::CODE_WHITESPACE_AFTER_NULLABILITY_SYMBOL]);
-		$this->assertAllFixedInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/fixableParameterTypeHintSpacingWhitespaceAfterNullabilitySymbol.php', [], [ParameterTypeHintSpacingSniff::CODE_WHITESPACE_AFTER_NULLABILITY_SYMBOL]);
+		self::assertAllFixedInFile($report);
 	}
 
 }

--- a/tests/Sniffs/TypeHints/ReturnTypeHintSpacingSniffTest.php
+++ b/tests/Sniffs/TypeHints/ReturnTypeHintSpacingSniffTest.php
@@ -7,148 +7,148 @@ class ReturnTypeHintSpacingSniffTest extends \SlevomatCodingStandard\Sniffs\Test
 
 	public function testCorrectSpacing(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/returnTypeHintsCorrect.php'));
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/returnTypeHintsCorrect.php'));
 	}
 
 	public function testIncorrectSpacing(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/returnTypeHintsIncorrect.php');
-		$this->assertSniffError(
+		$report = self::checkFile(__DIR__ . '/data/returnTypeHintsIncorrect.php');
+		self::assertSniffError(
 			$report,
 			3,
 			ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			8,
 			ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			13,
 			ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			13,
 			ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			18,
 			ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			23,
 			ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			28,
 			ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			33,
 			ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			33,
 			ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			38,
 			ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			75,
 			ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			80,
 			ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			85,
 			ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			90,
 			ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			95,
 			ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			100,
 			ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			105,
 			ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			105,
 			ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			110,
 			ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			110,
 			ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			115,
 			ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			115,
 			ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			120,
 			ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			120,
 			ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			125,
 			ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			125,
 			ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			130,
 			ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			130,
 			ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_TYPE_HINT
@@ -157,93 +157,93 @@ class ReturnTypeHintSpacingSniffTest extends \SlevomatCodingStandard\Sniffs\Test
 
 	public function testIncorrectSpacingInInterface(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/returnTypeHintsIncorrect.php');
-		$this->assertSniffError(
+		$report = self::checkFile(__DIR__ . '/data/returnTypeHintsIncorrect.php');
+		self::assertSniffError(
 			$report,
 			46,
 			ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			48,
 			ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			50,
 			ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			52,
 			ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			54,
 			ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			56,
 			ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			58,
 			ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			58,
 			ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			60,
 			ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			60,
 			ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			62,
 			ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			62,
 			ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			64,
 			ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			64,
 			ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			66,
 			ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			66,
 			ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_TYPE_HINT
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			68,
 			ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON
 		);
-		$this->assertSniffError(
+		self::assertSniffError(
 			$report,
 			68,
 			ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_TYPE_HINT
@@ -252,52 +252,52 @@ class ReturnTypeHintSpacingSniffTest extends \SlevomatCodingStandard\Sniffs\Test
 
 	public function testCorrectSpacingWithNullable(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/returnNullableTypeHintsCorrect.php'));
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/returnNullableTypeHintsCorrect.php'));
 	}
 
 	public function testIncorrectSpacingWithNullable(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/returnNullableTypeHintsIncorrect.php');
+		$report = self::checkFile(__DIR__ . '/data/returnNullableTypeHintsIncorrect.php');
 
-		$this->assertSame(53, $report->getErrorCount());
+		self::assertSame(53, $report->getErrorCount());
 
-		$this->assertSniffError($report, 3, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
-		$this->assertSniffError($report, 8, ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
-		$this->assertSniffError($report, 13, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON);
-		$this->assertSniffError($report, 13, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
-		$this->assertSniffError($report, 18, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON);
-		$this->assertSniffError($report, 18, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
-		$this->assertSniffError($report, 18, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_AFTER_NULLABILITY_SYMBOL);
-		$this->assertSniffError($report, 23, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
-		$this->assertSniffError($report, 28, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_AFTER_NULLABILITY_SYMBOL);
-		$this->assertSniffError($report, 33, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON);
-		$this->assertSniffError($report, 33, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
-		$this->assertSniffError($report, 38, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON);
-		$this->assertSniffError($report, 38, ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
-		$this->assertSniffError($report, 38, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_AFTER_NULLABILITY_SYMBOL);
+		self::assertSniffError($report, 3, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
+		self::assertSniffError($report, 8, ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
+		self::assertSniffError($report, 13, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON);
+		self::assertSniffError($report, 13, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
+		self::assertSniffError($report, 18, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON);
+		self::assertSniffError($report, 18, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
+		self::assertSniffError($report, 18, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_AFTER_NULLABILITY_SYMBOL);
+		self::assertSniffError($report, 23, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
+		self::assertSniffError($report, 28, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_AFTER_NULLABILITY_SYMBOL);
+		self::assertSniffError($report, 33, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON);
+		self::assertSniffError($report, 33, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
+		self::assertSniffError($report, 38, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON);
+		self::assertSniffError($report, 38, ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
+		self::assertSniffError($report, 38, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_AFTER_NULLABILITY_SYMBOL);
 
-		$this->assertSniffError($report, 46, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
-		$this->assertSniffError($report, 48, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
-		$this->assertSniffError($report, 50, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
-		$this->assertSniffError($report, 52, ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
-		$this->assertSniffError($report, 54, ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
-		$this->assertSniffError($report, 56, ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
-		$this->assertSniffError($report, 58, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON);
-		$this->assertSniffError($report, 58, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
-		$this->assertSniffError($report, 60, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON);
-		$this->assertSniffError($report, 60, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
-		$this->assertSniffError($report, 62, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON);
-		$this->assertSniffError($report, 62, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
-		$this->assertSniffError($report, 64, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON);
-		$this->assertSniffError($report, 64, ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
-		$this->assertSniffError($report, 66, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON);
-		$this->assertSniffError($report, 66, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_AFTER_NULLABILITY_SYMBOL);
-		$this->assertSniffError($report, 68, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON);
-		$this->assertSniffError($report, 68, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_AFTER_NULLABILITY_SYMBOL);
+		self::assertSniffError($report, 46, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
+		self::assertSniffError($report, 48, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
+		self::assertSniffError($report, 50, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
+		self::assertSniffError($report, 52, ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
+		self::assertSniffError($report, 54, ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
+		self::assertSniffError($report, 56, ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
+		self::assertSniffError($report, 58, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON);
+		self::assertSniffError($report, 58, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
+		self::assertSniffError($report, 60, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON);
+		self::assertSniffError($report, 60, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
+		self::assertSniffError($report, 62, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON);
+		self::assertSniffError($report, 62, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
+		self::assertSniffError($report, 64, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON);
+		self::assertSniffError($report, 64, ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
+		self::assertSniffError($report, 66, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON);
+		self::assertSniffError($report, 66, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_AFTER_NULLABILITY_SYMBOL);
+		self::assertSniffError($report, 68, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON);
+		self::assertSniffError($report, 68, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_AFTER_NULLABILITY_SYMBOL);
 
-		$this->assertSniffError($report, 75, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
-		$this->assertSniffError($report, 80, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
-		$this->assertSniffError($report, 85, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
+		self::assertSniffError($report, 75, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
+		self::assertSniffError($report, 80, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
+		self::assertSniffError($report, 85, ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
 		$this->assertSniffError($report, 90, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_AFTER_NULLABILITY_SYMBOL);
 		$this->assertSniffError($report, 95, ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_NULLABILITY_SYMBOL);
 		$this->assertSniffError($report, 100, ReturnTypeHintSpacingSniff::CODE_WHITESPACE_AFTER_NULLABILITY_SYMBOL);
@@ -320,7 +320,7 @@ class ReturnTypeHintSpacingSniffTest extends \SlevomatCodingStandard\Sniffs\Test
 
 	public function testReturnTypeHintsArrayIncorrect(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/returnTypeHintsArrayIncorrect.php');
+		$report = self::checkFile(__DIR__ . '/data/returnTypeHintsArrayIncorrect.php');
 
 		$this->assertSame(1, $report->getErrorCount());
 
@@ -329,7 +329,7 @@ class ReturnTypeHintSpacingSniffTest extends \SlevomatCodingStandard\Sniffs\Test
 
 	public function testCorrectSpacingWithSpaceBeforeColon(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/returnTypeHintsCorrectSpaceBeforeColon.php', [
+		$report = self::checkFile(__DIR__ . '/data/returnTypeHintsCorrectSpaceBeforeColon.php', [
 			'spacesCountBeforeColon' => 1,
 		]);
 		$this->assertNoSniffErrorInFile($report);
@@ -337,7 +337,7 @@ class ReturnTypeHintSpacingSniffTest extends \SlevomatCodingStandard\Sniffs\Test
 
 	public function testIncorrectSpacingWithSpaceBeforeColon(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/returnTypeHintsIncorrectSpaceBeforeColon.php', [
+		$report = self::checkFile(__DIR__ . '/data/returnTypeHintsIncorrectSpaceBeforeColon.php', [
 			'spacesCountBeforeColon' => 1,
 		]);
 
@@ -373,43 +373,43 @@ class ReturnTypeHintSpacingSniffTest extends \SlevomatCodingStandard\Sniffs\Test
 
 	public function testFixableReturnTypeHintNoSpaceBetweenColonAndType(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableReturnTypeHintNoSpaceBetweenColonAndType.php', [], [ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_TYPE_HINT]);
+		$report = self::checkFile(__DIR__ . '/data/fixableReturnTypeHintNoSpaceBetweenColonAndType.php', [], [ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_TYPE_HINT]);
 		$this->assertAllFixedInFile($report);
 	}
 
 	public function testFixableReturnTypeHintMultipleSpacesBetweenColonAndType(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableReturnTypeHintMultipleSpacesBetweenColonAndType.php', [], [ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_TYPE_HINT]);
+		$report = self::checkFile(__DIR__ . '/data/fixableReturnTypeHintMultipleSpacesBetweenColonAndType.php', [], [ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_TYPE_HINT]);
 		$this->assertAllFixedInFile($report);
 	}
 
 	public function testFixableReturnTypeHintNoSpaceBetweenColonAndNullabilitySymbol(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableReturnTypeHintNoSpaceBetweenColonAndNullabilitySymbol.php', [], [ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL]);
+		$report = self::checkFile(__DIR__ . '/data/fixableReturnTypeHintNoSpaceBetweenColonAndNullabilitySymbol.php', [], [ReturnTypeHintSpacingSniff::CODE_NO_SPACE_BETWEEN_COLON_AND_NULLABILITY_SYMBOL]);
 		$this->assertAllFixedInFile($report);
 	}
 
 	public function testFixableReturnTypeHintMultipleSpacesBetweenColonAndNullabilitySymbol(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableReturnTypeHintMultipleSpacesBetweenColonAndNullabilitySymbol.php', [], [ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_NULLABILITY_SYMBOL]);
+		$report = self::checkFile(__DIR__ . '/data/fixableReturnTypeHintMultipleSpacesBetweenColonAndNullabilitySymbol.php', [], [ReturnTypeHintSpacingSniff::CODE_MULTIPLE_SPACES_BETWEEN_COLON_AND_NULLABILITY_SYMBOL]);
 		$this->assertAllFixedInFile($report);
 	}
 
 	public function testFixableReturnTypeHintWhitespaceAfterNullabilitySymbol(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableReturnTypeHintWhitespaceAfterNullabilitySymbol.php', [], [ReturnTypeHintSpacingSniff::CODE_WHITESPACE_AFTER_NULLABILITY_SYMBOL]);
+		$report = self::checkFile(__DIR__ . '/data/fixableReturnTypeHintWhitespaceAfterNullabilitySymbol.php', [], [ReturnTypeHintSpacingSniff::CODE_WHITESPACE_AFTER_NULLABILITY_SYMBOL]);
 		$this->assertAllFixedInFile($report);
 	}
 
 	public function testFixableReturnTypeHintWhitespaceBeforeColon(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableReturnTypeHintWhitespaceBeforeColon.php', [], [ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON]);
+		$report = self::checkFile(__DIR__ . '/data/fixableReturnTypeHintWhitespaceBeforeColon.php', [], [ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON]);
 		$this->assertAllFixedInFile($report);
 	}
 
 	public function testFixableReturnTypeHintWhitespaceBeforeColonWithSpace(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/fixableReturnTypeHintWhitespaceBeforeColonWithSpace.php',
 			['spacesCountBeforeColon' => 1],
 			[ReturnTypeHintSpacingSniff::CODE_WHITESPACE_BEFORE_COLON, ReturnTypeHintSpacingSniff::CODE_INCORRECT_SPACES_BEFORE_COLON]

--- a/tests/Sniffs/TypeHints/TypeHintDeclarationSniffTest.php
+++ b/tests/Sniffs/TypeHints/TypeHintDeclarationSniffTest.php
@@ -7,7 +7,7 @@ class TypeHintDeclarationSniffTest extends \SlevomatCodingStandard\Sniffs\TestCa
 
 	public function testNoErrors(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/typeHintDeclarationNoErrors.php', [
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/typeHintDeclarationNoErrors.php', [
 			'enableNullableTypeHints' => false,
 			'enableVoidTypeHint' => false,
 			'enableObjectTypeHint' => false,
@@ -29,7 +29,7 @@ class TypeHintDeclarationSniffTest extends \SlevomatCodingStandard\Sniffs\TestCa
 
 	public function testErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/typeHintDeclarationErrors.php', [
+		$report = self::checkFile(__DIR__ . '/data/typeHintDeclarationErrors.php', [
 			'enableNullableTypeHints' => false,
 			'enableVoidTypeHint' => false,
 			'enableObjectTypeHint' => false,
@@ -40,82 +40,82 @@ class TypeHintDeclarationSniffTest extends \SlevomatCodingStandard\Sniffs\TestCa
 			],
 		]);
 
-		$this->assertSame(63, $report->getErrorCount());
+		self::assertSame(63, $report->getErrorCount());
 
-		$this->assertSniffError($report, 11, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
-		$this->assertSniffError($report, 18, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
-		$this->assertSniffError($report, 25, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
-		$this->assertSniffError($report, 32, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
-		$this->assertSniffError($report, 39, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
-		$this->assertSniffError($report, 46, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
-		$this->assertSniffError($report, 122, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
-		$this->assertSniffError($report, 128, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT, 'Method \FooClass::parametersWithoutTypeHintAndWithAnnotationWithoutParameterName() does not have parameter type hint for its parameter $a but it should be possible to add it based on @param annotation "string".');
-		$this->assertSniffError($report, 128, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT, 'Method \FooClass::parametersWithoutTypeHintAndWithAnnotationWithoutParameterName() does not have parameter type hint for its parameter $b but it should be possible to add it based on @param annotation "bool|null".');
-		$this->assertSniffError($report, 137, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
-		$this->assertSniffError($report, 210, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
+		self::assertSniffError($report, 11, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
+		self::assertSniffError($report, 18, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
+		self::assertSniffError($report, 25, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
+		self::assertSniffError($report, 32, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
+		self::assertSniffError($report, 39, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
+		self::assertSniffError($report, 46, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
+		self::assertSniffError($report, 122, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
+		self::assertSniffError($report, 128, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT, 'Method \FooClass::parametersWithoutTypeHintAndWithAnnotationWithoutParameterName() does not have parameter type hint for its parameter $a but it should be possible to add it based on @param annotation "string".');
+		self::assertSniffError($report, 128, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT, 'Method \FooClass::parametersWithoutTypeHintAndWithAnnotationWithoutParameterName() does not have parameter type hint for its parameter $b but it should be possible to add it based on @param annotation "bool|null".');
+		self::assertSniffError($report, 137, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
+		self::assertSniffError($report, 210, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
 
-		$this->assertSniffError($report, 50, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
-		$this->assertSniffError($report, 58, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
-		$this->assertSniffError($report, 66, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
-		$this->assertSniffError($report, 74, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
-		$this->assertSniffError($report, 82, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
-		$this->assertSniffError($report, 90, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
-		$this->assertSniffError($report, 114, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
+		self::assertSniffError($report, 50, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
+		self::assertSniffError($report, 58, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
+		self::assertSniffError($report, 66, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
+		self::assertSniffError($report, 74, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
+		self::assertSniffError($report, 82, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
+		self::assertSniffError($report, 90, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
+		self::assertSniffError($report, 114, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
 
-		$this->assertSniffError($report, 18, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
-		$this->assertSniffError($report, 58, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
-		$this->assertSniffError($report, 98, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
-		$this->assertSniffError($report, 105, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
-		$this->assertSniffError($report, 217, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
-		$this->assertSniffError($report, 225, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
-		$this->assertSniffError($report, 233, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
-		$this->assertSniffError($report, 241, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
-		$this->assertSniffError($report, 248, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
-		$this->assertSniffError($report, 255, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
-		$this->assertSniffError($report, 386, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		self::assertSniffError($report, 18, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		self::assertSniffError($report, 58, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		self::assertSniffError($report, 98, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		self::assertSniffError($report, 105, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		self::assertSniffError($report, 217, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		self::assertSniffError($report, 225, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		self::assertSniffError($report, 233, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		self::assertSniffError($report, 241, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		self::assertSniffError($report, 248, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		self::assertSniffError($report, 255, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		self::assertSniffError($report, 386, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
 
-		$this->assertSniffError($report, 107, TypeHintDeclarationSniff::CODE_MISSING_PROPERTY_TYPE_HINT);
-		$this->assertSniffError($report, 109, TypeHintDeclarationSniff::CODE_MISSING_PROPERTY_TYPE_HINT);
+		self::assertSniffError($report, 107, TypeHintDeclarationSniff::CODE_MISSING_PROPERTY_TYPE_HINT);
+		self::assertSniffError($report, 109, TypeHintDeclarationSniff::CODE_MISSING_PROPERTY_TYPE_HINT);
 
-		$this->assertSniffError($report, 141, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_RETURN_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 146, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_RETURN_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 151, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_RETURN_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 154, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_RETURN_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 162, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_RETURN_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 200, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_RETURN_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 267, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_RETURN_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 275, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_RETURN_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 312, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_RETURN_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 327, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_RETURN_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 354, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_RETURN_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 375, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_RETURN_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 141, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_RETURN_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 146, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_RETURN_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 151, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_RETURN_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 154, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_RETURN_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 162, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_RETURN_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 200, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_RETURN_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 267, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_RETURN_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 275, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_RETURN_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 312, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_RETURN_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 327, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_RETURN_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 354, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_RETURN_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 375, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_RETURN_TYPE_HINT_SPECIFICATION);
 
-		$this->assertSniffError($report, 169, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PARAMETER_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 173, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PARAMETER_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 177, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PARAMETER_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 180, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PARAMETER_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 187, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PARAMETER_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 208, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PARAMETER_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 283, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PARAMETER_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 290, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PARAMETER_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 321, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PARAMETER_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 332, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PARAMETER_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 346, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PARAMETER_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 367, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PARAMETER_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 169, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PARAMETER_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 173, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PARAMETER_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 177, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PARAMETER_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 180, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PARAMETER_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 187, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PARAMETER_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 208, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PARAMETER_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 283, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PARAMETER_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 290, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PARAMETER_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 321, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PARAMETER_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 332, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PARAMETER_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 346, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PARAMETER_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 367, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PARAMETER_TYPE_HINT_SPECIFICATION);
 
-		$this->assertSniffError($report, 193, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PROPERTY_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 196, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PROPERTY_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 297, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PROPERTY_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 302, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PROPERTY_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 307, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PROPERTY_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 337, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PROPERTY_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 341, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PROPERTY_TYPE_HINT_SPECIFICATION);
-		$this->assertSniffError($report, 362, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PROPERTY_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 193, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PROPERTY_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 196, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PROPERTY_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 297, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PROPERTY_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 302, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PROPERTY_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 307, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PROPERTY_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 337, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PROPERTY_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 341, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PROPERTY_TYPE_HINT_SPECIFICATION);
+		self::assertSniffError($report, 362, TypeHintDeclarationSniff::CODE_MISSING_TRAVERSABLE_PROPERTY_TYPE_HINT_SPECIFICATION);
 	}
 
 	public function testVoidAndIterable(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/voidAndIterableTypeHintDeclaration.php', [
+		$report = self::checkFile(__DIR__ . '/data/voidAndIterableTypeHintDeclaration.php', [
 			'enableNullableTypeHints' => false,
 			'enableVoidTypeHint' => false,
 			'enableObjectTypeHint' => false,
@@ -124,42 +124,42 @@ class TypeHintDeclarationSniffTest extends \SlevomatCodingStandard\Sniffs\TestCa
 			],
 		]);
 
-		$this->assertSame(2, $report->getErrorCount());
+		self::assertSame(2, $report->getErrorCount());
 
-		$this->assertSniffError($report, 10, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
-		$this->assertSniffError($report, 35, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		self::assertSniffError($report, 10, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
+		self::assertSniffError($report, 35, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
 	}
 
 	public function testEnabledVoidTypeHintNoErrors(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/enabledVoidTypeHintNoErrors.php', [
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/enabledVoidTypeHintNoErrors.php', [
 			'enableVoidTypeHint' => true,
 		]));
 	}
 
 	public function testEnabledVoidTypeHintErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/enabledVoidTypeHintErrors.php', [
+		$report = self::checkFile(__DIR__ . '/data/enabledVoidTypeHintErrors.php', [
 			'enableNullableTypeHints' => false,
 			'enableVoidTypeHint' => true,
 			'enableObjectTypeHint' => false,
 		]);
 
-		$this->assertSame(8, $report->getErrorCount());
+		self::assertSame(8, $report->getErrorCount());
 
-		$this->assertSniffError($report, 3, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
-		$this->assertSniffError($report, 14, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
-		$this->assertSniffError($report, 16, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
-		$this->assertSniffError($report, 24, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
-		$this->assertSniffError($report, 31, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
-		$this->assertSniffError($report, 35, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
-		$this->assertSniffError($report, 39, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
-		$this->assertSniffError($report, 51, TypeHintDeclarationSniff::CODE_INCORRECT_RETURN_TYPE_HINT);
+		self::assertSniffError($report, 3, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
+		self::assertSniffError($report, 14, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
+		self::assertSniffError($report, 16, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
+		self::assertSniffError($report, 24, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		self::assertSniffError($report, 31, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
+		self::assertSniffError($report, 35, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
+		self::assertSniffError($report, 39, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
+		self::assertSniffError($report, 51, TypeHintDeclarationSniff::CODE_INCORRECT_RETURN_TYPE_HINT);
 	}
 
 	public function testEnabledNullableTypeHintsNoErrors(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/typeHintDeclarationEnabledNullableTypeHintsNoErrors.php', [
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/typeHintDeclarationEnabledNullableTypeHintsNoErrors.php', [
 			'enableNullableTypeHints' => true,
 			'enableVoidTypeHint' => false,
 			'enableObjectTypeHint' => false,
@@ -168,33 +168,33 @@ class TypeHintDeclarationSniffTest extends \SlevomatCodingStandard\Sniffs\TestCa
 
 	public function testEnabledNullableTypeHintsErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/typeHintDeclarationEnabledNullableTypeHintsErrors.php', [
+		$report = self::checkFile(__DIR__ . '/data/typeHintDeclarationEnabledNullableTypeHintsErrors.php', [
 			'enableNullableTypeHints' => true,
 			'enableVoidTypeHint' => false,
 			'enableObjectTypeHint' => false,
 		]);
 
-		$this->assertSame(14, $report->getErrorCount());
+		self::assertSame(14, $report->getErrorCount());
 
-		$this->assertSniffError($report, 13, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
-		$this->assertSniffError($report, 21, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
-		$this->assertSniffError($report, 26, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
-		$this->assertSniffError($report, 31, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
-		$this->assertSniffError($report, 39, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
-		$this->assertSniffError($report, 46, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
-		$this->assertSniffError($report, 53, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
-		$this->assertSniffError($report, 61, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
-		$this->assertSniffError($report, 69, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
-		$this->assertSniffError($report, 77, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
-		$this->assertSniffError($report, 85, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
-		$this->assertSniffError($report, 93, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
-		$this->assertSniffError($report, 100, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
-		$this->assertSniffError($report, 107, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		self::assertSniffError($report, 13, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
+		self::assertSniffError($report, 21, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
+		self::assertSniffError($report, 26, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		self::assertSniffError($report, 31, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		self::assertSniffError($report, 39, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
+		self::assertSniffError($report, 46, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		self::assertSniffError($report, 53, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
+		self::assertSniffError($report, 61, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
+		self::assertSniffError($report, 69, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		self::assertSniffError($report, 77, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		self::assertSniffError($report, 85, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		self::assertSniffError($report, 93, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		self::assertSniffError($report, 100, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		self::assertSniffError($report, 107, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
 	}
 
 	public function testDisabledNullableTypeHintsNoErrors(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/typeHintDeclarationDisabledNullableTypeHintsNoErrors.php', [
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/typeHintDeclarationDisabledNullableTypeHintsNoErrors.php', [
 			'enableNullableTypeHints' => false,
 			'enableVoidTypeHint' => false,
 			'enableObjectTypeHint' => false,
@@ -203,22 +203,22 @@ class TypeHintDeclarationSniffTest extends \SlevomatCodingStandard\Sniffs\TestCa
 
 	public function testDisabledNullableTypeHintsErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/typeHintDeclarationDisabledNullableTypeHintsErrors.php', [
+		$report = self::checkFile(__DIR__ . '/data/typeHintDeclarationDisabledNullableTypeHintsErrors.php', [
 			'enableNullableTypeHints' => false,
 			'enableVoidTypeHint' => false,
 			'enableObjectTypeHint' => false,
 		]);
 
-		$this->assertSame(3, $report->getErrorCount());
+		self::assertSame(3, $report->getErrorCount());
 
-		$this->assertSniffError($report, 11, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
-		$this->assertSniffError($report, 19, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
-		$this->assertSniffError($report, 27, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		self::assertSniffError($report, 11, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
+		self::assertSniffError($report, 19, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
+		self::assertSniffError($report, 27, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
 	}
 
 	public function testEnabledEachParameterAndReturnInspectionNoErrors(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/typeHintDeclarationEnabledEachParameterAndReturnInspectionNoErrors.php', [
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/typeHintDeclarationEnabledEachParameterAndReturnInspectionNoErrors.php', [
 			'enableNullableTypeHints' => false,
 			'enableVoidTypeHint' => false,
 			'enableObjectTypeHint' => false,
@@ -228,7 +228,7 @@ class TypeHintDeclarationSniffTest extends \SlevomatCodingStandard\Sniffs\TestCa
 
 	public function testEnabledEachParameterAndReturnInspectionErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/typeHintDeclarationEnabledEachParameterAndReturnInspectionErrors.php', [
+		$report = self::checkFile(__DIR__ . '/data/typeHintDeclarationEnabledEachParameterAndReturnInspectionErrors.php', [
 			'enableNullableTypeHints' => false,
 			'enableVoidTypeHint' => false,
 			'enableObjectTypeHint' => false,
@@ -236,28 +236,28 @@ class TypeHintDeclarationSniffTest extends \SlevomatCodingStandard\Sniffs\TestCa
 			'enableEachParameterAndReturnInspection' => true,
 		]);
 
-		$this->assertSame(11, $report->getErrorCount());
+		self::assertSame(11, $report->getErrorCount());
 
 		$parameterMessage = function (string $method, string $parameter): string {
 			return sprintf('Method \FooNamespace\FooClass::%s() has useless @param annotation for parameter $%s.', $method, $parameter);
 		};
 
-		$this->assertSniffError($report, 11, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
-		$this->assertSniffError($report, 18, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
-		$this->assertSniffError($report, 27, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
-		$this->assertSniffError($report, 32, TypeHintDeclarationSniff::CODE_USELESS_PARAMETER_ANNOTATION, $parameterMessage('withUselessParameterButRequiredReturn', 'foo'));
-		$this->assertSniffError($report, 40, TypeHintDeclarationSniff::CODE_USELESS_PARAMETER_ANNOTATION, $parameterMessage('withMultipleUselessParametersAndReturn', 'foo'));
-		$this->assertSniffError($report, 42, TypeHintDeclarationSniff::CODE_USELESS_PARAMETER_ANNOTATION, $parameterMessage('withMultipleUselessParametersAndReturn', 'baz'));
-		$this->assertSniffError($report, 43, TypeHintDeclarationSniff::CODE_USELESS_RETURN_ANNOTATION);
-		$this->assertSniffError($report, 51, TypeHintDeclarationSniff::CODE_USELESS_PARAMETER_ANNOTATION, $parameterMessage('withDescriptionAndUselessParameter', 'foo'));
-		$this->assertSniffError($report, 59, TypeHintDeclarationSniff::CODE_USELESS_RETURN_ANNOTATION);
-		$this->assertSniffError($report, 67, TypeHintDeclarationSniff::CODE_USELESS_PARAMETER_ANNOTATION, $parameterMessage('withUsefulAnnotationAndUselessParameter', 'foo'));
-		$this->assertSniffError($report, 75, TypeHintDeclarationSniff::CODE_USELESS_RETURN_ANNOTATION);
+		self::assertSniffError($report, 11, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		self::assertSniffError($report, 18, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		self::assertSniffError($report, 27, TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT);
+		self::assertSniffError($report, 32, TypeHintDeclarationSniff::CODE_USELESS_PARAMETER_ANNOTATION, $parameterMessage('withUselessParameterButRequiredReturn', 'foo'));
+		self::assertSniffError($report, 40, TypeHintDeclarationSniff::CODE_USELESS_PARAMETER_ANNOTATION, $parameterMessage('withMultipleUselessParametersAndReturn', 'foo'));
+		self::assertSniffError($report, 42, TypeHintDeclarationSniff::CODE_USELESS_PARAMETER_ANNOTATION, $parameterMessage('withMultipleUselessParametersAndReturn', 'baz'));
+		self::assertSniffError($report, 43, TypeHintDeclarationSniff::CODE_USELESS_RETURN_ANNOTATION);
+		self::assertSniffError($report, 51, TypeHintDeclarationSniff::CODE_USELESS_PARAMETER_ANNOTATION, $parameterMessage('withDescriptionAndUselessParameter', 'foo'));
+		self::assertSniffError($report, 59, TypeHintDeclarationSniff::CODE_USELESS_RETURN_ANNOTATION);
+		self::assertSniffError($report, 67, TypeHintDeclarationSniff::CODE_USELESS_PARAMETER_ANNOTATION, $parameterMessage('withUsefulAnnotationAndUselessParameter', 'foo'));
+		self::assertSniffError($report, 75, TypeHintDeclarationSniff::CODE_USELESS_RETURN_ANNOTATION);
 	}
 
 	public function testFixableReturnTypeHints(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableReturnTypeHints.php', [
+		$report = self::checkFile(__DIR__ . '/data/fixableReturnTypeHints.php', [
 			'enableNullableTypeHints' => true,
 			'enableVoidTypeHint' => false,
 			'enableObjectTypeHint' => false,
@@ -267,34 +267,34 @@ class TypeHintDeclarationSniffTest extends \SlevomatCodingStandard\Sniffs\TestCa
 			],
 		], [TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT]);
 
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableReturnTypeHintsWithEnabledVoid(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableReturnTypeHintsWithEnabledVoid.php', [
+		$report = self::checkFile(__DIR__ . '/data/fixableReturnTypeHintsWithEnabledVoid.php', [
 			'enableNullableTypeHints' => false,
 			'enableVoidTypeHint' => true,
 			'enableObjectTypeHint' => false,
 		], [TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT, TypeHintDeclarationSniff::CODE_INCORRECT_RETURN_TYPE_HINT]);
 
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableReturnTypeHintsWithDisabledVoid(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableReturnTypeHintsWithDisabledVoid.php', [
+		$report = self::checkFile(__DIR__ . '/data/fixableReturnTypeHintsWithDisabledVoid.php', [
 			'enableNullableTypeHints' => false,
 			'enableVoidTypeHint' => false,
 			'enableObjectTypeHint' => false,
 		], [TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT, TypeHintDeclarationSniff::CODE_INCORRECT_RETURN_TYPE_HINT]);
 
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableParameterTypeHintsWithEnabledNullableTypeHints(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableParameterTypeHintsWithEnabledNullableTypeHints.php', [
+		$report = self::checkFile(__DIR__ . '/data/fixableParameterTypeHintsWithEnabledNullableTypeHints.php', [
 			'enableNullableTypeHints' => true,
 			'enableVoidTypeHint' => false,
 			'enableObjectTypeHint' => false,
@@ -304,34 +304,34 @@ class TypeHintDeclarationSniffTest extends \SlevomatCodingStandard\Sniffs\TestCa
 			],
 		], [TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT]);
 
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableParameterTypeHintsWithDisabledNullableTypeHints(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableParameterTypeHintsWithDisabledNullableTypeHints.php', [
+		$report = self::checkFile(__DIR__ . '/data/fixableParameterTypeHintsWithDisabledNullableTypeHints.php', [
 			'enableNullableTypeHints' => false,
 			'enableVoidTypeHint' => false,
 			'enableObjectTypeHint' => false,
 		], [TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT]);
 
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableUselessDocComments(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableUselessDocComments.php', [
+		$report = self::checkFile(__DIR__ . '/data/fixableUselessDocComments.php', [
 			'enableNullableTypeHints' => true,
 			'enableVoidTypeHint' => true,
 			'enableObjectTypeHint' => false,
 		], [TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT]);
 
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testFixableEnableEachParameterAndReturnInspection(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/fixableEnableEachParameterAndReturnInspection.php', [
+		$report = self::checkFile(__DIR__ . '/data/fixableEnableEachParameterAndReturnInspection.php', [
 			'enableNullableTypeHints' => false,
 			'enableVoidTypeHint' => false,
 			'enableObjectTypeHint' => false,
@@ -339,41 +339,41 @@ class TypeHintDeclarationSniffTest extends \SlevomatCodingStandard\Sniffs\TestCa
 			'usefulAnnotations' => ['@useful'],
 		], [TypeHintDeclarationSniff::CODE_USELESS_DOC_COMMENT, TypeHintDeclarationSniff::CODE_USELESS_PARAMETER_ANNOTATION, TypeHintDeclarationSniff::CODE_USELESS_RETURN_ANNOTATION]);
 
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testEnabledObjectTypeHintNoErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/typeHintDeclarationEnabledObjectTypeHintNoErrors.php', [
+		$report = self::checkFile(__DIR__ . '/data/typeHintDeclarationEnabledObjectTypeHintNoErrors.php', [
 			'enableNullableTypeHints' => true,
 			'enableVoidTypeHint' => false,
 			'enableObjectTypeHint' => true,
 		]);
-		$this->assertNoSniffErrorInFile($report);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testEnabledObjectTypeHintErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/typeHintDeclarationEnabledObjectTypeHintErrors.php', [
+		$report = self::checkFile(__DIR__ . '/data/typeHintDeclarationEnabledObjectTypeHintErrors.php', [
 			'enableNullableTypeHints' => true,
 			'enableVoidTypeHint' => false,
 			'enableObjectTypeHint' => true,
 		]);
 
-		$this->assertSame(2, $report->getErrorCount());
+		self::assertSame(2, $report->getErrorCount());
 
-		$this->assertSniffError($report, 11, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
-		$this->assertSniffError($report, 16, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
+		self::assertSniffError($report, 11, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
+		self::assertSniffError($report, 16, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
 	}
 
 	public function testDisabledObjectTypeHintNoErrors(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/typeHintDeclarationDisabledObjectTypeHintNoErrors.php', [
+		$report = self::checkFile(__DIR__ . '/data/typeHintDeclarationDisabledObjectTypeHintNoErrors.php', [
 			'enableNullableTypeHints' => true,
 			'enableVoidTypeHint' => false,
 			'enableObjectTypeHint' => false,
 		]);
-		$this->assertNoSniffErrorInFile($report);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 }

--- a/tests/Sniffs/Types/EmptyLinesAroundTypeBracesSniffTest.php
+++ b/tests/Sniffs/Types/EmptyLinesAroundTypeBracesSniffTest.php
@@ -7,131 +7,131 @@ class EmptyLinesAroundTypeBracesSniffTest extends \SlevomatCodingStandard\Sniffs
 
 	public function testCorrectCorrectEmptyLines(): void
 	{
-		$this->assertNoSniffErrorInFile($this->checkFile(__DIR__ . '/data/correctEmptyLines.php'));
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/correctEmptyLines.php'));
 	}
 
 	public function testNoEmptyLineAfterOpeningBrace(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/noEmptyLineAfterOpeningBrace.php', [], [EmptyLinesAroundTypeBracesSniff::CODE_NO_EMPTY_LINE_AFTER_OPENING_BRACE]);
+		$report = self::checkFile(__DIR__ . '/data/noEmptyLineAfterOpeningBrace.php', [], [EmptyLinesAroundTypeBracesSniff::CODE_NO_EMPTY_LINE_AFTER_OPENING_BRACE]);
 
-		$this->assertSame(1, $report->getErrorCount());
+		self::assertSame(1, $report->getErrorCount());
 
-		$this->assertSniffError($report, 4, EmptyLinesAroundTypeBracesSniff::CODE_NO_EMPTY_LINE_AFTER_OPENING_BRACE);
+		self::assertSniffError($report, 4, EmptyLinesAroundTypeBracesSniff::CODE_NO_EMPTY_LINE_AFTER_OPENING_BRACE);
 
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testMultipleEmptyLinesAfterOpeningBrace(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/multipleEmptyLinesAfterOpeningBrace.php', [], [EmptyLinesAroundTypeBracesSniff::CODE_MULTIPLE_EMPTY_LINES_AFTER_OPENING_BRACE]);
+		$report = self::checkFile(__DIR__ . '/data/multipleEmptyLinesAfterOpeningBrace.php', [], [EmptyLinesAroundTypeBracesSniff::CODE_MULTIPLE_EMPTY_LINES_AFTER_OPENING_BRACE]);
 
-		$this->assertSame(1, $report->getErrorCount());
+		self::assertSame(1, $report->getErrorCount());
 
-		$this->assertSniffError($report, 4, EmptyLinesAroundTypeBracesSniff::CODE_MULTIPLE_EMPTY_LINES_AFTER_OPENING_BRACE);
+		self::assertSniffError($report, 4, EmptyLinesAroundTypeBracesSniff::CODE_MULTIPLE_EMPTY_LINES_AFTER_OPENING_BRACE);
 
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testNoEmptyLineBeforeClosingBrace(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/noEmptyLineBeforeClosingBrace.php', [], [EmptyLinesAroundTypeBracesSniff::CODE_NO_EMPTY_LINE_BEFORE_CLOSING_BRACE]);
+		$report = self::checkFile(__DIR__ . '/data/noEmptyLineBeforeClosingBrace.php', [], [EmptyLinesAroundTypeBracesSniff::CODE_NO_EMPTY_LINE_BEFORE_CLOSING_BRACE]);
 
-		$this->assertSame(1, $report->getErrorCount());
+		self::assertSame(1, $report->getErrorCount());
 
-		$this->assertSniffError($report, 10, EmptyLinesAroundTypeBracesSniff::CODE_NO_EMPTY_LINE_BEFORE_CLOSING_BRACE);
+		self::assertSniffError($report, 10, EmptyLinesAroundTypeBracesSniff::CODE_NO_EMPTY_LINE_BEFORE_CLOSING_BRACE);
 
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testMultipleEmptyLinesBeforeClosingBrace(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/multipleEmptyLinesBeforeClosingBrace.php', [], [EmptyLinesAroundTypeBracesSniff::CODE_MULTIPLE_EMPTY_LINES_BEFORE_CLOSING_BRACE]);
+		$report = self::checkFile(__DIR__ . '/data/multipleEmptyLinesBeforeClosingBrace.php', [], [EmptyLinesAroundTypeBracesSniff::CODE_MULTIPLE_EMPTY_LINES_BEFORE_CLOSING_BRACE]);
 
-		$this->assertSame(1, $report->getErrorCount());
+		self::assertSame(1, $report->getErrorCount());
 
-		$this->assertSniffError($report, 13, EmptyLinesAroundTypeBracesSniff::CODE_MULTIPLE_EMPTY_LINES_BEFORE_CLOSING_BRACE);
+		self::assertSniffError($report, 13, EmptyLinesAroundTypeBracesSniff::CODE_MULTIPLE_EMPTY_LINES_BEFORE_CLOSING_BRACE);
 
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testCorrectCorrectEmptyLinesWithZeroLines(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/correctEmptyLinesZeroLines.php', [
+		$report = self::checkFile(__DIR__ . '/data/correctEmptyLinesZeroLines.php', [
 			'linesCountAfterOpeningBrace' => 0,
 			'linesCountBeforeClosingBrace' => 0,
 		]);
 
-		$this->assertNoSniffErrorInFile($report);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testOneLineAfterOpeningBraceWithZeroExpected(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/oneEmptyLineAfterOpeningBraceWithZeroExpected.php',
 			['linesCountAfterOpeningBrace' => 0],
 			[EmptyLinesAroundTypeBracesSniff::CODE_INCORRECT_EMPTY_LINES_AFTER_OPENING_BRACE]
 		);
 
-		$this->assertSame(1, $report->getErrorCount());
+		self::assertSame(1, $report->getErrorCount());
 
-		$this->assertSniffError($report, 4, EmptyLinesAroundTypeBracesSniff::CODE_INCORRECT_EMPTY_LINES_AFTER_OPENING_BRACE);
+		self::assertSniffError($report, 4, EmptyLinesAroundTypeBracesSniff::CODE_INCORRECT_EMPTY_LINES_AFTER_OPENING_BRACE);
 
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testOneLineBeforeClosingBraceWithZeroExpected(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/oneEmptyLineBeforeClosingBraceWithZeroExpected.php',
 			['linesCountBeforeClosingBrace' => 0],
 			[EmptyLinesAroundTypeBracesSniff::CODE_INCORRECT_EMPTY_LINES_BEFORE_CLOSING_BRACE]
 		);
 
-		$this->assertSame(1, $report->getErrorCount());
+		self::assertSame(1, $report->getErrorCount());
 
-		$this->assertSniffError($report, 10, EmptyLinesAroundTypeBracesSniff::CODE_INCORRECT_EMPTY_LINES_BEFORE_CLOSING_BRACE);
+		self::assertSniffError($report, 10, EmptyLinesAroundTypeBracesSniff::CODE_INCORRECT_EMPTY_LINES_BEFORE_CLOSING_BRACE);
 
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testCorrectCorrectEmptyLinesWithTwoLines(): void
 	{
-		$report = $this->checkFile(__DIR__ . '/data/correctEmptyLinesTwoLines.php', [
+		$report = self::checkFile(__DIR__ . '/data/correctEmptyLinesTwoLines.php', [
 			'linesCountAfterOpeningBrace' => 2,
 			'linesCountBeforeClosingBrace' => 2,
 		]);
 
-		$this->assertNoSniffErrorInFile($report);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testOneLineAfterOpeningBraceWithTwoExpected(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/oneEmptyLineAfterOpeningBraceWithTwoExpected.php',
 			['linesCountAfterOpeningBrace' => 2],
 			[EmptyLinesAroundTypeBracesSniff::CODE_INCORRECT_EMPTY_LINES_AFTER_OPENING_BRACE]
 		);
 
-		$this->assertSame(1, $report->getErrorCount());
+		self::assertSame(1, $report->getErrorCount());
 
-		$this->assertSniffError($report, 4, EmptyLinesAroundTypeBracesSniff::CODE_INCORRECT_EMPTY_LINES_AFTER_OPENING_BRACE);
+		self::assertSniffError($report, 4, EmptyLinesAroundTypeBracesSniff::CODE_INCORRECT_EMPTY_LINES_AFTER_OPENING_BRACE);
 
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 	public function testOneLineBeforeClosingBraceWithTwoExpected(): void
 	{
-		$report = $this->checkFile(
+		$report = self::checkFile(
 			__DIR__ . '/data/oneEmptyLineBeforeClosingBraceWithTwoExpected.php',
 			['linesCountBeforeClosingBrace' => 2],
 			[EmptyLinesAroundTypeBracesSniff::CODE_INCORRECT_EMPTY_LINES_BEFORE_CLOSING_BRACE]
 		);
 
-		$this->assertSame(1, $report->getErrorCount());
+		self::assertSame(1, $report->getErrorCount());
 
-		$this->assertSniffError($report, 12, EmptyLinesAroundTypeBracesSniff::CODE_INCORRECT_EMPTY_LINES_BEFORE_CLOSING_BRACE);
+		self::assertSniffError($report, 12, EmptyLinesAroundTypeBracesSniff::CODE_INCORRECT_EMPTY_LINES_BEFORE_CLOSING_BRACE);
 
-		$this->assertAllFixedInFile($report);
+		self::assertAllFixedInFile($report);
 	}
 
 }


### PR DESCRIPTION
This makes all assertion calls and also TestCase's utility methods static.

it's a tiny tests-only BC break if anyone extends Slevomat's TestCase and also overrides any of the utility methods.
Calling static methods dynamically is otherwise valid code.

See https://github.com/phpstan/phpstan/issues/514, phpstan/phpstan-strict-rules#4, phpstan/phpstan-strict-rules#5 and https://github.com/doctrine/dbal/commit/62eb475891cd9aa18cbc802532683b3c5b40d5fb#commitcomment-24420550.