### PR TITLE
EarlyExit: don't break the complete PHPCS run for unsupported syntaxes

### DIFF
--- a/tests/Sniffs/ControlStructures/EarlyExitSniffTest.php
+++ b/tests/Sniffs/ControlStructures/EarlyExitSniffTest.php
@@ -3,7 +3,6 @@
 namespace SlevomatCodingStandard\Sniffs\ControlStructures;
 
 use SlevomatCodingStandard\Sniffs\TestCase;
-use Throwable;
 
 class EarlyExitSniffTest extends TestCase
 {
@@ -41,37 +40,44 @@ class EarlyExitSniffTest extends TestCase
 
 	public function testIfWithoutCurlyBraces(): void
 	{
-		self::expectException(Throwable::class);
-		self::expectExceptionMessage('"if" without curly braces is not supported.');
-		self::checkFile(__DIR__ . '/data/earlyExitIfWithoutCurlyBraces.php', [], [EarlyExitSniff::CODE_EARLY_EXIT_NOT_USED]);
+		$report = self::checkFile(__DIR__ . '/data/earlyExitIfWithoutCurlyBraces.php', [], [EarlyExitSniff::CODE_EARLY_EXIT_NOT_USED]);
+
+		self::assertSame(0, $report->getErrorCount());
 	}
 
 	public function testElseifWithoutCurlyBraces(): void
 	{
-		self::expectException(Throwable::class);
-		self::expectExceptionMessage('"elseif" without curly braces is not supported.');
-		self::checkFile(__DIR__ . '/data/earlyExitElseifWithoutCurlyBraces.php', [], [EarlyExitSniff::CODE_USELESS_ELSEIF]);
+		$report = self::checkFile(__DIR__ . '/data/earlyExitElseifWithoutCurlyBraces.php', [], [EarlyExitSniff::CODE_USELESS_ELSEIF]);
+
+		self::assertSame(0, $report->getErrorCount());
 	}
 
 	public function testElseifWithSpace(): void
 	{
-		self::expectException(Throwable::class);
-		self::expectExceptionMessage('"else" without curly braces is not supported.');
-		self::checkFile(__DIR__ . '/data/earlyExitElseifWithSpace.php', [], [EarlyExitSniff::CODE_USELESS_ELSEIF]);
+		$report = self::checkFile(__DIR__ . '/data/earlyExitElseifWithSpace.php', [], [EarlyExitSniff::CODE_USELESS_ELSEIF]);
+
+		self::assertSame(0, $report->getErrorCount());
 	}
 
 	public function testElseWithoutCurlyBraces(): void
 	{
-		self::expectException(Throwable::class);
-		self::expectExceptionMessage('"else" without curly braces is not supported.');
-		self::checkFile(__DIR__ . '/data/earlyExitElseWithoutCurlyBraces.php', [], [EarlyExitSniff::CODE_USELESS_ELSE]);
+		$report = self::checkFile(__DIR__ . '/data/earlyExitElseWithoutCurlyBraces.php', [], [EarlyExitSniff::CODE_USELESS_ELSE]);
+
+		self::assertSame(0, $report->getErrorCount());
 	}
 
 	public function testInvalidElseif(): void
 	{
-		self::expectException(Throwable::class);
-		self::expectExceptionMessage('"else" without curly braces is not supported.');
-		self::checkFile(__DIR__ . '/data/earlyExitInvalidElseif.php', [], [EarlyExitSniff::CODE_USELESS_ELSEIF]);
+		$report = self::checkFile(__DIR__ . '/data/earlyExitInvalidElseif.php', [], [EarlyExitSniff::CODE_USELESS_ELSEIF]);
+
+		self::assertSame(0, $report->getErrorCount());
+	}
+
+	public function testAlternativeSyntax(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/earlyExitAlternativeSyntax.php', [], [EarlyExitSniff::CODE_USELESS_ELSEIF]);
+
+		self::assertSame(0, $report->getErrorCount());
 	}
 
 	public function testIgnoredStandaloneIfInScopeNoErrors(): void

--- a/tests/Sniffs/ControlStructures/data/earlyExitAlternativeSyntax.php
+++ b/tests/Sniffs/ControlStructures/data/earlyExitAlternativeSyntax.php
@@ -1,0 +1,12 @@
+<?php
+
+function () {
+	if (true) : ?>
+		<div></div>
+	<?php elseif (false) : ?>
+		<div></div>
+	<?php else : ?>
+		<div></div>
+	<?php
+	endif;
+};


### PR DESCRIPTION
While it is your prerogative, of course, to choose not to support certain syntaxes, when these are encountered the sniff should exit silently.

As things were, the sniff would exit with an _uncaught exception_ which within PHPCS was then translated to an `Internal.Exception` error which stops the PHPCS dead for the file being scanned, this includes breaking the run for all other sniffs in a project ruleset.

Exceptions are intended for developers, not for end-users.

The end-user of PHPCS can do nothing with an uncaught exception. Instead, this exception should be caught within the sniff and the sniff should return silently as it couldn't be determined whether something is or isn't an error for the rules the sniff is checking for.

Includes adjusted unit tests + a new unit test for control structures using alternative syntax, which clearly isn't supported either and would - until now - cause an `Undefined index: scope_condition` notice, which - again - would stop the PHPCS scan dead.