### PR TITLE
TypeHintDeclarationSniff: Add onlyStandalone option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ Sniff provides the following settings:
 * `traversableTypeHints`: enforces which typehints must have specified contained type. E. g. if you set this to `\Doctrine\Common\Collections\Collection`, then `\Doctrine\Common\Collections\Collection` must always be supplied with the contained type: `\Doctrine\Common\Collections\Collection|Foo[]`.
 * `allAnnotationsAreUseful`: phpDoc is useful if it contain any annotation.
 * `enableEachParameterAndReturnInspection`: enables inspection and fixing of `@param` and `@return` annotations separately. Useful when you only want to document parameters or return values that could not be expressed natively (i.e. member types of `array` or `Traversable`).
+* `onlyStandalone`: enables restricting inspections to classes and interfaces that don't extend/implement anything.
 
-This sniff can cause an error if you're overriding or implementing a parent method which does not have typehints. In such cases add `@phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint` annotation to the method to have this sniff skip it.
+This sniff can cause an error if you're overriding or implementing a parent method which does not have typehints. In such cases use the `onlyStandalone` setting, or add `@phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint` annotation to the method to have this sniff skip it.
 
 #### SlevomatCodingStandard.TypeHints.UselessConstantTypeHint 🔧
 

--- a/tests/Sniffs/TypeHints/TypeHintDeclarationSniffTest.php
+++ b/tests/Sniffs/TypeHints/TypeHintDeclarationSniffTest.php
@@ -327,4 +327,31 @@ class TypeHintDeclarationSniffTest extends TestCase
 		self::assertAllFixedInFile($report);
 	}
 
+	public function testOnlyStandalone(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/typeHintDeclarationOnlyStandalone.php', [
+			'onlyStandalone' => true,
+		]);
+
+		self::assertSame(17, $report->getErrorCount());
+
+		self::assertSniffError($report, 6, TypeHintDeclarationSniff::CODE_MISSING_PROPERTY_TYPE_HINT);
+		self::assertSniffError($report, 8, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
+		self::assertSniffError($report, 8, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
+		self::assertSniffError($report, 17, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
+		self::assertSniffError($report, 17, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
+		self::assertSniffError($report, 24, TypeHintDeclarationSniff::CODE_MISSING_PROPERTY_TYPE_HINT);
+		self::assertSniffError($report, 26, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
+		self::assertSniffError($report, 26, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
+		self::assertSniffError($report, 58, TypeHintDeclarationSniff::CODE_MISSING_PROPERTY_TYPE_HINT);
+		self::assertSniffError($report, 60, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
+		self::assertSniffError($report, 60, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
+		self::assertSniffError($report, 77, TypeHintDeclarationSniff::CODE_MISSING_PROPERTY_TYPE_HINT);
+		self::assertSniffError($report, 79, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
+		self::assertSniffError($report, 79, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
+		self::assertSniffError($report, 85, TypeHintDeclarationSniff::CODE_MISSING_PARAMETER_TYPE_HINT);
+		self::assertSniffError($report, 85, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
+		self::assertSniffError($report, 89, TypeHintDeclarationSniff::CODE_MISSING_RETURN_TYPE_HINT);
+	}
+
 }

--- a/tests/Sniffs/TypeHints/data/typeHintDeclarationOnlyStandalone.php
+++ b/tests/Sniffs/TypeHints/data/typeHintDeclarationOnlyStandalone.php
@@ -1,0 +1,90 @@
+<?php
+
+class StandaloneClass
+{
+
+	public $property;
+
+	public function method($parameter)
+	{
+	}
+
+}
+
+interface StandaloneInterface
+{
+
+	public function method($parameter);
+
+}
+
+trait StandaloneTrait
+{
+
+	public $property;
+
+	public function method($parameter)
+	{
+	}
+
+}
+
+class ExtendingClass extends StandaloneClass
+{
+
+	public $property;
+
+	public function method($parameter)
+	{
+	}
+
+}
+
+class ImplementingClass implements StandaloneInterface
+{
+
+	public $property;
+
+	public function method($parameter)
+	{
+	}
+
+}
+
+class UsingClass
+{
+	use StandaloneTrait;
+
+	public $property;
+
+	public function method($parameter)
+	{
+	}
+
+}
+
+interface ExtendingInterface extends StandaloneInterface
+{
+
+	public function method($parameter);
+
+}
+
+trait UsingTrait
+{
+	use StandaloneTrait;
+
+	public $property;
+
+	public function method($parameter)
+	{
+	}
+
+}
+
+function someFunction($parameter)
+{
+}
+
+$someClosure = function () {
+};


### PR DESCRIPTION
I haven't been able to use `TypeHintDeclaration` due to the problems with inheritance/interfaces 
(refs https://github.com/libero/php-coding-standard/pull/52#discussion_r263697632, https://github.com/libero/php-coding-standard/pull/32#issuecomment-464018464, https://github.com/libero/php-coding-standard/pull/40#discussion_r245673354). I think it should be possible to add an option to restrict it to classes/interfaces that don't extend/implement anything (and PHPStan/code review can cover the rest).