### PR TITLE
Fix crash in RequireCombinedAssignmentOperatorSniff

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Operators/RequireCombinedAssignmentOperatorSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Operators/RequireCombinedAssignmentOperatorSniff.php
@@ -46,8 +46,10 @@ class RequireCombinedAssignmentOperatorSniff implements Sniff
 	 */
 	public function process(File $phpcsFile, $equalPointer): void
 	{
-		/** @var int $variableStartPointer */
 		$variableStartPointer = TokenHelper::findNextEffective($phpcsFile, $equalPointer + 1);
+		if ($variableStartPointer === null) {
+			return;
+		}
 		$variableEndPointer = IdentificatorHelper::findEndPointer($phpcsFile, $variableStartPointer);
 
 		if ($variableEndPointer === null) {


### PR DESCRIPTION
This causes an uncaught TypeError for malformed php files such as:

```php
<?php
$x =
```