### PR TITLE
Follow type hint when converting to generics syntax

### DIFF
--- a/tests/Sniffs/TypeHints/DisallowArrayTypeHintSyntaxSniffTest.php
+++ b/tests/Sniffs/TypeHints/DisallowArrayTypeHintSyntaxSniffTest.php
@@ -21,7 +21,7 @@ class DisallowArrayTypeHintSyntaxSniffTest extends TestCase
 			],
 		]);
 
-		self::assertSame(17, $report->getErrorCount());
+		self::assertSame(21, $report->getErrorCount());
 
 		self::assertSniffError($report, 6, DisallowArrayTypeHintSyntaxSniff::CODE_DISALLOWED_ARRAY_TYPE_HINT_SYNTAX, 'Usage of array type hint syntax in "\DateTimeImmutable[]" is disallowed, use generic type hint syntax instead.');
 		self::assertSniffError($report, 7, DisallowArrayTypeHintSyntaxSniff::CODE_DISALLOWED_ARRAY_TYPE_HINT_SYNTAX, 'Usage of array type hint syntax in "bool[]" is disallowed, use generic type hint syntax instead.');
@@ -40,6 +40,10 @@ class DisallowArrayTypeHintSyntaxSniffTest extends TestCase
 		self::assertSniffError($report, 36, DisallowArrayTypeHintSyntaxSniff::CODE_DISALLOWED_ARRAY_TYPE_HINT_SYNTAX, 'Usage of array type hint syntax in "int[]" is disallowed, use generic type hint syntax instead.');
 		self::assertSniffError($report, 39, DisallowArrayTypeHintSyntaxSniff::CODE_DISALLOWED_ARRAY_TYPE_HINT_SYNTAX, 'Usage of array type hint syntax in "string[]" is disallowed, use generic type hint syntax instead.');
 		self::assertSniffError($report, 42, DisallowArrayTypeHintSyntaxSniff::CODE_DISALLOWED_ARRAY_TYPE_HINT_SYNTAX, 'Usage of array type hint syntax in "int[]" is disallowed, use generic type hint syntax instead.');
+		self::assertSniffError($report, 45, DisallowArrayTypeHintSyntaxSniff::CODE_DISALLOWED_ARRAY_TYPE_HINT_SYNTAX, 'Usage of array type hint syntax in "string[][]" is disallowed, use generic type hint syntax instead.');
+		self::assertSniffError($report, 49, DisallowArrayTypeHintSyntaxSniff::CODE_DISALLOWED_ARRAY_TYPE_HINT_SYNTAX, 'Usage of array type hint syntax in "string[][]" is disallowed, use generic type hint syntax instead.');
+		self::assertSniffError($report, 53, DisallowArrayTypeHintSyntaxSniff::CODE_DISALLOWED_ARRAY_TYPE_HINT_SYNTAX, 'Usage of array type hint syntax in "string[][]" is disallowed, use generic type hint syntax instead.');
+		self::assertSniffError($report, 57, DisallowArrayTypeHintSyntaxSniff::CODE_DISALLOWED_ARRAY_TYPE_HINT_SYNTAX, 'Usage of array type hint syntax in "string[][]" is disallowed, use generic type hint syntax instead.');
 
 		self::assertAllFixedInFile($report);
 	}

--- a/tests/Sniffs/TypeHints/data/disallowArrayTypeHintSyntaxErrors.fixed.php
+++ b/tests/Sniffs/TypeHints/data/disallowArrayTypeHintSyntaxErrors.fixed.php
@@ -42,4 +42,20 @@ class Whatever
 	/** @var array<int>|string */
 	public $k;
 
+	/** @return iterable<array<string>> */
+	public function l() : iterable {
+	}
+
+	/** @param iterable<array<string>> $n */
+	public function m(iterable $n) {
+	}
+
+	/** @return \ArrayObject<array<string>> */
+	public function o() : ArrayObject {
+	}
+
+	/** @param \ArrayObject<array<string>> $p */
+	public function p(ArrayObject $q) {
+	}
+
 }

--- a/tests/Sniffs/TypeHints/data/disallowArrayTypeHintSyntaxErrors.php
+++ b/tests/Sniffs/TypeHints/data/disallowArrayTypeHintSyntaxErrors.php
@@ -42,4 +42,20 @@ class Whatever
 	/** @var int[]|string */
 	public $k;
 
+	/** @return string[][] */
+	public function l() : iterable {
+	}
+
+	/** @param string[][] $n */
+	public function m(iterable $n) {
+	}
+
+	/** @return string[][]|\ArrayObject */
+	public function o() : ArrayObject {
+	}
+
+	/** @param string[][]|\ArrayObject $p */
+	public function p(ArrayObject $q) {
+	}
+
 }


### PR DESCRIPTION
Thanks for the work implementing generics. 🎉

Found a bug try it out in https://github.com/libero/php-coding-standard/pull/40: argument/return type hints aren't used, so it always becomes `array` rather than `iterable`, `ArrayObject` etc.