### PR TITLE
Fix RequireSingleLineMethodSignature for semicolons

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Classes/AbstractMethodSignature.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/AbstractMethodSignature.php
@@ -46,6 +46,9 @@ abstract class AbstractMethodSignature implements Sniff
 		assert(!is_bool($signatureStartPointer));
 
 		$pointerAfterSignatureEnd = TokenHelper::findNext($phpcsFile, [T_OPEN_CURLY_BRACKET, T_SEMICOLON], $methodPointer + 1);
+		if ($phpcsFile->getTokens()[$pointerAfterSignatureEnd]['code'] === T_SEMICOLON) {
+			return [$signatureStartPointer, $pointerAfterSignatureEnd];
+		}
 
 		$signatureEndPointer = TokenHelper::findPreviousEffective($phpcsFile, $pointerAfterSignatureEnd - 1);
 		assert(is_int($signatureEndPointer));

--- a/tests/Sniffs/Classes/data/requireSingleLineMethodSignatureNoErrors.php
+++ b/tests/Sniffs/Classes/data/requireSingleLineMethodSignatureNoErrors.php
@@ -45,7 +45,7 @@ interface B
 	);
 
 	public function multiLineMethodWithPrecisely121CharsOnSingleline(
-		$someHugeVariableNameJustToFillTheSpaceBlaah
+		$someHugeVariableNameJustToFillTheSpaceBlah
 	) : void;
 }
 


### PR DESCRIPTION
Not sure why would you @kukulich change the test when it was working fine before ... anyway, I reverted your change and added a fix.

Without this, the phpcs was jumping between LineLengthSniff error when on single line and with error here when on multiple lines...