### PR TITLE
PHPCS: add schema tags to the ruleset

### DIFF
--- a/SlevomatCodingStandard/ruleset.xml
+++ b/SlevomatCodingStandard/ruleset.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
-<ruleset name="Slevomat Coding Standard">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Slevomat Coding Standard" xsi:noNamespaceSchemaLocation="../vendor/squizlabs/php_codesniffer/phpcs.xsd">
 	<autoload>./../autoload-bootstrap.php</autoload>
 </ruleset>

--- a/build/phpcs.xml
+++ b/build/phpcs.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="Slevomat Coding Standard">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Slevomat Coding Standard" xsi:noNamespaceSchemaLocation="../vendor/squizlabs/php_codesniffer/phpcs.xsd">
 	<arg name="extensions" value="php"/>
 	<arg name="tab-width" value="4"/>
 	<arg name="cache" value="./../temp/phpcs"/>


### PR DESCRIPTION
See:
* https://github.com/squizlabs/PHP_CodeSniffer/pull/1433
* https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.2.0

Note: I have not done this for the `Consistence` ruleset as that is a copy of another ruleset and should be fixed there.