### PR TITLE
Fix JumpStatementsSpacingSniff

### DIFF
--- a/SlevomatCodingStandard/Sniffs/ControlStructures/AbstractControlStructureSpacingSniff.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/AbstractControlStructureSpacingSniff.php
@@ -334,11 +334,16 @@ abstract class AbstractControlStructureSpacingSniff implements Sniff
 			return $nextPointer;
 		}
 
-		if ($tokens[$nextPointer]['code'] === T_OPEN_SHORT_ARRAY) {
-			return (int) TokenHelper::findNext($phpcsFile, T_SEMICOLON, $tokens[$nextPointer]['bracket_closer'] + 1);
+		$nextPointer = $tokens[$nextPointer]['code'] === T_OPEN_SHORT_ARRAY
+			? (int) TokenHelper::findNext($phpcsFile, T_SEMICOLON, $tokens[$nextPointer]['bracket_closer'] + 1)
+			: (int) TokenHelper::findNext($phpcsFile, T_SEMICOLON, $tokens[$nextPointer]['scope_closer'] + 1);
+
+		$level = $tokens[$controlStructurePointer]['level'];
+		while ($level !== $tokens[$nextPointer]['level']) {
+			$nextPointer = (int) TokenHelper::findNext($phpcsFile, T_SEMICOLON, $nextPointer + 1);
 		}
 
-		return (int) TokenHelper::findNext($phpcsFile, T_SEMICOLON, $tokens[$nextPointer]['scope_closer'] + 1);
+		return $nextPointer;
 	}
 
 }

--- a/tests/Sniffs/ControlStructures/data/jumpStatementsSpacingWithDefaultSettingsNoErrors.php
+++ b/tests/Sniffs/ControlStructures/data/jumpStatementsSpacingWithDefaultSettingsNoErrors.php
@@ -116,3 +116,29 @@ function () {
 
     return 10;
 };
+
+function () {
+	return Something::something(
+		['foo' => 'bar'],
+		function () {
+			$a = 1;
+			$b = 2;
+
+			return $a + $b;
+		}
+	);
+};
+
+function () {
+	return Something::something()
+		->somethingElse('blaah')
+		->callback(
+			function () {
+				$a = 1;
+				$b = 2;
+
+				return $a + $b;
+			}
+		)
+		->andDone();
+};


### PR DESCRIPTION
Next semicolon was guessed incorrectly when the argument to return/throw/yield was a function call which itself had an array and callback arguments.