### PR TITLE
Fix return type hint finder [BUG]

### DIFF
--- a/SlevomatCodingStandard/Helpers/FunctionHelper.php
+++ b/SlevomatCodingStandard/Helpers/FunctionHelper.php
@@ -244,7 +244,7 @@ class FunctionHelper
 		do {
 			$nextToken = $isAbstract
 				? TokenHelper::findNextLocalExcluding($phpcsFile, $abstractExcludeTokens, $nextToken + 1)
-				: TokenHelper::findNextExcluding($phpcsFile, TokenHelper::$ineffectiveTokenCodes, $nextToken + 1, $tokens[$functionPointer]['scope_opener'] - 1);
+				: TokenHelper::findNextExcluding($phpcsFile, TokenHelper::$ineffectiveTokenCodes, $nextToken + 1, $tokens[$functionPointer]['scope_opener']);
 
 			$isTypeHint = $nextToken !== null;
 			if (!$isTypeHint) {

--- a/tests/Helpers/FunctionHelperTest.php
+++ b/tests/Helpers/FunctionHelperTest.php
@@ -350,6 +350,14 @@ class FunctionHelperTest extends TestCase
 		self::assertSame($functionPointer + 7, $returnTypeHint->getStartPointer());
 		self::assertSame($functionPointer + 10, $returnTypeHint->getEndPointer());
 
+		$functionPointer = $this->findFunctionPointerByName($phpcsFile, 'withReturnTypeHintNoSpace');
+		self::assertTrue(FunctionHelper::hasReturnTypeHint($phpcsFile, $functionPointer));
+		$returnTypeHint = FunctionHelper::findReturnTypeHint($phpcsFile, $functionPointer);
+		self::assertSame('\FooNamespace\FooInterface', $returnTypeHint->getTypeHint());
+		self::assertFalse($returnTypeHint->isNullable());
+		self::assertSame($functionPointer + 7, $returnTypeHint->getStartPointer());
+		self::assertSame($functionPointer + 10, $returnTypeHint->getEndPointer());
+
 		$functionPointer = $this->findFunctionPointerByName($phpcsFile, 'withoutReturnTypeHint');
 		self::assertFalse(FunctionHelper::hasReturnTypeHint($phpcsFile, $functionPointer));
 		self::assertNull(FunctionHelper::findReturnTypeHint($phpcsFile, $functionPointer));

--- a/tests/Helpers/data/functionReturnTypeHint.php
+++ b/tests/Helpers/data/functionReturnTypeHint.php
@@ -8,6 +8,10 @@ abstract class FooClass
 
 	}
 
+	public function withReturnTypeHintNoSpace(): \FooNamespace\FooInterface{
+
+	}
+
 	final public function withoutReturnTypeHint()
 	{
 


### PR DESCRIPTION
The `FuncitonHelper`'s `findReturnTypeHint` is not working properly under the following condition:

```php
function foo(): array{
}
```
but works with the following code
```php
function foo(): array {
}
```

The only difference is a space after the `array` type hint. 

This was due to the off-by-one parameter of the `TokenHelper::findeNextExcluding` function. 

The last parameter `endPointer` should be exclusive, however, when calling this function, a `-1` was used explicitly to specify the exclusiveness.

After removing the `-1`, everything seems to be working fine.