### PR TITLE
UselessIfConditionWithReturn: don't break the complete PHPCS run for unsupported syntaxes

### DIFF
--- a/SlevomatCodingStandard/Sniffs/ControlStructures/UselessIfConditionWithReturnSniff.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/UselessIfConditionWithReturnSniff.php
@@ -2,7 +2,6 @@
 
 namespace SlevomatCodingStandard\Sniffs\ControlStructures;
 
-use Exception;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use SlevomatCodingStandard\Helpers\ConditionHelper;
@@ -46,7 +45,8 @@ class UselessIfConditionWithReturnSniff implements Sniff
 		$tokens = $phpcsFile->getTokens();
 
 		if (!array_key_exists('scope_closer', $tokens[$ifPointer])) {
-			throw new Exception('"if" without curly braces is not supported.');
+			// If without curly braces is not supported.
+			return;
 		}
 
 		$ifBooleanPointer = $this->findBooleanAfterReturnInScope($phpcsFile, $tokens[$ifPointer]['scope_opener']);
@@ -81,7 +81,8 @@ class UselessIfConditionWithReturnSniff implements Sniff
 			&& $tokens[$elsePointer]['code'] === T_ELSE
 		) {
 			if (!array_key_exists('scope_closer', $tokens[$elsePointer])) {
-				throw new Exception('"else" without curly braces is not supported.');
+				// Else without curly braces is not supported.
+				return;
 			}
 
 			$elseBooleanPointer = $this->findBooleanAfterReturnInScope($phpcsFile, $tokens[$elsePointer]['scope_opener']);

--- a/tests/Sniffs/ControlStructures/UselessIfConditionWithReturnSniffTest.php
+++ b/tests/Sniffs/ControlStructures/UselessIfConditionWithReturnSniffTest.php
@@ -3,7 +3,6 @@
 namespace SlevomatCodingStandard\Sniffs\ControlStructures;
 
 use SlevomatCodingStandard\Sniffs\TestCase;
-use Throwable;
 
 class UselessIfConditionWithReturnSniffTest extends TestCase
 {
@@ -49,16 +48,16 @@ class UselessIfConditionWithReturnSniffTest extends TestCase
 
 	public function testIfWithoutCurlyBraces(): void
 	{
-		self::expectException(Throwable::class);
-		self::expectExceptionMessage('"if" without curly braces is not supported.');
-		self::checkFile(__DIR__ . '/data/uselessIfConditionWithReturnIfWithoutCurlyBraces.php');
+		$report = self::checkFile(__DIR__ . '/data/uselessIfConditionWithReturnIfWithoutCurlyBraces.php');
+
+		self::assertSame(0, $report->getErrorCount());
 	}
 
 	public function testElseWithoutCurlyBraces(): void
 	{
-		self::expectException(Throwable::class);
-		self::expectExceptionMessage('"else" without curly braces is not supported.');
-		self::checkFile(__DIR__ . '/data/uselessIfConditionWithReturnElseWithoutCurlyBraces.php');
+		$report = self::checkFile(__DIR__ . '/data/uselessIfConditionWithReturnElseWithoutCurlyBraces.php');
+
+		self::assertSame(0, $report->getErrorCount());
 	}
 
 }


### PR DESCRIPTION
While it is your prerogative, of course, to choose not to support certain syntaxes, when these are encountered the sniff should exit silently.

As things were, the sniff would exit with an _uncaught exception_ which within PHPCS was then translated to an `Internal.Exception` error which stops the PHPCS dead for the file being scanned, this includes breaking the run for all other sniffs in a project ruleset.

Exceptions are intended for developers, not for end-users.

The end-user of PHPCS can do nothing with an uncaught exception. Instead, this exception should be caught within the sniff and he sniff should return silently as it couldn't be determined whether something is or isn't an error for the rules the sniff is checking for.

Includes adjusted unit tests.

Related to #841