### PR TITLE
Fix `ModernClassNameReferenceSniff` reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Commas after last element in an array make adding a new element easier and resul
 
 This sniff enforces trailing commas in multi-line arrays and requires short array syntax `[]`.
 
-#### SlevomatCodingStandard.Classes.ModernClassNameReferenceSniff 🔧
+#### SlevomatCodingStandard.Classes.ModernClassNameReference 🔧
 
 Reports use of `__CLASS__`, `get_parent_class()`, `get_called_class()`, `get_class()` and `get_class($this)`.
 Class names should be referenced via `::class` contant when possible. 


### PR DESCRIPTION
In the readme the `ModernClassNameReference` sniff has accidentally included `Sniff` at the end.