### PR TITLE
ReferenceUsedNamesOnlySniff: Check @method annotations

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Namespaces/ReferenceUsedNamesOnlySniff.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/ReferenceUsedNamesOnlySniff.php
@@ -522,7 +522,7 @@ class ReferenceUsedNamesOnlySniff implements Sniff
 			$annotations = AnnotationHelper::getAnnotations($phpcsFile, $docCommentOpenPointer);
 
 			foreach ($annotations as $annotationName => $annotationsByName) {
-				if (!in_array($annotationName, ['@var', '@param', '@return', '@throws', '@property', '@property-read', '@property-write'], true)) {
+				if (!in_array($annotationName, ['@var', '@param', '@return', '@throws', '@property', '@property-read', '@property-write', '@method'], true)) {
 					continue;
 				}
 

--- a/tests/Sniffs/Namespaces/ReferenceUsedNamesOnlySniffTest.php
+++ b/tests/Sniffs/Namespaces/ReferenceUsedNamesOnlySniffTest.php
@@ -882,18 +882,19 @@ class ReferenceUsedNamesOnlySniffTest extends TestCase
 			]
 		);
 
-		self::assertSame(9, $report->getErrorCount());
+		self::assertSame(10, $report->getErrorCount());
 
-		self::assertSniffError($report, 10, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME, 'Class \Foo\DateTime should not be referenced via a fully qualified name, but via a use statement.');
-		self::assertSniffError($report, 14, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME, 'Class \Foo\DateTime should not be referenced via a fully qualified name, but via a use statement.');
-		self::assertSniffError($report, 29, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME, 'Class \Foo\ArrayObject should not be referenced via a fully qualified name, but via a use statement.');
-		self::assertSniffError($report, 31, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME, 'Class \Foo\Something should not be referenced via a fully qualified name, but via a use statement.');
-		self::assertSniffError($report, 32, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME, 'Class \Foo\Exception should not be referenced via a fully qualified name, but via a use statement.');
-		self::assertSniffError($report, 36, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME, 'Class \Foo\Traversable should not be referenced via a fully qualified name, but via a use statement.');
-		self::assertSniffError($report, 42, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME, 'Class \Foo\Something should not be referenced via a fully qualified name, but via a use statement.');
-		self::assertSniffError($report, 49, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME, 'Class \Foo\Something should not be referenced via a fully qualified name, but via a use statement.');
+		self::assertSniffError($report, 8, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME, 'Class \Foo\DateTime should not be referenced via a fully qualified name, but via a use statement.');
+		self::assertSniffError($report, 13, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME, 'Class \Foo\DateTime should not be referenced via a fully qualified name, but via a use statement.');
+		self::assertSniffError($report, 17, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME, 'Class \Foo\DateTime should not be referenced via a fully qualified name, but via a use statement.');
+		self::assertSniffError($report, 32, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME, 'Class \Foo\ArrayObject should not be referenced via a fully qualified name, but via a use statement.');
+		self::assertSniffError($report, 34, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME, 'Class \Foo\Something should not be referenced via a fully qualified name, but via a use statement.');
+		self::assertSniffError($report, 35, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME, 'Class \Foo\Exception should not be referenced via a fully qualified name, but via a use statement.');
+		self::assertSniffError($report, 39, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME, 'Class \Foo\Traversable should not be referenced via a fully qualified name, but via a use statement.');
+		self::assertSniffError($report, 45, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME, 'Class \Foo\Something should not be referenced via a fully qualified name, but via a use statement.');
+		self::assertSniffError($report, 52, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME, 'Class \Foo\Something should not be referenced via a fully qualified name, but via a use statement.');
 
-		self::assertSniffError($report, 38, ReferenceUsedNamesOnlySniff::CODE_PARTIAL_USE);
+		self::assertSniffError($report, 41, ReferenceUsedNamesOnlySniff::CODE_PARTIAL_USE);
 
 		self::assertAllFixedInFile($report);
 	}

--- a/tests/Sniffs/Namespaces/data/shouldBeInUseStatementSearchingInAnnotations.fixed.php
+++ b/tests/Sniffs/Namespaces/data/shouldBeInUseStatementSearchingInAnnotations.fixed.php
@@ -8,6 +8,9 @@ use Foo\ArrayObject;
 use Foo\Exception;
 use Foo\Traversable;
 
+/**
+ * @method \DateTimeImmutable|int|DateTime getProperty()
+ */
 abstract class Bar
 {
 

--- a/tests/Sniffs/Namespaces/data/shouldBeInUseStatementSearchingInAnnotations.php
+++ b/tests/Sniffs/Namespaces/data/shouldBeInUseStatementSearchingInAnnotations.php
@@ -4,6 +4,9 @@ namespace Foo\Test\Bla;
 
 use Foo\Something;
 
+/**
+ * @method \DateTimeImmutable|int|\Foo\DateTime getProperty()
+ */
 abstract class Bar
 {
 


### PR DESCRIPTION
Hello,

rule `SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly` does not check `@method` annotations when `searchAnnotations` option is set. So codebase still contains FQN in this annotation despite the coding standard forbids that.

This PR adds `@method` annotation to the list of checked ones.
