### PR TITLE
Correct RequireShortTernaryOperatorSniff Not Handling ?>

### DIFF
--- a/SlevomatCodingStandard/Sniffs/ControlStructures/RequireShortTernaryOperatorSniff.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/RequireShortTernaryOperatorSniff.php
@@ -14,6 +14,7 @@ use const T_BOOLEAN_NOT;
 use const T_CLOSE_PARENTHESIS;
 use const T_CLOSE_SHORT_ARRAY;
 use const T_CLOSE_SQUARE_BRACKET;
+use const T_CLOSE_TAG;
 use const T_COALESCE;
 use const T_COMMA;
 use const T_DOUBLE_ARROW;
@@ -55,7 +56,7 @@ class RequireShortTernaryOperatorSniff implements Sniff
 
 		$inlineElseEndPointer = $inlineElsePointer + 1;
 		while (true) {
-			if (in_array($tokens[$inlineElseEndPointer]['code'], [T_SEMICOLON, T_COMMA, T_DOUBLE_ARROW, T_CLOSE_SHORT_ARRAY, T_COALESCE], true)) {
+			if (in_array($tokens[$inlineElseEndPointer]['code'], [T_SEMICOLON, T_COMMA, T_DOUBLE_ARROW, T_CLOSE_SHORT_ARRAY, T_COALESCE, T_CLOSE_TAG], true)) {
 				break;
 			}
 

--- a/tests/Sniffs/ControlStructures/RequireShortTernaryOperatorSniffTest.php
+++ b/tests/Sniffs/ControlStructures/RequireShortTernaryOperatorSniffTest.php
@@ -50,4 +50,12 @@ class RequireShortTernaryOperatorSniffTest extends TestCase
 		self::assertAllFixedInFile($report);
 	}
 
+	public function testNoErrorRecurrence(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/requireShortTernaryOperatorCloseTag.php', [
+			'lineLengthLimit' => 120,
+		]);
+		self::assertNoSniffErrorInFile($report);
+	}
+
 }

--- a/tests/Sniffs/ControlStructures/data/requireShortTernaryOperatorCloseTag.php
+++ b/tests/Sniffs/ControlStructures/data/requireShortTernaryOperatorCloseTag.php
@@ -1,0 +1,1 @@
+<?= $this->title ? "{$this->title} - " : '' ?>foo<?= 'foo' ?>


### PR DESCRIPTION
There exists a bug where if terenary is followed by `?>` rather than a semicolon, the `RequireShortTernaryOperatorSniff` overruns the end of the tokens array throwing an out of bounds error.

This fixes it up and adds an accompanying test.