### PR TITLE
Fix ControlStructureSpacingSniff for cases when a control structure is at the very end of a file

### DIFF
--- a/SlevomatCodingStandard/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
@@ -328,7 +328,7 @@ class ControlStructureSpacingSniff implements Sniff
 			do {
 				$nextPointer = TokenHelper::findNextEffective($phpcsFile, $controlStructureEndPointer + 1);
 
-				if (!in_array($tokens[$nextPointer]['code'], [T_CATCH, T_FINALLY], true)) {
+				if (!isset($tokens[$nextPointer]) || !in_array($tokens[$nextPointer]['code'], [T_CATCH, T_FINALLY], true)) {
 					return $controlStructureEndPointer;
 				}
 


### PR DESCRIPTION
This one-liner is to fix a PHPCS ``Internal.Exception`` generated by ``ControlStructureSpacingSniff`` for a file like this:

    <?php
    
    try {
      true;
    }
    catch (\Exception $exception) {
    }

The PHPCS error is:

    An error occurred during processing; checking has been aborted. The error message was: Undefined index: in .../vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/ControlStructures/ControlStructureSpacingSniff.php on line 331 (Internal.Exception)

The issue is the ``try-catch`` construct being the last one in the file.