### PR TITLE
RequireTernaryOperator: don't break the complete PHPCS run for unsupported syntaxes

### DIFF
--- a/SlevomatCodingStandard/Sniffs/ControlStructures/RequireTernaryOperatorSniff.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/RequireTernaryOperatorSniff.php
@@ -2,7 +2,6 @@
 
 namespace SlevomatCodingStandard\Sniffs\ControlStructures;
 
-use Exception;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use SlevomatCodingStandard\Helpers\IdentificatorHelper;
@@ -46,7 +45,8 @@ class RequireTernaryOperatorSniff implements Sniff
 		$tokens = $phpcsFile->getTokens();
 
 		if (!array_key_exists('scope_closer', $tokens[$ifPointer])) {
-			throw new Exception('"if" without curly braces is not supported.');
+			// If without curly braces is not supported.
+			return;
 		}
 
 		$elsePointer = TokenHelper::findNextEffective($phpcsFile, $tokens[$ifPointer]['scope_closer'] + 1);
@@ -55,7 +55,8 @@ class RequireTernaryOperatorSniff implements Sniff
 		}
 
 		if (!array_key_exists('scope_closer', $tokens[$elsePointer])) {
-			throw new Exception('"else" without curly braces is not supported.');
+			// Else without curly braces is not supported.
+			return;
 		}
 
 		if (

--- a/tests/Sniffs/ControlStructures/RequireTernaryOperatorSniffTest.php
+++ b/tests/Sniffs/ControlStructures/RequireTernaryOperatorSniffTest.php
@@ -3,7 +3,6 @@
 namespace SlevomatCodingStandard\Sniffs\ControlStructures;
 
 use SlevomatCodingStandard\Sniffs\TestCase;
-use Throwable;
 
 class RequireTernaryOperatorSniffTest extends TestCase
 {
@@ -49,16 +48,16 @@ class RequireTernaryOperatorSniffTest extends TestCase
 
 	public function testIfWithoutCurlyBraces(): void
 	{
-		self::expectException(Throwable::class);
-		self::expectExceptionMessage('"if" without curly braces is not supported.');
-		self::checkFile(__DIR__ . '/data/requireTernaryOperatorIfWithoutCurlyBraces.php', [], [EarlyExitSniff::CODE_EARLY_EXIT_NOT_USED]);
+		$report = self::checkFile(__DIR__ . '/data/requireTernaryOperatorIfWithoutCurlyBraces.php');
+
+		self::assertSame(0, $report->getErrorCount());
 	}
 
 	public function testElseWithoutCurlyBraces(): void
 	{
-		self::expectException(Throwable::class);
-		self::expectExceptionMessage('"else" without curly braces is not supported.');
-		self::checkFile(__DIR__ . '/data/requireTernaryOperatorElseWithoutCurlyBraces.php', [], [EarlyExitSniff::CODE_USELESS_ELSE]);
+		$report = self::checkFile(__DIR__ . '/data/requireTernaryOperatorElseWithoutCurlyBraces.php');
+
+		self::assertSame(0, $report->getErrorCount());
 	}
 
 }


### PR DESCRIPTION
While it is your prerogative, of course, to choose not to support certain syntaxes, when these are encountered the sniff should exit silently.

As things were, the sniff would exit with an _uncaught exception_ which within PHPCS was then translated to an `Internal.Exception` error which stops the PHPCS dead for the file being scanned, this includes breaking the run for all other sniffs in a project ruleset.

Exceptions are intended for developers, not for end-users.

The end-user of PHPCS can do nothing with an uncaught exception. Instead, this exception should be caught within the sniff and he sniff should return silently as it couldn't be determined whether something is or isn't an error for the rules the sniff is checking for.

Includes adjusted unit tests - includes removing a reference to an unrelated sniff from the unit tests.

Related to #841