### PR TITLE
Use reset to move to start of array, not current()

### DIFF
--- a/SlevomatCodingStandard/Helpers/YodaHelper.php
+++ b/SlevomatCodingStandard/Helpers/YodaHelper.php
@@ -11,11 +11,11 @@ use function array_map;
 use function array_reverse;
 use function array_values;
 use function count;
-use function current;
 use function end;
 use function implode;
 use function in_array;
 use function key;
+use function reset;
 use const T_ARRAY;
 use const T_ARRAY_CAST;
 use const T_BOOL_CAST;
@@ -88,7 +88,7 @@ class YodaHelper
 	 */
 	private static function replace(File $phpcsFile, array $oldTokens, array $newTokens): void
 	{
-		current($oldTokens);
+		reset($oldTokens);
 		/** @var int $firstOldPointer */
 		$firstOldPointer = key($oldTokens);
 		end($oldTokens);


### PR DESCRIPTION
Fix use of current.://www.php.net/current

> The current() function simply returns the value of the array element
> that's currently being pointed to by the internal pointer.
> **It does not move the pointer in any way.**

Detected with PhanPluginUseReturnValueInternalKnown (checks for unused results of functions without side effects)

This probably wouldn't matter in php 7, unless something else was also calling functions such as next() and end()