### PR TITLE
PHPUnit: various tweaks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 .gitattributes export-ignore
 .gitignore export-ignore
 /.travis.yml export-ignore
+/phpunit.xml.dist export-ignore
 /build export-ignore
 /build.xml export-ignore
 /temp export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /composer.lock
 /temp
 /vendor
+phpnit.xml

--- a/build.xml
+++ b/build.xml
@@ -70,9 +70,7 @@
 			logoutput="true"
 			passthru="true"
 			checkreturn="true"
-		>
-			<arg path="tests"/>
-		</exec>
+		/>
 	</target>
 
 	<target name="tests-without-code-coverage">
@@ -83,7 +81,6 @@
 			checkreturn="true"
 		>
 			<arg line="--no-coverage"/>
-			<arg path="tests"/>
 		</exec>
 	</target>
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,26 @@
 <?xml version="1.0"?>
 <phpunit
-	bootstrap="tests/bootstrap.php"
-	colors="true"
-	backupGlobals="false"
-	backupStaticAttributes="false"
-	beStrictAboutChangesToGlobalState="true"
-	beStrictAboutOutputDuringTests="true"
-	beStrictAboutTestsThatDoNotTestAnything="true"
-	beStrictAboutTodoAnnotatedTests="true"
-	cacheResult="true"
-	cacheResultFile="temp/.phpunit.result.cache"
-	stopOnDefect="true"
-	executionOrder="defects"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/8.1/phpunit.xsd"
+		bootstrap="tests/bootstrap.php"
+		colors="true"
+		backupGlobals="false"
+		backupStaticAttributes="false"
+		beStrictAboutChangesToGlobalState="true"
+		beStrictAboutOutputDuringTests="true"
+		beStrictAboutTestsThatDoNotTestAnything="true"
+		beStrictAboutTodoAnnotatedTests="true"
+		cacheResult="true"
+		cacheResultFile="temp/.phpunit.result.cache"
+		stopOnDefect="true"
+		executionOrder="defects"
 >
+	<testsuites>
+		<testsuite name="slevomatcs">
+			<directory suffix="Test.php">./tests/</directory>
+		</testsuite>
+	</testsuites>
+
 	<logging>
 		<log
 			type="coverage-html"


### PR DESCRIPTION
* `.gitattributes` - same as the `tests` directory, the `phpunit.xml.dist` config file does also not need to be included in the packaged release.
* `.gitignore` - ignore the standard PHPUnit overload config file which may be used by individual devs.
* `phpunit.xml.dist` - validated the XML file and added the schema header.
* `phpunit.xml.dist` - add the testsuite node so the `phpunit` command can be run without additional command-line parameters.
* `build.xml` - remove the now unnecessary `path="tests"` command line argument.