### PR TITLE
Update PHPCS/Phing configuration

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -41,11 +41,6 @@
 			checkreturn="true"
 		>
 			<arg value="--standard=build/phpcs.xml"/>
-			<arg value="--ignore=*/data/*"/>
-			<arg value="--cache=temp/phpcs"/>
-			<arg path="SlevomatCodingStandard"/>
-			<arg path="build/PHPStan"/>
-			<arg path="tests"/>
 		</exec>
 	</target>
 
@@ -57,10 +52,6 @@
 			checkreturn="true"
 		>
 			<arg value="--standard=build/phpcs.xml"/>
-			<arg value="--ignore=*/data/*"/>
-			<arg path="SlevomatCodingStandard"/>
-			<arg path="build/PHPStan"/>
-			<arg path="tests"/>
 		</exec>
 	</target>
 

--- a/build/phpcs-consistence.xml
+++ b/build/phpcs-consistence.xml
@@ -3,8 +3,6 @@
 
 	<!-- copy of https://github.com/consistence/coding-standard/blob/master/Consistence/ruleset.xml for local checking usage -->
 
-	<config name="installed_paths" value="../../../SlevomatCodingStandard"/><!-- relative path from PHPCS source location -->
-
 	<rule ref="Generic.Arrays.ArrayIndent">
 		<exclude name="Generic.Arrays.ArrayIndent.CloseBraceNotNewLine"/><!-- multiLine items causes evaluation as multiLine array https://github.com/squizlabs/PHP_CodeSniffer/issues/1791 -->
 	</rule>

--- a/build/phpcs.xml
+++ b/build/phpcs.xml
@@ -2,8 +2,13 @@
 <ruleset name="Slevomat Coding Standard">
 	<arg name="extensions" value="php"/>
 	<arg name="tab-width" value="4"/>
+	<arg name="cache" value="./../temp/phpcs"/>
 	<arg value="s"/>
 	<arg value="p"/>
+
+	<file>./../</file>
+	<exclude-pattern>*/tests/*/data/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
 
 	<rule ref="./phpcs-consistence.xml">
 		<exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedIf"/><!-- Allow empty if statements - usually with a comment -->

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
 		"phpstan/phpstan": "0.11.6",
 		"phpstan/phpstan-phpunit": "0.11.1",
 		"phpstan/phpstan-strict-rules": "0.11",
-		"phpunit/phpunit": "8.1.4"
+		"phpunit/phpunit": "8.1.4",
+		"dealerdirect/phpcodesniffer-composer-installer": "0.5.0"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
As briefly discussed in https://github.com/slevomat/coding-standard/pull/696#issuecomment-494668645.

This commit changes two things:

1. It removes the hard-coded value for `installed_paths` from the `build/phpcs-consistence.xml` file.
    This hard-coded value presumed that every developer would have their dev environment set up in the same way, without it being describing anywhere how that should be.
    Instead, the `dealerdirect/phpcodesniffer-composer-installer` Composer PHPCS plugin which I have now added to the `composer.json` `require-dev` section can and will take care of setting the `installed_paths` properly, _independently_ of how someone has set-up their dev environment.
2. It moves the PHPCS command-line arguments which were previously set in the `build.xml` file to the `phpcs.xml` file.
    Note:
    - I have no clue why the non-existent `data` directory was being ignored, but I have not ported this over as that seems redundant.
    - Instead of hard-coded specifying the paths to scan, scan everything with the exception of the `vendor` directory.
        That way if a new subdirectory would be added or - like in the case of PR #696, a new file in the project root -, those will automatically be scanned.

Together, these changes now also make it possible to run PHPCS from another install than the one contained in `vendor`, like a Phar or git clone by just running `phpcs --standard=./build/phpcs.xml`.

Suggestion: moving the `phpcs.xml` file to the project root and renaming it `.phpcs.xml.dist` would be a nice next step as then you wouldn't even need to pass any arguments anymore and could just run it like `phpcs`.