### PR TITLE
Composer: update the PHPUnit requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"phpstan/phpstan": "0.11.6",
 		"phpstan/phpstan-phpunit": "0.11.1",
 		"phpstan/phpstan-strict-rules": "0.11",
-		"phpunit/phpunit": "8.1.4"
+		"phpunit/phpunit": "^7.5 || ^8.1"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
As the unit tests work perfectly fine on PHPUnit 7.5+, allow for PHPUnit 7 to be installed to prevent the Composer version conflict.

Tested & found working.

Fixes #693