### PR TITLE
Fixes some more false-positives for UnusedUsesSniff

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Namespaces/UnusedUsesSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/UnusedUsesSniff.php
@@ -206,7 +206,12 @@ class UnusedUsesSniff implements \PHP_CodeSniffer\Sniffs\Sniff
 							}
 
 							foreach ($contentsToCheck as $contentToCheck) {
-								if (!preg_match('~(?<=^|\|)(' . preg_quote($nameAsReferencedInFile, '~') . ')(?=\\s|\\\\|\||\[|$)~i', $contentToCheck, $matches)) {
+								$openers = ['|', '{', '(', ',', '<', ':'];
+								$openers = array_map('preg_quote', $openers, array_fill(0, count($openers), '~'));
+								$closers = ['\\', '|', '[', ',', '<', '>', '(' , ')', '{', '}', ':'];
+								$closers = array_map('preg_quote', $closers, array_fill(0, count($closers), '~'));
+								$regex = '~(?<=^|' . join('|', $openers) . ')(' . preg_quote($nameAsReferencedInFile, '~') . ')(?=\\s|' . join('|', $closers) . '|$)~i';
+								if (!preg_match($regex, $contentToCheck, $matches)) {
 									continue;
 								}
 

--- a/tests/Sniffs/Namespaces/UnusedUsesSniffTest.php
+++ b/tests/Sniffs/Namespaces/UnusedUsesSniffTest.php
@@ -108,7 +108,7 @@ class UnusedUsesSniffTest extends \SlevomatCodingStandard\Sniffs\TestCase
 			'searchAnnotations' => false,
 		]);
 
-		self::assertSame(36, $report->getErrorCount());
+		self::assertSame(40, $report->getErrorCount());
 
 		self::assertSniffError($report, 5, UnusedUsesSniff::CODE_UNUSED_USE, 'Type Assert is not used in this file.');
 		self::assertSniffError($report, 6, UnusedUsesSniff::CODE_UNUSED_USE, 'Type Doctrine\ORM\Mapping (as ORM) is not used in this file.');
@@ -145,6 +145,10 @@ class UnusedUsesSniffTest extends \SlevomatCodingStandard\Sniffs\TestCase
 		self::assertSniffError($report, 38, UnusedUsesSniff::CODE_UNUSED_USE, 'Type Inner1 is not used in this file.');
 		self::assertSniffError($report, 39, UnusedUsesSniff::CODE_UNUSED_USE, 'Type Inner2 is not used in this file.');
 		self::assertSniffError($report, 40, UnusedUsesSniff::CODE_UNUSED_USE, 'Type Inner3 is not used in this file.');
+		self::assertSniffError($report, 42, UnusedUsesSniff::CODE_UNUSED_USE, 'Type Closure is not used in this file.');
+		self::assertSniffError($report, 43, UnusedUsesSniff::CODE_UNUSED_USE, 'Type Generator is not used in this file.');
+		self::assertSniffError($report, 44, UnusedUsesSniff::CODE_UNUSED_USE, 'Type Traversable is not used in this file.');
+		self::assertSniffError($report, 45, UnusedUsesSniff::CODE_UNUSED_USE, 'Type Exception is not used in this file.');
 	}
 
 	public function testUsedUseInAnnotationWithEnabledSearchAnnotations(): void
@@ -246,6 +250,17 @@ class UnusedUsesSniffTest extends \SlevomatCodingStandard\Sniffs\TestCase
 	{
 		$report = self::checkFile(__DIR__ . '/data/fixableUnusedUses.php', [], [UnusedUsesSniff::CODE_UNUSED_USE]);
 		self::assertAllFixedInFile($report);
+	}
+
+	public function testUsedGeneric(): void
+	{
+		// tests for PSR-5 collection syntax and psalm-specific generics and shapes
+		$report = self::checkFile(__DIR__ . '/data/unusedUsesInAnnotation.php', [
+			'searchAnnotations' => true,
+			'ignoredAnnotationNames' => ['@ignore'],
+			'ignoredAnnotations' => ['@group'],
+		]);
+		self::assertSame(1, $report->getErrorCount());
 	}
 
 }

--- a/tests/Sniffs/Namespaces/data/unusedUsesInAnnotation.php
+++ b/tests/Sniffs/Namespaces/data/unusedUsesInAnnotation.php
@@ -39,6 +39,12 @@ use Inner1;
 use Inner2;
 use Inner3;
 
+use Closure;
+use Generator;
+use Traversable;
+use Exception;
+
+
 /**
  * @ORM\Entity()
  * @ORM\DiscriminatorMap({
@@ -135,4 +141,51 @@ class Foo
 		return null;
 	}
 
+}
+
+/**
+ * Templates are used by Psalm and Phan
+ *
+ * @template TKey
+ * @template TValue
+ * @template-extends Traversable<TKey,TValue>
+ */
+class Generic
+{
+    /**
+     * @var array<TKey,TValue> PSR-5 collection
+     */
+    private $data;
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * @return Generator<TKey,TValue> generic/collection syntax
+     */
+    public function traverse()
+    {
+        foreach ($this->data as $key => $val) {
+            yield $key => $val;
+        }
+    }
+
+    /**
+     * @template T
+     * @param Closure(TValue):T $callable callable syntax
+     * @return Generic<TKey,T>
+     */
+    public function map($callable): self
+    {
+        return new self(array_map($callable, $this->data));
+    }
+
+    /**
+     * @psalm-return array{0:Exception,1:Exception} actually invalid
+     */
+    public function returnsArrayOfExceptions(): array
+    {
+        return [new stdClass, new stdClass];
+    }
 }


### PR DESCRIPTION
- Collection syntax (PSR-5): `Traversable<int,string>`
- Generics (psalm,phan): `Decorator<Classname>`
- Shapes (psalm): `@return array{length:int,data:string}`

Additionally, now corresponding regexp is built dynamically to make it
easier to extend.