### PR TITLE
Specifically mentions docblocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Looks for unused imports from other namespaces.
 
 Sniff provides the following settings:
 
-* `searchAnnotations` (defaults to `false`): enables searching for mentions in annotations, which is especially useful for projects using [Doctrine Annotations](https://github.com/doctrine/annotations)
+* `searchAnnotations` (defaults to `false`): enables searching for mentions in annotations and docblocks, which is especially useful for projects using [Doctrine Annotations](https://github.com/doctrine/annotations)
 * `ignoredAnnotationNames`: case sensitive list of annotation names that the sniff should ignore (only the name is ignored, annotation content is still searched). Useful for name collisions like `@testCase` annotation and `TestCase` class.
 * `ignoredAnnotations`: case sensitive list of annotation names that the sniff ignore completely (both name and content are ignored). Useful for name collisions like `@group Cache` annotation and `Cache` class.
 


### PR DESCRIPTION
The description for `UnusedUses`->`searchAnnotations` specifically mentions docblocks for those not using Doctrine