### PR TITLE
Fix README for TypeHintDeclarationSniff

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Sniff provides the following settings:
 * **DEPRECATED** `enableVoidTypeHint`: enforces to transform `@return void` into native `void` return typehint.
 * `enableObjectTypeHint`: enforces to transform `@param object` or `@return object` into native `object` typehint. It's on by default if you're on PHP 7.2+
 * `traversableTypeHints`: enforces which typehints must have specified contained type. E. g. if you set this to `\Doctrine\Common\Collections\Collection`, then `\Doctrine\Common\Collections\Collection` must always be supplied with the contained type: `\Doctrine\Common\Collections\Collection|Foo[]`.
-* **DEPRECATED** `usefulAnnotations`: prevents reporting and removing useless phpDocs if they contain an additional configured annotation like `@dataProvider`.
+* `usefulAnnotations`: prevents reporting and removing useless phpDocs if they contain an additional configured annotation like `@dataProvider`.
 * `allAnnotationsAreUseful`: phpDoc is useful if it contain any annotation.
 * `enableEachParameterAndReturnInspection`: enables inspection and fixing of `@param` and `@return` annotations separately. Useful when you only want to document parameters or return values that could not be expressed natively (i.e. member types of `array` or `Traversable`).
 


### PR DESCRIPTION
usefulAnnotations property is not deprecated.