### PR TITLE
TypeNameMatchesFileNameSniff: failing test for file without namespace

### DIFF
--- a/tests/Sniffs/Files/TypeNameMatchesFileNameSniffTest.php
+++ b/tests/Sniffs/Files/TypeNameMatchesFileNameSniffTest.php
@@ -24,6 +24,14 @@ class TypeNameMatchesFileNameSniffTest extends TestCase
 
 		self::assertSame(1, $report->getErrorCount());
 		self::assertSniffError($report, 5, TypeNameMatchesFileNameSniff::CODE_NO_MATCH_BETWEEN_TYPE_NAME_AND_FILE_NAME);
+
+		$report = self::checkFile(__DIR__ . '/data/rootNamespace/MissingNamespace.php', [
+			'rootNamespaces' => ['tests/Sniffs/Files/data/rootNamespace' => 'RootNamespace'],
+			'ignoredNamespaces' => ['IgnoredNamespace'],
+		]);
+
+		self::assertSame(1, $report->getErrorCount());
+		self::assertSniffError($report, 3, TypeNameMatchesFileNameSniff::CODE_NO_MATCH_BETWEEN_TYPE_NAME_AND_FILE_NAME);
 	}
 
 	public function testNoError(): void

--- a/tests/Sniffs/Files/data/rootNamespace/MissingNamespace.php
+++ b/tests/Sniffs/Files/data/rootNamespace/MissingNamespace.php
@@ -1,0 +1,5 @@
+<?php
+
+class MissingNamespace
+{
+}


### PR DESCRIPTION
`TypeNameMatchesFileNameSniff` completely ignores files without namespace declaration.

I think the expected behaviour is to report an error.