### PR TITLE
Don't throw exceptions when something isn't supported

### DIFF
--- a/SlevomatCodingStandard/Sniffs/ControlStructures/EarlyExitSniff.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/EarlyExitSniff.php
@@ -2,7 +2,6 @@
 
 namespace SlevomatCodingStandard\Sniffs\ControlStructures;
 
-use Exception;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use SlevomatCodingStandard\Helpers\ConditionHelper;
@@ -82,10 +81,14 @@ class EarlyExitSniff implements Sniff
 		$tokens = $phpcsFile->getTokens();
 
 		if (!array_key_exists('scope_opener', $tokens[$elsePointer])) {
-			throw new Exception('"else" without curly braces is not supported.');
+			return; // "else" without curly braces is not supported
 		}
 
 		$allConditionsPointers = $this->getAllConditionsPointers($phpcsFile, $elsePointer);
+
+		if ($allConditionsPointers === null) {
+			return;
+		}
 
 		$ifPointer = $allConditionsPointers[0];
 		$ifEarlyExitPointer = null;
@@ -206,6 +209,10 @@ class EarlyExitSniff implements Sniff
 
 		$allConditionsPointers = $this->getAllConditionsPointers($phpcsFile, $elseIfPointer);
 
+		if ($allConditionsPointers === null) {
+			return;
+		}
+
 		foreach ($allConditionsPointers as $conditionPointer) {
 			if ($elseIfPointer === $conditionPointer) {
 				break;
@@ -248,7 +255,7 @@ class EarlyExitSniff implements Sniff
 		$tokens = $phpcsFile->getTokens();
 
 		if (!array_key_exists('scope_closer', $tokens[$ifPointer])) {
-			throw new Exception('"if" without curly braces is not supported.');
+			return; // "if" without curly braces is not supported
 		}
 
 		$nextPointer = TokenHelper::findNextExcluding($phpcsFile, T_WHITESPACE, $tokens[$ifPointer]['scope_closer'] + 1);
@@ -391,7 +398,7 @@ class EarlyExitSniff implements Sniff
 	 * @param int $conditionPointer
 	 * @return int[]
 	 */
-	private function getAllConditionsPointers(File $phpcsFile, int $conditionPointer): array
+	private function getAllConditionsPointers(File $phpcsFile, int $conditionPointer): ?array
 	{
 		$tokens = $phpcsFile->getTokens();
 
@@ -409,7 +416,7 @@ class EarlyExitSniff implements Sniff
 
 		if ($tokens[$conditionPointer]['code'] !== T_ELSE) {
 			if (!array_key_exists('scope_closer', $tokens[$conditionPointer])) {
-				throw new Exception(sprintf('"%s" without curly braces is not supported.', $tokens[$conditionPointer]['content']));
+				return null; // "%s" without curly braces is not supported
 			}
 
 			$currentConditionPointer = TokenHelper::findNextEffective($phpcsFile, $tokens[$conditionPointer]['scope_closer'] + 1);

--- a/SlevomatCodingStandard/Sniffs/ControlStructures/RequireTernaryOperatorSniff.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/RequireTernaryOperatorSniff.php
@@ -2,7 +2,6 @@
 
 namespace SlevomatCodingStandard\Sniffs\ControlStructures;
 
-use Exception;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use SlevomatCodingStandard\Helpers\IdentificatorHelper;
@@ -45,7 +44,7 @@ class RequireTernaryOperatorSniff implements Sniff
 		$tokens = $phpcsFile->getTokens();
 
 		if (!array_key_exists('scope_closer', $tokens[$ifPointer])) {
-			throw new Exception('"if" without curly braces is not supported.');
+			return; // "if" without curly braces is not supported
 		}
 
 		$elsePointer = TokenHelper::findNextEffective($phpcsFile, $tokens[$ifPointer]['scope_closer'] + 1);
@@ -54,7 +53,7 @@ class RequireTernaryOperatorSniff implements Sniff
 		}
 
 		if (!array_key_exists('scope_closer', $tokens[$elsePointer])) {
-			throw new Exception('"else" without curly braces is not supported.');
+			return; // "else" without curly braces is not supported
 		}
 
 		if (

--- a/SlevomatCodingStandard/Sniffs/ControlStructures/UselessIfConditionWithReturnSniff.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/UselessIfConditionWithReturnSniff.php
@@ -2,7 +2,6 @@
 
 namespace SlevomatCodingStandard\Sniffs\ControlStructures;
 
-use Exception;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use SlevomatCodingStandard\Helpers\ConditionHelper;
@@ -46,7 +45,7 @@ class UselessIfConditionWithReturnSniff implements Sniff
 		$tokens = $phpcsFile->getTokens();
 
 		if (!array_key_exists('scope_closer', $tokens[$ifPointer])) {
-			throw new Exception('"if" without curly braces is not supported.');
+			return; // "if" without curly braces is not supported
 		}
 
 		$ifBooleanPointer = $this->findBooleanAfterReturnInScope($phpcsFile, $tokens[$ifPointer]['scope_opener']);
@@ -81,7 +80,7 @@ class UselessIfConditionWithReturnSniff implements Sniff
 			&& $tokens[$elsePointer]['code'] === T_ELSE
 		) {
 			if (!array_key_exists('scope_closer', $tokens[$elsePointer])) {
-				throw new Exception('"else" without curly braces is not supported.');
+				return; // "else" without curly braces is not supported
 			}
 
 			$elseBooleanPointer = $this->findBooleanAfterReturnInScope($phpcsFile, $tokens[$elsePointer]['scope_opener']);

--- a/tests/Sniffs/ControlStructures/ControlStructureSpacingSniffTest.php
+++ b/tests/Sniffs/ControlStructures/ControlStructureSpacingSniffTest.php
@@ -4,7 +4,6 @@ namespace SlevomatCodingStandard\Sniffs\ControlStructures;
 
 use SlevomatCodingStandard\Sniffs\Namespaces\UndefinedKeywordTokenException;
 use SlevomatCodingStandard\Sniffs\TestCase;
-use Throwable;
 
 class ControlStructureSpacingSniffTest extends TestCase
 {
@@ -164,16 +163,14 @@ class ControlStructureSpacingSniffTest extends TestCase
 
 	public function testIfWithoutCurlyBraces(): void
 	{
-		self::expectException(Throwable::class);
-		self::expectExceptionMessage('"if" without curly braces is not supported.');
-		self::checkFile(__DIR__ . '/data/controlStructureSpacingIfWithoutCurlyBraces.php');
+		$report = self::checkFile(__DIR__ . '/data/controlStructureSpacingIfWithoutCurlyBraces.php');
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testElseWithoutCurlyBraces(): void
 	{
-		self::expectException(Throwable::class);
-		self::expectExceptionMessage('"else" without curly braces is not supported.');
-		self::checkFile(__DIR__ . '/data/controlStructureSpacingElseWithoutCurlyBraces.php');
+		$report = self::checkFile(__DIR__ . '/data/controlStructureSpacingElseWithoutCurlyBraces.php');
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testAtTheEndOfFile(): void

--- a/tests/Sniffs/ControlStructures/EarlyExitSniffTest.php
+++ b/tests/Sniffs/ControlStructures/EarlyExitSniffTest.php
@@ -3,7 +3,6 @@
 namespace SlevomatCodingStandard\Sniffs\ControlStructures;
 
 use SlevomatCodingStandard\Sniffs\TestCase;
-use Throwable;
 
 class EarlyExitSniffTest extends TestCase
 {
@@ -41,30 +40,26 @@ class EarlyExitSniffTest extends TestCase
 
 	public function testIfWithoutCurlyBraces(): void
 	{
-		self::expectException(Throwable::class);
-		self::expectExceptionMessage('"if" without curly braces is not supported.');
-		self::checkFile(__DIR__ . '/data/earlyExitIfWithoutCurlyBraces.php', [], [EarlyExitSniff::CODE_EARLY_EXIT_NOT_USED]);
+		$report = self::checkFile(__DIR__ . '/data/earlyExitIfWithoutCurlyBraces.php', [], [EarlyExitSniff::CODE_EARLY_EXIT_NOT_USED]);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testElseifWithoutCurlyBraces(): void
 	{
-		self::expectException(Throwable::class);
-		self::expectExceptionMessage('"elseif" without curly braces is not supported.');
-		self::checkFile(__DIR__ . '/data/earlyExitElseifWithoutCurlyBraces.php', [], [EarlyExitSniff::CODE_USELESS_ELSEIF]);
+		$report = self::checkFile(__DIR__ . '/data/earlyExitElseifWithoutCurlyBraces.php', [], [EarlyExitSniff::CODE_USELESS_ELSEIF]);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testElseWithoutCurlyBraces(): void
 	{
-		self::expectException(Throwable::class);
-		self::expectExceptionMessage('"else" without curly braces is not supported.');
-		self::checkFile(__DIR__ . '/data/earlyExitElseWithoutCurlyBraces.php', [], [EarlyExitSniff::CODE_USELESS_ELSE]);
+		$report = self::checkFile(__DIR__ . '/data/earlyExitElseWithoutCurlyBraces.php', [], [EarlyExitSniff::CODE_USELESS_ELSE]);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testInvalidElseif(): void
 	{
-		self::expectException(Throwable::class);
-		self::expectExceptionMessage('"else" without curly braces is not supported.');
-		self::checkFile(__DIR__ . '/data/earlyExitInvalidElseif.php', [], [EarlyExitSniff::CODE_USELESS_ELSEIF]);
+		$report = self::checkFile(__DIR__ . '/data/earlyExitInvalidElseif.php', [], [EarlyExitSniff::CODE_USELESS_ELSEIF]);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testIgnoredStandaloneIfInScopeNoErrors(): void

--- a/tests/Sniffs/ControlStructures/RequireTernaryOperatorSniffTest.php
+++ b/tests/Sniffs/ControlStructures/RequireTernaryOperatorSniffTest.php
@@ -3,7 +3,6 @@
 namespace SlevomatCodingStandard\Sniffs\ControlStructures;
 
 use SlevomatCodingStandard\Sniffs\TestCase;
-use Throwable;
 
 class RequireTernaryOperatorSniffTest extends TestCase
 {
@@ -49,16 +48,14 @@ class RequireTernaryOperatorSniffTest extends TestCase
 
 	public function testIfWithoutCurlyBraces(): void
 	{
-		self::expectException(Throwable::class);
-		self::expectExceptionMessage('"if" without curly braces is not supported.');
-		self::checkFile(__DIR__ . '/data/requireTernaryOperatorIfWithoutCurlyBraces.php', [], [EarlyExitSniff::CODE_EARLY_EXIT_NOT_USED]);
+		$report = self::checkFile(__DIR__ . '/data/requireTernaryOperatorIfWithoutCurlyBraces.php', [], [EarlyExitSniff::CODE_EARLY_EXIT_NOT_USED]);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testElseWithoutCurlyBraces(): void
 	{
-		self::expectException(Throwable::class);
-		self::expectExceptionMessage('"else" without curly braces is not supported.');
-		self::checkFile(__DIR__ . '/data/requireTernaryOperatorElseWithoutCurlyBraces.php', [], [EarlyExitSniff::CODE_USELESS_ELSE]);
+		$report = self::checkFile(__DIR__ . '/data/requireTernaryOperatorElseWithoutCurlyBraces.php', [], [EarlyExitSniff::CODE_USELESS_ELSE]);
+		self::assertNoSniffErrorInFile($report);
 	}
 
 }

--- a/tests/Sniffs/ControlStructures/UselessIfConditionWithReturnSniffTest.php
+++ b/tests/Sniffs/ControlStructures/UselessIfConditionWithReturnSniffTest.php
@@ -3,7 +3,6 @@
 namespace SlevomatCodingStandard\Sniffs\ControlStructures;
 
 use SlevomatCodingStandard\Sniffs\TestCase;
-use Throwable;
 
 class UselessIfConditionWithReturnSniffTest extends TestCase
 {
@@ -48,16 +47,14 @@ class UselessIfConditionWithReturnSniffTest extends TestCase
 
 	public function testIfWithoutCurlyBraces(): void
 	{
-		self::expectException(Throwable::class);
-		self::expectExceptionMessage('"if" without curly braces is not supported.');
-		self::checkFile(__DIR__ . '/data/uselessIfConditionWithReturnIfWithoutCurlyBraces.php');
+		$report = self::checkFile(__DIR__ . '/data/uselessIfConditionWithReturnIfWithoutCurlyBraces.php');
+		self::assertNoSniffErrorInFile($report);
 	}
 
 	public function testElseWithoutCurlyBraces(): void
 	{
-		self::expectException(Throwable::class);
-		self::expectExceptionMessage('"else" without curly braces is not supported.');
-		self::checkFile(__DIR__ . '/data/uselessIfConditionWithReturnElseWithoutCurlyBraces.php');
+		$report = self::checkFile(__DIR__ . '/data/uselessIfConditionWithReturnElseWithoutCurlyBraces.php');
+		self::assertNoSniffErrorInFile($report);
 	}
 
 }


### PR DESCRIPTION
Currently exceptions are thrown, which isn't particularly useful as it breaks the process. Instead, this just skips them, so that it works with `Generic.ControlStructures.InlineControlStructure`. (Haven't looked into whether it's possible to add support instead, but this should be enough.)