### PR TITLE
Check if function has empty body and require comment at least

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,10 @@ Sniff provides the following settings:
 
 However, if you prefer Yoda conditions, you can use `RequireYodaComparisonSniff`.
 
+#### SlevomatCodingStandard.Functions.DisallowEmptyFunction
+
+Reports empty functions body and require at least a comment inside.
+
 #### SlevomatCodingStandard.Functions.DisallowArrowFunction
 
 Disallows arrow functions.

--- a/SlevomatCodingStandard/Sniffs/Functions/DisallowEmptyFunctionSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Functions/DisallowEmptyFunctionSniff.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Functions;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use SlevomatCodingStandard\Helpers\FunctionHelper;
+use SlevomatCodingStandard\Helpers\TokenHelper;
+use const T_FUNCTION;
+use const T_WHITESPACE;
+
+class DisallowEmptyFunctionSniff implements Sniff
+{
+
+	public const CODE_EMPTY_FUNCTION = 'EmptyFunction';
+
+	/**
+	 * @return (int|string)[]
+	 */
+	public function register(): array
+	{
+		return [T_FUNCTION];
+	}
+
+
+	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile
+	 * @param int $functionPointer
+	 */
+	public function process(File $phpcsFile, $functionPointer): void
+	{
+		$tokens = $phpcsFile->getTokens();
+
+		if (FunctionHelper::isAbstract($phpcsFile, $functionPointer)) {
+			return;
+		}
+
+		$firstContent = TokenHelper::findNextExcluding(
+			$phpcsFile,
+			T_WHITESPACE,
+			$tokens[$functionPointer]['scope_opener'] + 1,
+			$tokens[$functionPointer]['scope_closer']
+		);
+
+		if ($firstContent !== null) {
+			return;
+		}
+
+		$phpcsFile->addError(
+			'Empty function body must have at least a comment to explain why is empty.',
+			$functionPointer,
+			self::CODE_EMPTY_FUNCTION
+		);
+	}
+
+}

--- a/tests/Sniffs/Functions/DisallowEmptyFunctionSniffTest.php
+++ b/tests/Sniffs/Functions/DisallowEmptyFunctionSniffTest.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Functions;
+
+use SlevomatCodingStandard\Sniffs\TestCase;
+
+class DisallowEmptyFunctionSniffTest extends TestCase
+{
+
+	public function testNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/disallowEmptyFunctionNoErrors.php');
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/disallowEmptyFunctionErrors.php');
+
+		self::assertSame(5, $report->getErrorCount());
+
+		foreach ([3, 10, 12, 26, 29] as $line) {
+			self::assertSniffError($report, $line, DisallowEmptyFunctionSniff::CODE_EMPTY_FUNCTION);
+		}
+	}
+
+}

--- a/tests/Sniffs/Functions/data/disallowEmptyFunctionErrors.php
+++ b/tests/Sniffs/Functions/data/disallowEmptyFunctionErrors.php
@@ -1,0 +1,31 @@
+<?php
+
+function dummyFunctionWithEmptyLines()
+{
+
+
+
+}
+
+function dummyFunctionWithEmptyBody(){}
+
+function dummyFunctionWithOneNewlineInBody()
+{
+}
+
+function dummyFunctionWithEmptyComment()
+{
+	//
+}
+
+abstract class DummyClass
+{
+
+	abstract public function dummyAbstractMethodWithoutBody();
+
+	public function dummyMethodWithNewlineInBody() {
+	}
+
+	public function dummyMethodWithNoContent() {}
+
+}

--- a/tests/Sniffs/Functions/data/disallowEmptyFunctionNoErrors.php
+++ b/tests/Sniffs/Functions/data/disallowEmptyFunctionNoErrors.php
@@ -1,0 +1,52 @@
+<?php
+
+function dummyFunctionWithPerlLikeComment()
+{
+	# PERL like comment
+}
+
+function dummyFunctionWithInlineComment()
+{
+	// Line comment
+}
+
+function dummyFunctionWithBlockComment()
+{
+	/*
+	 Block comment
+	 */
+}
+
+function dummyFunctionWithDocBlockComment()
+{
+	/**
+	 * Doc block comment
+	 */
+}
+
+function dummyFunctionWithEmptyComment()
+{
+	//
+}
+
+function dummyFunctionWithSomeBody()
+{
+	return 4;
+}
+
+abstract class DummyClass
+{
+
+	abstract public function dummyAbstractMethodWithoutBody();
+
+	public function dummyMethodWithEmptyComment()
+	{
+		//
+	}
+
+	public function dummyMethodWithSomeBody()
+	{
+		return 4;
+	}
+
+}


### PR DESCRIPTION
Some framework boilerplates contain empty methods or function ready to insert you own code. If comment is empty, rule `SlevomatCodingStandard.Commenting.EmptyComment` removes that comment and method with empty body stays in the code.

In my opinion it would be nice to either insert real comment why method is empty (overriding parent etc.), or remove that function. That is why I created this sniff.

P.S. Not sure if `Commenting` is right namespace, what do you think?