### PR TITLE
Correct false statement about PHPStorm sniff compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ use LogStandard;
 Sniff provides the following settings:
 
 
-* `psr12Compatible`: sets the required order to `classes`, `functions` and `constants`. Default is PHPStorm compatible: `classes`, `constants` and `functions`.
+* `psr12Compatible`: sets the required order to `classes`, `functions` and `constants`. Default is: `classes`, `constants` and `functions`.
 * `caseSensitive`: compare namespaces case sensitively, which makes this order correct:
 
 ```php


### PR DESCRIPTION
The statement in README is no longer true

Related isssues:

https://github.com/slevomat/coding-standard/pull/326
https://github.com/slevomat/coding-standard/issues/346