### PR TITLE
Allow suppress for NullableTypeForNullDefaultValue sniff

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,7 +735,7 @@ Sniff provides the following settings:
 
 * `spacesCountBeforeColon`: the number of spaces expected between closing brace and colon.
 
-#### SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue 🔧
+#### SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue 🔧🚧
 
 Checks whether the nullablity `?` symbol is present before each nullable and optional parameter (which are marked as `= null`):
 

--- a/SlevomatCodingStandard/Sniffs/TypeHints/NullableTypeForNullDefaultValueSniff.php
+++ b/SlevomatCodingStandard/Sniffs/TypeHints/NullableTypeForNullDefaultValueSniff.php
@@ -4,6 +4,7 @@ namespace SlevomatCodingStandard\Sniffs\TypeHints;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
+use SlevomatCodingStandard\Helpers\SuppressHelper;
 use SlevomatCodingStandard\Helpers\TokenHelper;
 use function array_key_exists;
 use function array_merge;
@@ -22,6 +23,8 @@ class NullableTypeForNullDefaultValueSniff implements Sniff
 
 	public const CODE_NULLABILITY_SYMBOL_REQUIRED = 'NullabilitySymbolRequired';
 
+	private const NAME = 'SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue';
+
 	/**
 	 * @return array<int, (int|string)>
 	 */
@@ -37,6 +40,10 @@ class NullableTypeForNullDefaultValueSniff implements Sniff
 	 */
 	public function process(File $phpcsFile, $functionPointer): void
 	{
+		if (SuppressHelper::isSniffSuppressed($phpcsFile, $functionPointer, self::NAME)) {
+			return;
+		}
+
 		$tokens = $phpcsFile->getTokens();
 
 		$parenthesisOpener = array_key_exists('parenthesis_opener', $tokens[$functionPointer])

--- a/tests/Sniffs/TypeHints/data/nullableTypeForNullDefaultValueNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/nullableTypeForNullDefaultValueNoErrors.php
@@ -24,6 +24,14 @@ trait Foo
 class FooBar extends \stdClass
 {
 
+	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue
+	 */
+	private function isSniffSuppressed(string $a = null)
+	{
+
+	}
+
 	public function valid(?bool $bool = null, $noTypehint = null, ?int $int, string $a = 'default', ?string $b = 'null')
 	{
 


### PR DESCRIPTION
Eg. Symfony still supports ancient PHP 7.1 so type hints are often declared as

```php
    /**
     * Gets the listeners of a specific event or all listeners sorted by descending priority.
     *
     * @return array The event listeners for the specified event, or all event listeners by event name
     */
    public function getListeners(string $eventName = null);
```
 with missing `?` for nullable types. It is not possible to type hint implementations as 

```php
    public function getListeners(?string $eventName = null) {}
```

Therefore there's need for suppressing the `SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue.NullabilitySymbolRequired`