### PR TITLE
AbstractControlStructureSpacingSniff: don't break the complete PHPCS run for unsupported syntaxes

### DIFF
--- a/SlevomatCodingStandard/Sniffs/ControlStructures/AbstractControlStructureSpacingSniff.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/AbstractControlStructureSpacingSniff.php
@@ -10,6 +10,7 @@ use SlevomatCodingStandard\Helpers\CommentHelper;
 use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
 use SlevomatCodingStandard\Helpers\TokenHelper;
 use SlevomatCodingStandard\Sniffs\Namespaces\UndefinedKeywordTokenException;
+use Throwable;
 use function array_key_exists;
 use function array_map;
 use function constant;
@@ -84,7 +85,13 @@ abstract class AbstractControlStructureSpacingSniff implements Sniff
 	public function process(File $phpcsFile, $controlStructurePointer): void
 	{
 		$this->checkLinesBefore($phpcsFile, $controlStructurePointer);
-		$this->checkLinesAfter($phpcsFile, $controlStructurePointer);
+
+		try {
+			$this->checkLinesAfter($phpcsFile, $controlStructurePointer);
+		} catch (Throwable $e) {
+			// Unsupported syntax without curly braces.
+			return;
+		}
 	}
 
 	/**
@@ -206,7 +213,12 @@ abstract class AbstractControlStructureSpacingSniff implements Sniff
 	{
 		$tokens = $phpcsFile->getTokens();
 
-		$controlStructureEndPointer = $this->findControlStructureEnd($phpcsFile, $controlStructurePointer);
+		try {
+			$controlStructureEndPointer = $this->findControlStructureEnd($phpcsFile, $controlStructurePointer);
+		} catch (Throwable $e) {
+			throw new Exception($e->getMessage());
+		}
+
 		$pointerAfterControlStructureEnd = TokenHelper::findNextEffective($phpcsFile, $controlStructureEndPointer + 1);
 		if ($pointerAfterControlStructureEnd !== null && $tokens[$pointerAfterControlStructureEnd]['code'] === T_SEMICOLON) {
 			$controlStructureEndPointer = $pointerAfterControlStructureEnd;

--- a/tests/Sniffs/ControlStructures/BlockControlStructureSpacingSniffTest.php
+++ b/tests/Sniffs/ControlStructures/BlockControlStructureSpacingSniffTest.php
@@ -4,7 +4,6 @@ namespace SlevomatCodingStandard\Sniffs\ControlStructures;
 
 use SlevomatCodingStandard\Sniffs\Namespaces\UndefinedKeywordTokenException;
 use SlevomatCodingStandard\Sniffs\TestCase;
-use Throwable;
 
 class BlockControlStructureSpacingSniffTest extends TestCase
 {
@@ -152,16 +151,16 @@ class BlockControlStructureSpacingSniffTest extends TestCase
 
 	public function testIfWithoutCurlyBraces(): void
 	{
-		self::expectException(Throwable::class);
-		self::expectExceptionMessage('"if" without curly braces is not supported.');
-		self::checkFile(__DIR__ . '/data/blockControlStructureSpacingIfWithoutCurlyBraces.php');
+		$report = self::checkFile(__DIR__ . '/data/blockControlStructureSpacingIfWithoutCurlyBraces.php');
+
+		self::assertSame(0, $report->getErrorCount());
 	}
 
 	public function testElseWithoutCurlyBraces(): void
 	{
-		self::expectException(Throwable::class);
-		self::expectExceptionMessage('"else" without curly braces is not supported.');
-		self::checkFile(__DIR__ . '/data/blockControlStructureSpacingElseWithoutCurlyBraces.php');
+		$report = self::checkFile(__DIR__ . '/data/blockControlStructureSpacingElseWithoutCurlyBraces.php');
+
+		self::assertSame(0, $report->getErrorCount());
 	}
 
 	public function testAtTheEndOfFile(): void


### PR DESCRIPTION
While it is your prerogative, of course, to choose not to support certain syntaxes, when these are encountered the sniff should exit silently.

As things were, the sniff would exit with an _uncaught exception_ which within PHPCS was then translated to an `Internal.Exception` error which stops the PHPCS dead for the file being scanned, this includes breaking the run for all other sniffs in a project ruleset.

Exceptions are intended for developers, not for end-users.

The end-user of PHPCS can do nothing with an uncaught exception. Instead, this exception should be caught within the sniff and he sniff should return silently as it couldn't be determined whether something is or isn't an error for the rules the sniff is checking for.

Includes adjusted unit tests for the `BlockControlStructureSpacing` sniff.

Related to #841