### PR TITLE
add failing test for early exit - condition cannot be moved any further

### DIFF
--- a/tests/Sniffs/ControlStructures/data/earlyExitNoErrors.php
+++ b/tests/Sniffs/ControlStructures/data/earlyExitNoErrors.php
@@ -133,3 +133,12 @@ for ($i = 0; $i < 100; $i++) {
 
 	doSomethingAgain();
 }
+
+function passWhenConditionIsOnTheEndOfMethod()
+{
+	for ($i = 0; $i < 100; $i++) {
+		if ($i % 2 === 0) {
+			doSomething();
+		}
+	}
+}


### PR DESCRIPTION
If I have condition inside of foreach loop, I don't know the actual value of property, so I cannot to rewrite this piece of code to be able to pass phpcs check.