### PR TITLE
Bug fix: rename AbstractControlStructureSpacingSniff (remove Sniff suffix)

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Classes/AbstractPropertyAndConstantSpacing.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/AbstractPropertyAndConstantSpacing.php
@@ -19,7 +19,7 @@ use const T_STRING;
 use const T_VAR;
 use const T_VARIABLE;
 
-abstract class AbstractPropertyAndConstantSpacingSniff implements Sniff
+abstract class AbstractPropertyAndConstantSpacing implements Sniff
 {
 
 	/** @var int */

--- a/SlevomatCodingStandard/Sniffs/Classes/ConstantSpacingSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/ConstantSpacingSniff.php
@@ -6,7 +6,7 @@ use PHP_CodeSniffer\Files\File;
 use function sprintf;
 use const T_CONST;
 
-class ConstantSpacingSniff extends AbstractPropertyAndConstantSpacingSniff
+class ConstantSpacingSniff extends AbstractPropertyAndConstantSpacing
 {
 
 	public const CODE_INCORRECT_COUNT_OF_BLANK_LINES_AFTER_CONSTANT = 'IncorrectCountOfBlankLinesAfterConstant';

--- a/SlevomatCodingStandard/Sniffs/Classes/ParentCallSpacingSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/ParentCallSpacingSniff.php
@@ -5,13 +5,13 @@ namespace SlevomatCodingStandard\Sniffs\Classes;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use SlevomatCodingStandard\Helpers\TokenHelper;
-use SlevomatCodingStandard\Sniffs\ControlStructures\AbstractControlStructureSpacingSniff;
+use SlevomatCodingStandard\Sniffs\ControlStructures\AbstractControlStructureSpacing;
 use function array_key_exists;
 use function array_merge;
 use function in_array;
 use const T_PARENT;
 
-class ParentCallSpacingSniff extends AbstractControlStructureSpacingSniff
+class ParentCallSpacingSniff extends AbstractControlStructureSpacing
 {
 
 	/**

--- a/SlevomatCodingStandard/Sniffs/Classes/PropertySpacingSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/PropertySpacingSniff.php
@@ -9,7 +9,7 @@ use const T_PROTECTED;
 use const T_PUBLIC;
 use const T_VAR;
 
-class PropertySpacingSniff extends AbstractPropertyAndConstantSpacingSniff
+class PropertySpacingSniff extends AbstractPropertyAndConstantSpacing
 {
 
 	public const CODE_INCORRECT_COUNT_OF_BLANK_LINES_AFTER_PROPERTY = 'IncorrectCountOfBlankLinesAfterProperty';

--- a/SlevomatCodingStandard/Sniffs/ControlStructures/AbstractControlStructureSpacing.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/AbstractControlStructureSpacing.php
@@ -46,7 +46,7 @@ use const T_TRY;
 use const T_WHILE;
 use const T_WHITESPACE;
 
-abstract class AbstractControlStructureSpacingSniff implements Sniff
+abstract class AbstractControlStructureSpacing implements Sniff
 {
 
 	public const CODE_INCORRECT_LINES_COUNT_BEFORE_CONTROL_STRUCTURE = 'IncorrectLinesCountBeforeControlStructure';

--- a/SlevomatCodingStandard/Sniffs/ControlStructures/BlockControlStructureSpacingSniff.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/BlockControlStructureSpacingSniff.php
@@ -16,7 +16,7 @@ use const T_SWITCH;
 use const T_TRY;
 use const T_WHILE;
 
-class BlockControlStructureSpacingSniff extends AbstractControlStructureSpacingSniff
+class BlockControlStructureSpacingSniff extends AbstractControlStructureSpacing
 {
 
 	/** @var string[] */

--- a/SlevomatCodingStandard/Sniffs/ControlStructures/JumpStatementsSpacingSniff.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/JumpStatementsSpacingSniff.php
@@ -16,7 +16,7 @@ use const T_THROW;
 use const T_YIELD;
 use const T_YIELD_FROM;
 
-class JumpStatementsSpacingSniff extends AbstractControlStructureSpacingSniff
+class JumpStatementsSpacingSniff extends AbstractControlStructureSpacing
 {
 
 	/** @var bool */

--- a/build/phpcs.xml
+++ b/build/phpcs.xml
@@ -34,7 +34,7 @@
 	<rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
 	<rule ref="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming">
 		<exclude-pattern>SlevomatCodingStandard/Sniffs/Classes/AbstractPropertyAndConstantSpacingSniff.php</exclude-pattern>
-		<exclude-pattern>SlevomatCodingStandard/Sniffs/ControlStructures/AbstractControlStructureSpacingSniff.php</exclude-pattern>
+		<exclude-pattern>SlevomatCodingStandard/Sniffs/ControlStructures/AbstractControlStructureSpacing.php</exclude-pattern>
 		<exclude-pattern>SlevomatCodingStandard/Sniffs/Namespaces/AbstractFullyQualifiedGlobalReference.php</exclude-pattern>
 	</rule>
 	<rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming"/>

--- a/build/phpcs.xml
+++ b/build/phpcs.xml
@@ -33,7 +33,7 @@
 	<rule ref="SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants"/>
 	<rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
 	<rule ref="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming">
-		<exclude-pattern>SlevomatCodingStandard/Sniffs/Classes/AbstractPropertyAndConstantSpacingSniff.php</exclude-pattern>
+		<exclude-pattern>SlevomatCodingStandard/Sniffs/Classes/AbstractPropertyAndConstantSpacing.php</exclude-pattern>
 		<exclude-pattern>SlevomatCodingStandard/Sniffs/ControlStructures/AbstractControlStructureSpacing.php</exclude-pattern>
 		<exclude-pattern>SlevomatCodingStandard/Sniffs/Namespaces/AbstractFullyQualifiedGlobalReference.php</exclude-pattern>
 	</rule>


### PR DESCRIPTION
PHPCS automatically loads all files with a `Sniff.php` suffix in `Sniffs/Category` directories of a standard, presuming they are actual sniffs.
And if the complete standard is included, it will (generally speaking) do so in category -> file alphabetic order.

As - with that logic - the newly introduced `ParentCallSpacingSniff` is loaded before the sniffs in the `ControlStructures` category and extends the `AbstractControlStructureSpacingSniff` which will therefore be autoloaded, a `Fatal error:  Cannot declare class SlevomatCodingStandard\Sniffs\ControlStructures\AbstractControlStructureSpacingSniff, because the name is already in use`  will be the result when the PHPCS autoloader reaches the `ControlStructures` folder.

The PHPCS autoloader will also handle the loading of non-Sniff files in the `SlevomatCodingStandard` directory and subdirectories without problem or conflict, they just shouldn't be suffixed with `Sniff`.

Having said all that, this PR renames the `AbstractControlStructureSpacingSniff` class to `AbstractControlStructureSpacing`, including renaming the file.

This solves the conflict.

Alternatively, it could be elected to move all `abstract` base sniff classes to, for instance, an `Abstracts` subdirectory of `SlevomatCodingStandard`. That should also solve the problem.