### PR TITLE
Make PSR 12 Compatible Sorting default in AlphabeticallySortedUsesSniff

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Namespaces/AlphabeticallySortedUsesSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/AlphabeticallySortedUsesSniff.php
@@ -13,9 +13,6 @@ class AlphabeticallySortedUsesSniff implements \PHP_CodeSniffer\Sniffs\Sniff
 	public const CODE_INCORRECT_ORDER = 'IncorrectlyOrderedUses';
 
 	/** @var bool */
-	public $psr12Compatible = false;
-
-	/** @var bool */
 	public $caseSensitive = false;
 
 	/** @var \SlevomatCodingStandard\Helpers\UseStatement|null */
@@ -107,8 +104,8 @@ class AlphabeticallySortedUsesSniff implements \PHP_CodeSniffer\Sniffs\Sniff
 		if (!$a->hasSameType($b)) {
 			$order = [
 				UseStatement::TYPE_DEFAULT => 1,
-				UseStatement::TYPE_FUNCTION => $this->psr12Compatible ? 2 : 3,
-				UseStatement::TYPE_CONSTANT => $this->psr12Compatible ? 3 : 2,
+				UseStatement::TYPE_FUNCTION => 2,
+				UseStatement::TYPE_CONSTANT => 3,
 			];
 
 			return $order[$a->getType()] <=> $order[$b->getType()];


### PR DESCRIPTION
New IDEA 2018.1 seems to sort it in PSR 12 compatible way. I believe it's the same with PHPStorm.

Let's make it default