### PR TITLE
Fixed recognizing reference names as these could contain spaces

### DIFF
--- a/SlevomatCodingStandard/Helpers/ReferencedNameHelper.php
+++ b/SlevomatCodingStandard/Helpers/ReferencedNameHelper.php
@@ -3,6 +3,7 @@
 namespace SlevomatCodingStandard\Helpers;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 use const T_ANON_CLASS;
 use const T_ARRAY;
 use const T_AS;
@@ -190,7 +191,7 @@ class ReferencedNameHelper
 
 	public static function getReferencedNameEndPointer(File $phpcsFile, int $startPointer): int
 	{
-		$pointerAfterEndPointer = TokenHelper::findNextExcluding($phpcsFile, array_merge([T_RETURN_TYPE], TokenHelper::$nameTokenCodes), $startPointer + 1);
+		$pointerAfterEndPointer = TokenHelper::findNextExcluding($phpcsFile, array_merge([T_RETURN_TYPE], TokenHelper::$nameTokenCodes, Tokens::$emptyTokens), $startPointer + 1);
 		return $pointerAfterEndPointer === null ? $startPointer : $pointerAfterEndPointer - 1;
 	}
 


### PR DESCRIPTION
We can have namespace with spaces in PHP. This is completely valid code with spaces around namespace separator:

```php
namespace Hello \ World;

use MyName\ Space;

class Hey extends \ Other \ ParentClass
{
    use MyTraits
        \Aware;
}
```

etc.

Recognising references with spaces doesn't work correctly now which causes some issues where using with other sniffs. We are getting imported wrong class in first iteration I've seen something like `use ;` (without class name) - what is invalid code and breaks other sniffs in the iteration.
