### PR TITLE
Update to PHPCS 3.4 and fix BC Changes

### DIFF
--- a/SlevomatCodingStandard/Sniffs/PHP/TypeCastSniff.php
+++ b/SlevomatCodingStandard/Sniffs/PHP/TypeCastSniff.php
@@ -5,6 +5,7 @@ namespace SlevomatCodingStandard\Sniffs\PHP;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use SlevomatCodingStandard\Helpers\TokenHelper;
+use const T_BINARY_CAST;
 use const T_BOOL_CAST;
 use const T_DOUBLE_CAST;
 use const T_INT_CAST;
@@ -41,6 +42,7 @@ class TypeCastSniff implements Sniff
 			T_DOUBLE_CAST,
 			T_INT_CAST,
 			T_UNSET_CAST,
+			T_BINARY_CAST,
 		];
 	}
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 	},
 	"require": {
 		"php": "^7.1",
-		"squizlabs/php_codesniffer": "^3.3.1"
+		"squizlabs/php_codesniffer": "^3.4.0"
 	},
 	"require-dev": {
 		"jakub-onderka/php-parallel-lint": "1.0.0",


### PR DESCRIPTION
From the [changelog](https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.4.0):
> All types of binary casting are now tokenzied as T_BINARY_CAST