### PR TITLE
php 7.1 and 7.2 backward compatibility.

### DIFF
--- a/SlevomatCodingStandard/Helpers/PropertyHelper.php
+++ b/SlevomatCodingStandard/Helpers/PropertyHelper.php
@@ -47,7 +47,7 @@ class PropertyHelper
 			TokenHelper::getContent($phpcsFile, $typeHintStartPointer, $typeHintEndPointer),
 			$nullabilitySymbolPointer !== null,
 			$nullabilitySymbolPointer ?? $typeHintStartPointer,
-			$typeHintEndPointer,
+			$typeHintEndPointer
 		);
 	}
 


### PR DESCRIPTION
This PR removes a trailing comma in a function call (this feature was introduced in php 7.3) to ensure backward compatibility with php 7.1 and 7.2 as stated in the composer.json file.
It should fix the errors reported by travis.