### PR TITLE
Add test case for invalid useless variable report

### DIFF
--- a/tests/Sniffs/Variables/data/uselessVariableNoErrors.php
+++ b/tests/Sniffs/Variables/data/uselessVariableNoErrors.php
@@ -133,3 +133,16 @@ function assigmentInCondition() {
 	}
 
 }
+
+class Foo
+{
+    protected static $bar = [];
+
+    public static function popBar() : array
+    {
+        $bar = self::$bar;
+        self::$bar = [];
+
+        return $bar;
+    }
+}


### PR DESCRIPTION
`UselessVariableSniff` incorrectly reports that a variable is useless there. If you change the name of either the static variable or the local one, the sniffs reports no errors.