### PR TITLE
Add parent call spacing sniff

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,17 @@ Sniff provides the following settings:
 Reports use of `__CLASS__`, `get_parent_class()`, `get_called_class()`, `get_class()` and `get_class($this)`.
 Class names should be referenced via `::class` constant when possible. 
 
+#### SlevomatCodingStandard.Classes.ParentCallSpacing 🔧
+
+Enforces configurable number of lines around parent method call.
+
+Sniff provides the following settings:
+
+* `linesCountBeforeControlStructure`: allows to configure the number of lines before parent call.
+* `linesCountBeforeFirstControlStructure`: allows to configure the number of lines before first parent call.
+* `linesCountAfterControlStructure`: allows to configure the number of lines after parent call.
+* `linesCountAfterLastControlStructure`: allows to configure the number of lines after last parent call.
+
 #### SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming
 
 Reports use of superfluous prefix or suffix "Abstract" for abstract classes.

--- a/SlevomatCodingStandard/Sniffs/Classes/ParentCallSpacingSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/ParentCallSpacingSniff.php
@@ -44,4 +44,10 @@ class ParentCallSpacingSniff extends AbstractControlStructureSpacingSniff
 		return [T_PARENT];
 	}
 
+	/** @return string[] */
+	protected function getTokensToCheck(): array
+	{
+		return ['T_PARENT'];
+	}
+
 }

--- a/SlevomatCodingStandard/Sniffs/Classes/ParentCallSpacingSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/ParentCallSpacingSniff.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use SlevomatCodingStandard\Helpers\TokenHelper;
+use SlevomatCodingStandard\Sniffs\ControlStructures\AbstractControlStructureSpacingSniff;
+use function array_key_exists;
+use function array_merge;
+use function in_array;
+use const T_PARENT;
+
+class ParentCallSpacingSniff extends AbstractControlStructureSpacingSniff
+{
+
+	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile
+	 * @param int $parentPointer
+	 */
+	public function process(File $phpcsFile, $parentPointer): void
+	{
+		$tokens = $phpcsFile->getTokens();
+
+		if (array_key_exists('nested_parenthesis', $tokens[$parentPointer])) {
+			return;
+		}
+
+		$previousEffectivePointer = TokenHelper::findPreviousEffective($phpcsFile, $parentPointer - 1);
+		$assignmentAndEqualityTokens = array_merge(Tokens::$assignmentTokens, Tokens::$equalityTokens);
+		if (in_array($tokens[$previousEffectivePointer]['code'], $assignmentAndEqualityTokens, true)) {
+			return;
+		}
+
+		parent::process($phpcsFile, $parentPointer);
+	}
+
+	/**
+	 * @return string[]
+	 */
+	protected function getSupportedTokens(): array
+	{
+		return [T_PARENT];
+	}
+
+}

--- a/SlevomatCodingStandard/Sniffs/ControlStructures/AbstractControlStructureSpacingSniff.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/AbstractControlStructureSpacingSniff.php
@@ -91,7 +91,7 @@ abstract class AbstractControlStructureSpacingSniff implements Sniff
 	}
 
 	/**
-	 * @return int[]
+	 * @return array<int|string>
 	 */
 	abstract protected function getSupportedTokens(): array;
 
@@ -104,7 +104,7 @@ abstract class AbstractControlStructureSpacingSniff implements Sniff
 			$supportedTokens = $this->getSupportedTokens();
 
 			$this->normalizedTokensToCheck = array_map(
-				static function (string $tokenCode) use ($supportedTokens): int {
+				static function (string $tokenCode) use ($supportedTokens) {
 					if (!defined($tokenCode)) {
 						throw new UndefinedKeywordTokenException($tokenCode);
 					}

--- a/SlevomatCodingStandard/Sniffs/ControlStructures/AbstractControlStructureSpacingSniff.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/AbstractControlStructureSpacingSniff.php
@@ -65,9 +65,6 @@ abstract class AbstractControlStructureSpacingSniff implements Sniff
 	/** @var int */
 	public $linesCountAfterLastControlStructure = 0;
 
-	/** @var string[] */
-	public $tokensToCheck = [];
-
 	/** @var (string|int)[]|null */
 	private $normalizedTokensToCheck;
 
@@ -76,7 +73,7 @@ abstract class AbstractControlStructureSpacingSniff implements Sniff
 	 */
 	public function register(): array
 	{
-		return $this->getTokensToCheck();
+		return $this->getNormalizedTokensToCheck();
 	}
 
 	/**
@@ -95,10 +92,11 @@ abstract class AbstractControlStructureSpacingSniff implements Sniff
 	 */
 	abstract protected function getSupportedTokens(): array;
 
-	/**
-	 * @return (int|string)[]
-	 */
-	private function getTokensToCheck(): array
+	/** @return string[] */
+	abstract protected function getTokensToCheck(): array;
+
+	/** @return (int|string)[] */
+	private function getNormalizedTokensToCheck(): array
 	{
 		if ($this->normalizedTokensToCheck === null) {
 			$supportedTokens = $this->getSupportedTokens();
@@ -116,7 +114,7 @@ abstract class AbstractControlStructureSpacingSniff implements Sniff
 
 					return $const;
 				},
-				SniffSettingsHelper::normalizeArray($this->tokensToCheck)
+				SniffSettingsHelper::normalizeArray($this->getTokensToCheck())
 			);
 
 			if (count($this->normalizedTokensToCheck) === 0) {

--- a/SlevomatCodingStandard/Sniffs/ControlStructures/BlockControlStructureSpacingSniff.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/BlockControlStructureSpacingSniff.php
@@ -19,6 +19,9 @@ use const T_WHILE;
 class BlockControlStructureSpacingSniff extends AbstractControlStructureSpacingSniff
 {
 
+	/** @var string[] */
+	public $tokensToCheck = [];
+
 	/**
 	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
 	 * @param \PHP_CodeSniffer\Files\File $phpcsFile
@@ -49,6 +52,12 @@ class BlockControlStructureSpacingSniff extends AbstractControlStructureSpacingS
 			T_CASE,
 			T_DEFAULT,
 		];
+	}
+
+	/** @return string[] */
+	protected function getTokensToCheck(): array
+	{
+		return $this->tokensToCheck;
 	}
 
 	private function isWhilePartOfDo(File $phpcsFile, int $controlStructurePointer): bool

--- a/SlevomatCodingStandard/Sniffs/ControlStructures/JumpStatementsSpacingSniff.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/JumpStatementsSpacingSniff.php
@@ -22,6 +22,9 @@ class JumpStatementsSpacingSniff extends AbstractControlStructureSpacingSniff
 	/** @var bool */
 	public $allowSingleLineYieldStacking = true;
 
+	/** @var string[] */
+	public $tokensToCheck = [];
+
 	/**
 	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
 	 * @param \PHP_CodeSniffer\Files\File $phpcsFile
@@ -50,6 +53,12 @@ class JumpStatementsSpacingSniff extends AbstractControlStructureSpacingSniff
 			T_YIELD,
 			T_YIELD_FROM,
 		];
+	}
+
+	/** @return string[] */
+	protected function getTokensToCheck(): array
+	{
+		return $this->tokensToCheck;
 	}
 
 	protected function checkLinesBefore(File $phpcsFile, int $controlStructurePointer): void

--- a/tests/Sniffs/Classes/ParentCallSpacingSniffTest.php
+++ b/tests/Sniffs/Classes/ParentCallSpacingSniffTest.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Classes;
+
+use SlevomatCodingStandard\Sniffs\TestCase;
+
+class ParentCallSpacingSniffTest extends TestCase
+{
+
+	public function testNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/parentCallSpacingNoErrors.php');
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/parentCallSpacingErrors.php');
+
+		self::assertSame(2, $report->getErrorCount());
+
+		self::assertSniffError($report, 5, ParentCallSpacingSniff::CODE_INCORRECT_LINES_COUNT_AFTER_CONTROL_STRUCTURE, 'Expected 1 lines after "parent", found 0.');
+		self::assertSniffError($report, 11, ParentCallSpacingSniff::CODE_INCORRECT_LINES_COUNT_BEFORE_CONTROL_STRUCTURE, 'Expected 1 lines before "parent", found 0.');
+
+		self::assertAllFixedInFile($report);
+	}
+
+}

--- a/tests/Sniffs/Classes/data/parentCallSpacingErrors.fixed.php
+++ b/tests/Sniffs/Classes/data/parentCallSpacingErrors.fixed.php
@@ -1,0 +1,15 @@
+<?php
+
+class X {
+	function a() {
+		parent::a();
+
+		echo 'wow';
+	}
+
+	function b() {
+		echo 'wow';
+
+		parent::b();
+	}
+}

--- a/tests/Sniffs/Classes/data/parentCallSpacingErrors.php
+++ b/tests/Sniffs/Classes/data/parentCallSpacingErrors.php
@@ -1,0 +1,13 @@
+<?php
+
+class X {
+	function a() {
+		parent::a();
+		echo 'wow';
+	}
+
+	function b() {
+		echo 'wow';
+		parent::b();
+	}
+}

--- a/tests/Sniffs/Classes/data/parentCallSpacingNoErrors.php
+++ b/tests/Sniffs/Classes/data/parentCallSpacingNoErrors.php
@@ -1,0 +1,27 @@
+<?php
+
+class X {
+	function a() {
+		parent::a();
+
+		echo 'wow';
+	}
+
+	function b() {
+		echo 'wow';
+
+		parent::b();
+	}
+
+	function c() {
+		$x = parent::c();
+		echo $x;
+	}
+
+	function d() {
+		wow(
+			parent::c()
+		);
+		echo $x;
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/slevomat/coding-standard/issues/678

I'm not sure if we should create a separate sniff extending the abstract class, or just keep it here. What do you think? Splitting is trivial ... just pitch me a good name :D 