### PR TITLE
Require minimum PHPCS v3.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	"require": {
 		"php": "^7.2",
 		"phpstan/phpdoc-parser": "0.3.5",
-		"squizlabs/php_codesniffer": "^3.4.1"
+		"squizlabs/php_codesniffer": "^3.5.0"
 	},
 	"require-dev": {
 		"jakub-onderka/php-parallel-lint": "1.0.0",


### PR DESCRIPTION
PHPCS `v3.5` contains the `PSR-12` standards and no BC.

This will help the maintainers of this package decided if they're going to deprecate some sniff in favor of `phpcs`' ones.