### PR TITLE
Disable caching before runing fixer

### DIFF
--- a/SlevomatCodingStandard/Sniffs/TestCase.php
+++ b/SlevomatCodingStandard/Sniffs/TestCase.php
@@ -104,6 +104,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
 	protected function assertAllFixedInFile(\PHP_CodeSniffer\Files\File $codeSnifferFile): void
 	{
+		$codeSnifferFile->disableCaching();
 		$codeSnifferFile->fixer->fixFile();
 		self::assertStringEqualsFile(preg_replace('~(\\.php)$~', '.fixed\\1', $codeSnifferFile->getFilename()), $codeSnifferFile->fixer->getContents());
 	}


### PR DESCRIPTION
The tests that are focused on fixer won't work if you have something like `<arg name="cache" value=".phpcs-cache"/>` in your ruleset.