### PR TITLE
Failing test for UnusedUsesSniff

### DIFF
--- a/tests/Sniffs/Namespaces/UnusedUsesSniffTest.php
+++ b/tests/Sniffs/Namespaces/UnusedUsesSniffTest.php
@@ -108,7 +108,7 @@ class UnusedUsesSniffTest extends \SlevomatCodingStandard\Sniffs\TestCase
 			'searchAnnotations' => false,
 		]);
 
-		self::assertSame(30, $report->getErrorCount());
+		self::assertSame(32, $report->getErrorCount());
 
 		self::assertSniffError($report, 5, UnusedUsesSniff::CODE_UNUSED_USE, 'Type Assert is not used in this file.');
 		self::assertSniffError($report, 6, UnusedUsesSniff::CODE_UNUSED_USE, 'Type Doctrine\ORM\Mapping (as ORM) is not used in this file.');
@@ -139,6 +139,8 @@ class UnusedUsesSniffTest extends \SlevomatCodingStandard\Sniffs\TestCase
 		self::assertSniffError($report, 32, UnusedUsesSniff::CODE_UNUSED_USE, 'Type MethodParameter2 is not used in this file.');
 		self::assertSniffError($report, 33, UnusedUsesSniff::CODE_UNUSED_USE, 'Type MethodParameter3 is not used in this file.');
 		self::assertSniffError($report, 34, UnusedUsesSniff::CODE_UNUSED_USE, 'Type MethodParameter4 is not used in this file.');
+		self::assertSniffError($report, 35, UnusedUsesSniff::CODE_UNUSED_USE, 'Type Discriminator\Lorem is not used in this file.');
+		self::assertSniffError($report, 36, UnusedUsesSniff::CODE_UNUSED_USE, 'Type Discriminator\Ipsum is not used in this file.');
 	}
 
 	public function testUsedUseInAnnotationWithEnabledSearchAnnotations(): void

--- a/tests/Sniffs/Namespaces/data/unusedUsesInAnnotation.php
+++ b/tests/Sniffs/Namespaces/data/unusedUsesInAnnotation.php
@@ -32,9 +32,15 @@ use MethodParameter1;
 use MethodParameter2;
 use MethodParameter3;
 use MethodParameter4;
+use Discriminator\Lorem;
+use Discriminator\Ipsum;
 
 /**
  * @ORM\Entity()
+ * @ORM\DiscriminatorMap({
+ *     "lorem" = Lorem::class,
+ *     "ipsum" = Ipsum::class,
+ * })
  */
 class Boo
 {


### PR DESCRIPTION
`UnusedUsesSniff` with `searchAnnotations` enabled reports false positive for the following doctrine entity annotation:

```
 * @ORM\DiscriminatorMap({
 *     "lorem" = Lorem::class,
 *     "ipsum" = Ipsum::class,
 * })
```