### PR TITLE
Travis: fail the build early if CS/PHPStan would fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,16 @@ jobs:
       env: DEPENDENCIES=highest
       script: bin/phing lint
 
+    - stage: Coding standard
+      php: 7.4
+      env: DEPENDENCIES=highest
+      script: bin/phing cs
+
+    - stage: Static analysis
+      php: 7.4
+      env: DEPENDENCIES=highest
+      script: bin/phing phpstan
+
     - stage: Tests
       php: 7.1
       env: DEPENDENCIES=lowest
@@ -158,16 +168,6 @@ jobs:
         - choco install composer --ia "/DEV=C:\tools\php"
         - export PATH=/c/tools/php:$PATH
       script: bin/phing tests-without-code-coverage
-
-    - stage: Coding standard
-      php: 7.4
-      env: DEPENDENCIES=highest
-      script: bin/phing cs
-
-    - stage: Static analysis
-      php: 7.4
-      env: DEPENDENCIES=highest
-      script: bin/phing phpstan
 
     - stage: Code coverage
       php: 7.4


### PR DESCRIPTION
... instead of running the (more expensive) unit tests first.

This will give quicker build results for builds which would fail on CS/PHPStan.