### PR TITLE
Add TypeCast sniff

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,12 @@ Sniff provides the following settings:
 
 Enforces using shorthand scalar typehint variants in phpDocs: `int` instead of `integer` and `bool` instead of `boolean`. This is for consistency with native scalar typehints which also allow shorthand variants only.
 
+
+#### SlevomatCodingStandard.PHP.TypeCast 🔧
+
+Enforces using shorthand cast operators, forbids use of unset and binary cast operators: `(bool)` instead of `(boolean)`, `(int)` instead of `(integer)`, `(float)` instead of `(double)` or `(real)`. `(binary)` and `(unset)` are forbidden.
+
+
 #### SlevomatCodingStandard.Files.TypeNameMatchesFileName
 
 For projects not following the [PSR-0](http://www.php-fig.org/psr/psr-0/) or [PSR-4](http://www.php-fig.org/psr/psr-4/) autoloading standards, this sniff checks whether a namespace and a name of a class/interface/trait follows agreed-on way to organize code into directories and files.

--- a/SlevomatCodingStandard/Sniffs/PHP/TypeCastSniff.php
+++ b/SlevomatCodingStandard/Sniffs/PHP/TypeCastSniff.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\PHP;
+
+use SlevomatCodingStandard\Helpers\TokenHelper;
+
+class TypeCastSniff implements \PHP_CodeSniffer\Sniffs\Sniff
+{
+
+	public const CODE_FORBIDDEN_CAST_USED = 'ForbiddenCastUsed';
+	public const CODE_INVALID_CAST_USED = 'InvalidCastUsed';
+
+	private const INVALID_CASTS = [
+		'binary' => null,
+		'boolean' => 'bool',
+		'double' => 'float',
+		'integer' => 'int',
+		'real' => 'float',
+		'unset' => null,
+	];
+
+	/**
+	 * @return mixed[]
+	 */
+	public function register(): array
+	{
+		return [
+			T_STRING_CAST,
+			T_BOOL_CAST,
+			T_DOUBLE_CAST,
+			T_INT_CAST,
+			T_UNSET_CAST,
+		];
+	}
+
+	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile
+	 * @param int $pointer
+	 */
+	public function process(\PHP_CodeSniffer\Files\File $phpcsFile, $pointer): void
+	{
+		$tokens = $phpcsFile->getTokens();
+		$cast = $tokens[$pointer]['content'];
+
+		preg_match('~^\(\s*(\S+)\s*\)\z~i', $cast, $matches);
+
+		$castName = $matches[1];
+		$castNameLower = strtolower($castName);
+
+		if (!array_key_exists($castNameLower, self::INVALID_CASTS)) {
+			return;
+		}
+
+		if ($castNameLower === 'unset') {
+			$phpcsFile->addError(sprintf('Cast "%s" is forbidden, use "unset(...)" or assign "null" instead.', $cast), $pointer, self::CODE_FORBIDDEN_CAST_USED);
+
+			return;
+		}
+
+		if ($castNameLower === 'binary') {
+			$fix = $phpcsFile->addFixableError(sprintf('"Cast "%s" is forbidden and has no effect.', $cast), $pointer, self::CODE_FORBIDDEN_CAST_USED);
+
+			if (!$fix) {
+				return;
+			}
+
+			for ($i = $pointer, $end = TokenHelper::findNextEffective($phpcsFile, $pointer + 1); $i < $end; $i++) {
+				$phpcsFile->fixer->beginChangeset();
+				$phpcsFile->fixer->replaceToken($i, '');
+				$phpcsFile->fixer->endChangeset();
+			}
+
+			return;
+		}
+
+		$fix = $phpcsFile->addFixableError(
+			sprintf('Cast "%s" is forbidden, use "(%s)" instead.', $cast, self::INVALID_CASTS[$castNameLower]),
+			$pointer,
+			self::CODE_INVALID_CAST_USED
+		);
+
+		if (!$fix) {
+			return;
+		}
+
+		$phpcsFile->fixer->beginChangeset();
+		$phpcsFile->fixer->replaceToken($pointer, '(' . self::INVALID_CASTS[$castNameLower] . ')');
+		$phpcsFile->fixer->endChangeset();
+	}
+
+}

--- a/tests/Sniffs/PHP/TypeCastSniffTest.php
+++ b/tests/Sniffs/PHP/TypeCastSniffTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\PHP;
+
+class TypeCastSniffTest extends \SlevomatCodingStandard\Sniffs\TestCase
+{
+
+	public function testNoErrors(): void
+	{
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/typeCastNoErrors.php'));
+	}
+
+	public function testErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/typeCastErrors.php');
+
+		self::assertSame(8, $report->getErrorCount());
+
+		self::assertSniffError($report, 3, TypeCastSniff::CODE_FORBIDDEN_CAST_USED, 'Cast "(unset)" is forbidden, use "unset(...)" or assign "null" instead.');
+		self::assertSniffError($report, 4, TypeCastSniff::CODE_FORBIDDEN_CAST_USED, 'Cast "(binary)" is forbidden and has no effect.');
+
+		self::assertSniffError($report, 6, TypeCastSniff::CODE_INVALID_CAST_USED, 'Cast "(boolean)" is forbidden, use "(bool)" instead.');
+		self::assertSniffError($report, 7, TypeCastSniff::CODE_INVALID_CAST_USED, 'Cast "(double)" is forbidden, use "(float)" instead.');
+		self::assertSniffError($report, 8, TypeCastSniff::CODE_INVALID_CAST_USED, 'Cast "(integer)" is forbidden, use "(int)" instead.');
+		self::assertSniffError($report, 9, TypeCastSniff::CODE_INVALID_CAST_USED, 'Cast "(real)" is forbidden, use "(float)" instead.');
+
+		self::assertSniffError($report, 11, TypeCastSniff::CODE_INVALID_CAST_USED, 'Cast "(DOUBLE)" is forbidden, use "(float)" instead.');
+		self::assertSniffError($report, 12, TypeCastSniff::CODE_INVALID_CAST_USED, 'Cast "( integer )" is forbidden, use "(int)" instead.');
+
+		self::assertAllFixedInFile($report);
+	}
+
+}

--- a/tests/Sniffs/PHP/data/typeCastErrors.fixed.php
+++ b/tests/Sniffs/PHP/data/typeCastErrors.fixed.php
@@ -1,0 +1,12 @@
+<?php
+
+(unset) $foo;
+'abc';
+
+(bool) 123;
+(float) 123;
+(int) '123';
+(float) 123;
+
+(float) 123;
+(int) 123;

--- a/tests/Sniffs/PHP/data/typeCastErrors.php
+++ b/tests/Sniffs/PHP/data/typeCastErrors.php
@@ -1,0 +1,12 @@
+<?php
+
+(unset) $foo;
+(binary) 'abc';
+
+(boolean) 123;
+(double) 123;
+(integer) '123';
+(real) 123;
+
+(DOUBLE) 123;
+( integer ) 123;

--- a/tests/Sniffs/PHP/data/typeCastNoErrors.php
+++ b/tests/Sniffs/PHP/data/typeCastNoErrors.php
@@ -1,0 +1,15 @@
+<?php
+
+(string) 123;
+(bool) 123;
+(int) true;
+(float) 123;
+(array) new stdClass();
+(object) [];
+
+(STRING) 123;
+
+( string) 123;
+(string ) 123;
+( string ) 123;
+


### PR DESCRIPTION
Enforces using shorthand cast operators, forbids use of unset and binary cast operators: `(bool)` instead of `(boolean)`, `(int)` instead of `(integer)`, `(float)` instead of `(double)` or `(real)`. `(binary)` and `(unset)` are forbidden.

Made all fixable except unset, that one is harder and I was a bit lazy to think of all edge cases (also `(unset)` is not functionally equivalent to `unset()` and auto-fix could break things).

Not sure about residing namespace, but it didn't fit into TypeHints namespace where LongTypeHints resides.
Suggestions for better name?