### PR TITLE
UnusedUsesSniff: Better handle php open tags

### DIFF
--- a/tests/Sniffs/Namespaces/UnusedUsesSniffTest.php
+++ b/tests/Sniffs/Namespaces/UnusedUsesSniffTest.php
@@ -287,4 +287,12 @@ class UnusedUsesSniffTest extends TestCase
 		self::assertNoSniffErrorInFile($report);
 	}
 
+	public function testUseAfterOpeningTag(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/unusedUsesUseAfterOpen.php', [
+			'searchAnnotations' => true,
+		]);
+		self::assertNoSniffErrorInFile($report);
+	}
+
 }

--- a/tests/Sniffs/Namespaces/data/unusedUsesUseAfterOpen.php
+++ b/tests/Sniffs/Namespaces/data/unusedUsesUseAfterOpen.php
@@ -1,0 +1,13 @@
+<?php
+
+use Foo\Bar;
+use Qux\Quux;
+
+?><?php
+
+echo Bar::BAZ;
+
+/**
+ * @var Quux $baz
+ */
+echo $baz;


### PR DESCRIPTION
UnusedUsesSniff gets false positives if more than one `<?php` opening tag is used in a file. This is because the sniff was defining the scope of a namespace to the _most recent_ T_NAMESPACE or *most recent* T_OPEN_TAG.

This was pretty easily resolved by changing the definition of the namespace to the _most recent_ T_NAMESPACE or the **first** T_OPEN_TAG.