### PR TITLE
DocCommentHelper: Trim description, test anonymous/inline descriptions

### DIFF
--- a/SlevomatCodingStandard/Helpers/DocCommentHelper.php
+++ b/SlevomatCodingStandard/Helpers/DocCommentHelper.php
@@ -63,7 +63,7 @@ class DocCommentHelper
 				continue;
 			}
 
-			$comments[] = new Comment($i, $tokens[$i]['content']);
+			$comments[] = new Comment($i, trim($tokens[$i]['content']));
 		}
 
 		return count($comments) > 0 ? $comments : null;

--- a/tests/Helpers/DocCommentHelperTest.php
+++ b/tests/Helpers/DocCommentHelperTest.php
@@ -132,6 +132,22 @@ class DocCommentHelperTest extends \SlevomatCodingStandard\Helpers\TestCase
 		);
 	}
 
+	public function testUnboundGetDocCommentDescription(): void
+	{
+		self::assertSame(
+			['Created by Slevomat.'],
+			$this->stringifyComments(DocCommentHelper::getDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findPointerByLineAndType($this->getTestedCodeSnifferFile(), 3, T_DOC_COMMENT_OPEN_TAG)))
+		);
+	}
+
+	public function testUnboundMultiLineGetDocCommentDescription(): void
+	{
+		self::assertSame(
+			['This is', 'multiline.'],
+			$this->stringifyComments(DocCommentHelper::getDocCommentDescription($this->getTestedCodeSnifferFile(), $this->findPointerByLineAndType($this->getTestedCodeSnifferFile(), 5, T_DOC_COMMENT_OPEN_TAG)))
+		);
+	}
+
 	private function getTestedCodeSnifferFile(): \PHP_CodeSniffer\Files\File
 	{
 		if ($this->testedCodeSnifferFile === null) {

--- a/tests/Helpers/TestCase.php
+++ b/tests/Helpers/TestCase.php
@@ -98,6 +98,33 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
+	 * @param \PHP_CodeSniffer\Files\File $codeSnifferFile
+	 * @param int $line
+	 * @param int|string $tokenCode
+	 * @return int|null
+	 */
+	protected function findPointerByLineAndType(\PHP_CodeSniffer\Files\File $codeSnifferFile, int $line, $tokenCode): ?int
+	{
+		$tokens = $codeSnifferFile->getTokens();
+		for ($i = 0; $i < count($tokens); $i++) {
+			if ($tokens[$i]['line'] > $line) {
+				return null;
+			}
+
+			if ($tokens[$i]['line'] < $line) {
+				continue;
+			}
+
+			if ($tokens[$i]['code'] !== $tokenCode) {
+				continue;
+			}
+
+			return $i;
+		}
+		return null;
+	}
+
+	/**
 	 * @param int|string $code
 	 * @return string|null
 	 */

--- a/tests/Helpers/data/docComment.php
+++ b/tests/Helpers/data/docComment.php
@@ -1,5 +1,12 @@
 <?php
 
+/** Created by Slevomat. */
+
+/**
+ * This is
+ * multiline.
+ */
+
 /**
  * Class WithDocComment
  *


### PR DESCRIPTION
Just a little addition to 170deb0bcc78f89dc3c1ccb3aa61837cc45a3fb3.

In case of the inline comment, there is a space at the end - it may also be a PHPCS bug?