### PR TITLE
Fix RequireTernaryOperatorSniff for variable refs

### DIFF
--- a/SlevomatCodingStandard/Sniffs/ControlStructures/RequireTernaryOperatorSniff.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/RequireTernaryOperatorSniff.php
@@ -9,6 +9,7 @@ use SlevomatCodingStandard\Helpers\IdentificatorHelper;
 use SlevomatCodingStandard\Helpers\TokenHelper;
 use function array_key_exists;
 use function sprintf;
+use const T_BITWISE_AND;
 use const T_ELSE;
 use const T_EQUAL;
 use const T_IF;
@@ -139,16 +140,24 @@ class RequireTernaryOperatorSniff implements Sniff
 			return;
 		}
 
+		$pointerAfterAssignmentInIf = TokenHelper::findNextEffective($phpcsFile, $assignmentPointerInIf + 1);
+		$pointerAfterAssignmentInElse = TokenHelper::findNextEffective($phpcsFile, $assignmentPointerInElse + 1);
+
+		if (
+			$tokens[$pointerAfterAssignmentInIf]['code'] === T_BITWISE_AND ||
+			$tokens[$pointerAfterAssignmentInElse]['code'] === T_BITWISE_AND
+		) {
+			return;
+		}
+
 		$fix = $phpcsFile->addFixableError('Use ternary operator.', $ifPointer, self::CODE_TERNARY_OPERATOR_NOT_USED);
 
 		if (!$fix) {
 			return;
 		}
 
-		$pointerAfterAssignmentInIf = TokenHelper::findNextEffective($phpcsFile, $assignmentPointerInIf + 1);
 		/** @var int $semicolonAfterAssignmentInIf */
 		$semicolonAfterAssignmentInIf = TokenHelper::findNext($phpcsFile, T_SEMICOLON, $pointerAfterAssignmentInIf + 1);
-		$pointerAfterAssignmentInElse = TokenHelper::findNextEffective($phpcsFile, $assignmentPointerInElse + 1);
 		$semicolonAfterAssignmentInElse = TokenHelper::findNext($phpcsFile, T_SEMICOLON, $pointerAfterAssignmentInElse + 1);
 
 		$phpcsFile->fixer->beginChangeset();

--- a/tests/Sniffs/ControlStructures/data/requireTernaryOperatorNoErrors.php
+++ b/tests/Sniffs/ControlStructures/data/requireTernaryOperatorNoErrors.php
@@ -78,3 +78,23 @@ if (true) {
 if (true) {
 	echo 'true';
 }
+
+$foo = 1;
+$bar = 2;
+if (true) {
+	$ref = &$foo;
+} else {
+	$ref = &$bar;
+}
+
+if (true) {
+	$ref = $foo;
+} else {
+	$ref = &$bar;
+}
+
+if (true) {
+	$ref = &$foo;
+} else {
+	$ref = $bar;
+}


### PR DESCRIPTION
Fixes https://github.com/slevomat/coding-standard/issues/826