### PR TITLE
Fix implementation of method findFirstTokenOnNextLine

### DIFF
--- a/SlevomatCodingStandard/Helpers/TokenHelper.php
+++ b/SlevomatCodingStandard/Helpers/TokenHelper.php
@@ -3,6 +3,7 @@
 namespace SlevomatCodingStandard\Helpers;
 
 use PHP_CodeSniffer\Files\File;
+use function array_key_exists;
 use function count;
 use const T_ARRAY_HINT;
 use const T_BREAK;
@@ -291,12 +292,21 @@ class TokenHelper
 	 */
 	public static function findFirstTokenOnNextLine(File $phpcsFile, int $pointer): ?int
 	{
-		$newLinePointer = self::findNextContent($phpcsFile, [T_WHITESPACE, T_DOC_COMMENT_WHITESPACE], $phpcsFile->eolChar, $pointer);
-		if ($newLinePointer === null) {
+		$tokens = $phpcsFile->getTokens();
+		if ($pointer >= count($tokens)) {
 			return null;
 		}
-		$tokens = $phpcsFile->getTokens();
-		return isset($tokens[$newLinePointer + 1]) ? $newLinePointer + 1 : null;
+
+		$line = $tokens[$pointer]['line'];
+
+		do {
+			$pointer++;
+			if (!array_key_exists($pointer, $tokens)) {
+				return null;
+			}
+		} while ($tokens[$pointer]['line'] === $line);
+
+		return $pointer;
 	}
 
 	/**

--- a/tests/Helpers/TokenHelperTest.php
+++ b/tests/Helpers/TokenHelperTest.php
@@ -222,6 +222,14 @@ class TokenHelperTest extends TestCase
 		self::assertTokenPointer(T_STRING, 4, $phpcsFile, TokenHelper::findFirstTokenOnNextLine($phpcsFile, $variableTokenPointer));
 	}
 
+	public function testFindFirstTokenOnNextLineEndingWithAComment(): void
+	{
+		$phpcsFile = $this->getCodeSnifferFile(__DIR__ . '/data/sampleFour.php');
+		$variableTokenPointer = TokenHelper::findNext($phpcsFile, T_VARIABLE, 0);
+		self::assertTokenPointer(T_VARIABLE, 3, $phpcsFile, $variableTokenPointer);
+		self::assertTokenPointer(T_STRING, 4, $phpcsFile, TokenHelper::findFirstTokenOnNextLine($phpcsFile, $variableTokenPointer));
+	}
+
 	public function testFindFirstTokenOnNextLineInDocComment(): void
 	{
 		$phpcsFile = $this->getCodeSnifferFile(

--- a/tests/Helpers/data/sampleFour.php
+++ b/tests/Helpers/data/sampleFour.php
@@ -1,0 +1,5 @@
+<?php
+
+$i++; // some comment
+foo();
+$a = 3;


### PR DESCRIPTION
Before changing the implementation I was getting this test result:

```
1) SlevomatCodingStandard\Helpers\TokenHelperTest::testFindFirstTokenOnNextLineEndingWithAComment
Expected T_STRING, actual token is T_VARIABLE
Failed asserting that 320 is identical to 319.
```

The problem is that new line is part of the `T_COMMENT` and the content comparison in the `findNext` method is done "exactly" (`$content === $tokens[$i]`), therefore the new line in the comment is not detected (the token is skipped).