### PR TITLE
UnusedUsesSniff: add option to ignore specified annotation names

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Looks for unused imports from other namespaces.
 Sniff provides the following settings:
 
 * `searchAnnotations` (defaults to `false`): enables searching for mentions in annotations, which is especially useful for projects using [Doctrine Annotations](https://github.com/doctrine/annotations)
+* `ignoredAnnotationNames`: case sensitive list of annotation names that the sniff should ignore (only the name is ignored, annotation content is still searched). Useful for name collisions like `@testCase` annotation and `TestCase` class from [Nette Tester](https://github.com/nette/tester).
 
 #### SlevomatCodingStandard.Namespaces.UseFromSameNamespace 🔧
 

--- a/SlevomatCodingStandard/Sniffs/Namespaces/UnusedUsesSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/UnusedUsesSniff.php
@@ -19,6 +19,9 @@ class UnusedUsesSniff implements \PHP_CodeSniffer\Sniffs\Sniff
 	/** @var bool */
 	public $searchAnnotations = false;
 
+	/** @var string[] */
+	public $ignoredAnnotationNames = [];
+
 	/**
 	 * @return mixed[]
 	 */
@@ -89,16 +92,18 @@ class UnusedUsesSniff implements \PHP_CodeSniffer\Sniffs\Sniff
 
 					foreach ($annotations as $annotationName => $annotationsByName) {
 						if (preg_match('~^@(' . preg_quote($nameAsReferencedInFile, '~') . ')(?=[^a-z\\d]|$)~i', $annotationName, $matches)) {
-							$usedNames[$uniqueId] = true;
+							if (!in_array($matches[1], $this->ignoredAnnotationNames, true)) {
+								$usedNames[$uniqueId] = true;
 
-							if ($matches[1] !== $nameAsReferencedInFile) {
-								/** @var \SlevomatCodingStandard\Helpers\Annotation $annotation */
-								foreach ($annotationsByName as $annotation) {
-									$phpcsFile->addError(sprintf(
-										'Case of reference name "%s" and use statement "%s" do not match.',
-										$matches[1],
-										$unusedNames[$uniqueId]->getNameAsReferencedInFile()
-									), $annotation->getPointer(), self::CODE_MISMATCHING_CASE);
+								if ($matches[1] !== $nameAsReferencedInFile) {
+									/** @var \SlevomatCodingStandard\Helpers\Annotation $annotation */
+									foreach ($annotationsByName as $annotation) {
+										$phpcsFile->addError(sprintf(
+											'Case of reference name "%s" and use statement "%s" do not match.',
+											$matches[1],
+											$unusedNames[$uniqueId]->getNameAsReferencedInFile()
+										), $annotation->getPointer(), self::CODE_MISMATCHING_CASE);
+									}
 								}
 							}
 						}

--- a/SlevomatCodingStandard/Sniffs/Namespaces/UnusedUsesSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/UnusedUsesSniff.php
@@ -6,6 +6,7 @@ use SlevomatCodingStandard\Helpers\AnnotationHelper;
 use SlevomatCodingStandard\Helpers\NamespaceHelper;
 use SlevomatCodingStandard\Helpers\ReferencedName;
 use SlevomatCodingStandard\Helpers\ReferencedNameHelper;
+use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
 use SlevomatCodingStandard\Helpers\TokenHelper;
 use SlevomatCodingStandard\Helpers\UseStatement;
 use SlevomatCodingStandard\Helpers\UseStatementHelper;
@@ -22,6 +23,9 @@ class UnusedUsesSniff implements \PHP_CodeSniffer\Sniffs\Sniff
 	/** @var string[] */
 	public $ignoredAnnotationNames = [];
 
+	/** @var string[]|null */
+	private $normalizedIgnoredAnnotationNames;
+
 	/**
 	 * @return mixed[]
 	 */
@@ -30,6 +34,18 @@ class UnusedUsesSniff implements \PHP_CodeSniffer\Sniffs\Sniff
 		return [
 			T_OPEN_TAG,
 		];
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private function getIgnoredAnnotationNames(): array
+	{
+		if ($this->normalizedIgnoredAnnotationNames === null) {
+			$this->normalizedIgnoredAnnotationNames = SniffSettingsHelper::normalizeArray($this->ignoredAnnotationNames);
+		}
+
+		return $this->normalizedIgnoredAnnotationNames;
 	}
 
 	/**
@@ -92,7 +108,7 @@ class UnusedUsesSniff implements \PHP_CodeSniffer\Sniffs\Sniff
 
 					foreach ($annotations as $annotationName => $annotationsByName) {
 						if (preg_match('~^@(' . preg_quote($nameAsReferencedInFile, '~') . ')(?=[^a-z\\d]|$)~i', $annotationName, $matches)) {
-							if (!in_array($matches[1], $this->ignoredAnnotationNames, true)) {
+							if (!in_array($matches[1], $this->getIgnoredAnnotationNames(), true)) {
 								$usedNames[$uniqueId] = true;
 
 								if ($matches[1] !== $nameAsReferencedInFile) {

--- a/SlevomatCodingStandard/Sniffs/Namespaces/UnusedUsesSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/UnusedUsesSniff.php
@@ -107,8 +107,8 @@ class UnusedUsesSniff implements \PHP_CodeSniffer\Sniffs\Sniff
 					$uniqueId = UseStatement::getUniqueId($useStatement->getType(), $nameAsReferencedInFile);
 
 					foreach ($annotations as $annotationName => $annotationsByName) {
-						if (preg_match('~^@(' . preg_quote($nameAsReferencedInFile, '~') . ')(?=[^a-z\\d]|$)~i', $annotationName, $matches)) {
-							if (!in_array($matches[1], $this->getIgnoredAnnotationNames(), true)) {
+						if (!in_array(substr($annotationName, 1), $this->getIgnoredAnnotationNames(), true)) {
+							if (preg_match('~^@(' . preg_quote($nameAsReferencedInFile, '~') . ')(?=[^a-z\\d]|$)~i', $annotationName, $matches)) {
 								$usedNames[$uniqueId] = true;
 
 								if ($matches[1] !== $nameAsReferencedInFile) {

--- a/tests/Sniffs/Namespaces/UnusedUsesSniffTest.php
+++ b/tests/Sniffs/Namespaces/UnusedUsesSniffTest.php
@@ -159,32 +159,49 @@ class UnusedUsesSniffTest extends \SlevomatCodingStandard\Sniffs\TestCase
 			'searchAnnotations' => true,
 		], [UnusedUsesSniff::CODE_MISMATCHING_CASE]);
 
-		self::assertSame(6, $report->getErrorCount());
+		self::assertSame(7, $report->getErrorCount());
 
-		self::assertSniffError($report, 9, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "bar" and use statement "Bar" do not match');
-		self::assertSniffError($report, 11, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "BAR" and use statement "Bar" do not match');
-		self::assertSniffError($report, 15, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "bar" and use statement "Bar" do not match');
+		self::assertSniffError($report, 10, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "bar" and use statement "Bar" do not match');
+		self::assertSniffError($report, 12, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "BAR" and use statement "Bar" do not match');
 
-		self::assertSniffError($report, 13, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "boo" and use statement "Boo" do not match');
+		self::assertSniffError($report, 14, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "boo" and use statement "Boo" do not match');
 		self::assertSniffError($report, 15, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "BOO" and use statement "Boo" do not match');
-		self::assertSniffError($report, 18, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "boo" and use statement "Boo" do not match');
+		self::assertSniffError($report, 17, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "boo" and use statement "Boo" do not match');
+
+		self::assertSniffError($report, 59, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "ignore" and use statement "Ignore" do not match');
+
+		self::assertSniffError($report, 59, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "uuid" and use statement "Uuid" do not match');
+	}
+
+	public function testIgnoredAnnotationNamesAreNotUsed(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/caseInsensitiveUse.php', [
+			'searchAnnotations' => true,
+			'ignoredAnnotationNames' => ['ignore'],
+		], [UnusedUsesSniff::CODE_UNUSED_USE]);
+
+		self::assertSame(1, $report->getErrorCount());
+
+		self::assertSniffError($report, 8, UnusedUsesSniff::CODE_UNUSED_USE, 'Type Ignore is not used in this file.');
 	}
 
 	public function testIgnoredAnnotationNames(): void
 	{
 		$report = self::checkFile(__DIR__ . '/data/caseInsensitiveUse.php', [
 			'searchAnnotations' => true,
-			'ignoredAnnotationNames' => ['BOO'],
+			'ignoredAnnotationNames' => ['ignore'],
 		], [UnusedUsesSniff::CODE_MISMATCHING_CASE]);
 
-		self::assertSame(5, $report->getErrorCount());
+		self::assertSame(6, $report->getErrorCount());
 
-		self::assertSniffError($report, 9, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "bar" and use statement "Bar" do not match');
-		self::assertSniffError($report, 11, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "BAR" and use statement "Bar" do not match');
-		self::assertSniffError($report, 15, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "bar" and use statement "Bar" do not match');
+		self::assertSniffError($report, 10, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "bar" and use statement "Bar" do not match');
+		self::assertSniffError($report, 12, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "BAR" and use statement "Bar" do not match');
 
-		self::assertSniffError($report, 13, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "boo" and use statement "Boo" do not match');
-		self::assertSniffError($report, 18, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "boo" and use statement "Boo" do not match');
+		self::assertSniffError($report, 14, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "boo" and use statement "Boo" do not match');
+		self::assertSniffError($report, 15, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "BOO" and use statement "Boo" do not match');
+		self::assertSniffError($report, 17, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "boo" and use statement "Boo" do not match');
+
+		self::assertSniffError($report, 59, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "uuid" and use statement "Uuid" do not match');
 	}
 
 	public function testUsedTrait(): void

--- a/tests/Sniffs/Namespaces/UnusedUsesSniffTest.php
+++ b/tests/Sniffs/Namespaces/UnusedUsesSniffTest.php
@@ -159,14 +159,32 @@ class UnusedUsesSniffTest extends \SlevomatCodingStandard\Sniffs\TestCase
 			'searchAnnotations' => true,
 		], [UnusedUsesSniff::CODE_MISMATCHING_CASE]);
 
+		self::assertSame(6, $report->getErrorCount());
+
+		self::assertSniffError($report, 9, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "bar" and use statement "Bar" do not match');
+		self::assertSniffError($report, 11, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "BAR" and use statement "Bar" do not match');
+		self::assertSniffError($report, 15, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "bar" and use statement "Bar" do not match');
+
+		self::assertSniffError($report, 13, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "boo" and use statement "Boo" do not match');
+		self::assertSniffError($report, 15, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "BOO" and use statement "Boo" do not match');
+		self::assertSniffError($report, 18, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "boo" and use statement "Boo" do not match');
+	}
+
+	public function testIgnoredAnnotationNames(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/caseInsensitiveUse.php', [
+			'searchAnnotations' => true,
+			'ignoredAnnotationNames' => ['BOO'],
+		], [UnusedUsesSniff::CODE_MISMATCHING_CASE]);
+
 		self::assertSame(5, $report->getErrorCount());
 
 		self::assertSniffError($report, 9, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "bar" and use statement "Bar" do not match');
 		self::assertSniffError($report, 11, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "BAR" and use statement "Bar" do not match');
+		self::assertSniffError($report, 15, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "bar" and use statement "Bar" do not match');
 
 		self::assertSniffError($report, 13, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "boo" and use statement "Boo" do not match');
-		self::assertSniffError($report, 14, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "BOO" and use statement "Boo" do not match');
-		self::assertSniffError($report, 16, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "boo" and use statement "Boo" do not match');
+		self::assertSniffError($report, 18, UnusedUsesSniff::CODE_MISMATCHING_CASE, 'Case of reference name "boo" and use statement "Boo" do not match');
 	}
 
 	public function testUsedTrait(): void

--- a/tests/Sniffs/Namespaces/data/caseInsensitiveUse.php
+++ b/tests/Sniffs/Namespaces/data/caseInsensitiveUse.php
@@ -11,7 +11,9 @@ new bar();
 new BAR();
 
 /** @var boo */
-/** @BOO */
+/**
+ * @BOO(foo=bar::class)
+ */
 /**
  * @ORM\OneToMany(targetEntity=boo::class, mappedBy="boo")
  */

--- a/tests/Sniffs/Namespaces/data/caseInsensitiveUse.php
+++ b/tests/Sniffs/Namespaces/data/caseInsensitiveUse.php
@@ -5,15 +5,14 @@ use Foo\Boo;
 use Exception;
 use Uuid;
 use Route;
+use Ignore;
 
 new bar();
 
 new BAR();
 
 /** @var boo */
-/**
- * @BOO(foo=bar::class)
- */
+/** @BOO */
 /**
  * @ORM\OneToMany(targetEntity=boo::class, mappedBy="boo")
  */
@@ -53,4 +52,9 @@ new Route();
 /**
  * @Route("/widget/list", name="widget_list")
  * @Route("/widget/view/{uuid}", name="widget_view")
+ */
+
+
+/**
+ * @ignore(foo=uuid::class)
  */


### PR DESCRIPTION
For more details about the motivations see discussion in #278