### PR TITLE
TraitUseSpacingSniff: Add linesCountBeforeFirstUseWhenFirstInClass #866

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ Enforces configurable number of lines before first `use`, after last `use` and b
 Sniff provides the following settings:
 
 * `linesCountBeforeFirstUse`: allows to configure the number of lines before first `use`.
+* `linesCountBeforeFirstUseWhenFirstInClass`: allows to configure the number of lines before first `use` when the `use` is the first statement in the class.
 * `linesCountBetweenUses`: allows to configure the number of lines between two `use` statements.
 * `linesCountAfterLastUse`: allows to configure the number of lines after last `use`.
 * `linesCountAfterLastUseWhenLastInClass`: allows to configure the number of lines after last `use` when the `use` is the last statement in the class.

--- a/SlevomatCodingStandard/Sniffs/Classes/TraitUseSpacingSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/TraitUseSpacingSniff.php
@@ -29,6 +29,9 @@ class TraitUseSpacingSniff implements Sniff
 	public $linesCountBeforeFirstUse = 1;
 
 	/** @var int */
+	public $linesCountBeforeFirstUseWhenFirstInClass = null;
+
+	/** @var int */
 	public $linesCountBetweenUses = 0;
 
 	/** @var int */
@@ -69,8 +72,11 @@ class TraitUseSpacingSniff implements Sniff
 
 	private function checkLinesBeforeFirstUse(File $phpcsFile, int $firstUsePointer): void
 	{
+		$tokens = $phpcsFile->getTokens();
+
 		/** @var int $pointerBeforeFirstUse */
 		$pointerBeforeFirstUse = TokenHelper::findPreviousExcluding($phpcsFile, T_WHITESPACE, $firstUsePointer - 1);
+		$isAtTheStartOfClass = $tokens[$pointerBeforeFirstUse]['code'] === T_OPEN_CURLY_BRACKET;
 
 		$whitespaceBeforeFirstUse = '';
 
@@ -79,6 +85,12 @@ class TraitUseSpacingSniff implements Sniff
 		}
 
 		$requiredLinesCountBeforeFirstUse = SniffSettingsHelper::normalizeInteger($this->linesCountBeforeFirstUse);
+		if (
+			$isAtTheStartOfClass
+			&& $this->linesCountBeforeFirstUseWhenFirstInClass !== null
+		) {
+			$requiredLinesCountBeforeFirstUse = SniffSettingsHelper::normalizeInteger($this->linesCountBeforeFirstUseWhenFirstInClass);
+		}
 		$actualLinesCountBeforeFirstUse = substr_count($whitespaceBeforeFirstUse, $phpcsFile->eolChar) - 1;
 
 		if ($actualLinesCountBeforeFirstUse === $requiredLinesCountBeforeFirstUse) {

--- a/tests/Sniffs/Classes/TraitUseSpacingSniffTest.php
+++ b/tests/Sniffs/Classes/TraitUseSpacingSniffTest.php
@@ -62,6 +62,7 @@ class TraitUseSpacingSniffTest extends TestCase
 	{
 		$report = self::checkFile(__DIR__ . '/data/traitUseSpacingModifiedSettingsNoErrors.php', [
 			'linesCountBeforeFirstUse' => 0,
+			'linesCountBeforeFirstUseWhenFirstInClass' => 0,
 			'linesCountBetweenUses' => 1,
 			'linesCountAfterLastUse' => 2,
 			'linesCountAfterLastUseWhenLastInClass' => 2,
@@ -73,6 +74,7 @@ class TraitUseSpacingSniffTest extends TestCase
 	{
 		$report = self::checkFile(__DIR__ . '/data/traitUseSpacingModifiedSettingsErrors.php', [
 			'linesCountBeforeFirstUse' => 0,
+			'linesCountBeforeFirstUseWhenFirstInClass' => 0,
 			'linesCountBetweenUses' => 1,
 			'linesCountAfterLastUse' => 2,
 			'linesCountAfterLastUseWhenLastInClass' => 2,
@@ -89,10 +91,44 @@ class TraitUseSpacingSniffTest extends TestCase
 		self::assertAllFixedInFile($report);
 	}
 
+	public function testModifiedSettingWhenUseIsFirstInClassNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/traitUseSpacingModifiedSettingsWhenUseIsLastInClassNoErrors.php', [
+			'linesCountBeforeFirstUse' => 2,
+			'linesCountBeforeFirstUseWhenFirstInClass' => 0,
+			'linesCountBetweenUses' => 1,
+			'linesCountAfterLastUse' => 0,
+			'linesCountAfterLastUseWhenLastInClass' => 0,
+		]);
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testModifiedSettingWhenUseIsFirstInClassErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/traitUseSpacingModifiedSettingsWhenUseIsLastInClassErrors.php', [
+			'linesCountBeforeFirstUse' => 2,
+			'linesCountBeforeFirstUseWhenFirstInClass' => 0,
+			'linesCountBetweenUses' => 1,
+			'linesCountAfterLastUse' => 0,
+			'linesCountAfterLastUseWhenLastInClass' => 0,
+		]);
+
+		self::assertSame(5, $report->getErrorCount());
+
+		self::assertSniffError($report, 6, TraitUseSpacingSniff::CODE_INCORRECT_LINES_COUNT_BEFORE_FIRST_USE);
+		self::assertSniffError($report, 7, TraitUseSpacingSniff::CODE_INCORRECT_LINES_COUNT_BETWEEN_USES);
+		self::assertSniffError($report, 10, TraitUseSpacingSniff::CODE_INCORRECT_LINES_COUNT_BETWEEN_USES);
+		self::assertSniffError($report, 11, TraitUseSpacingSniff::CODE_INCORRECT_LINES_COUNT_BETWEEN_USES);
+		self::assertSniffError($report, 11, TraitUseSpacingSniff::CODE_INCORRECT_LINES_COUNT_AFTER_LAST_USE);
+
+		self::assertAllFixedInFile($report);
+	}
+
 	public function testModifiedSettingWhenUseIsLastInClassNoErrors(): void
 	{
 		$report = self::checkFile(__DIR__ . '/data/traitUseSpacingModifiedSettingsWhenUseIsLastInClassNoErrors.php', [
 			'linesCountBeforeFirstUse' => 0,
+			'linesCountBeforeFirstUseWhenFirstInClass' => 0,
 			'linesCountBetweenUses' => 1,
 			'linesCountAfterLastUse' => 2,
 			'linesCountAfterLastUseWhenLastInClass' => 0,
@@ -104,6 +140,7 @@ class TraitUseSpacingSniffTest extends TestCase
 	{
 		$report = self::checkFile(__DIR__ . '/data/traitUseSpacingModifiedSettingsWhenUseIsLastInClassErrors.php', [
 			'linesCountBeforeFirstUse' => 0,
+			'linesCountBeforeFirstUseWhenFirstInClass' => 0,
 			'linesCountBetweenUses' => 1,
 			'linesCountAfterLastUse' => 2,
 			'linesCountAfterLastUseWhenLastInClass' => 0,
@@ -124,6 +161,7 @@ class TraitUseSpacingSniffTest extends TestCase
 	{
 		$report = self::checkFile(__DIR__ . '/data/traitUseSpacingModifiedSettingsWhenUseIsLastInClass2Errors.php', [
 			'linesCountBeforeFirstUse' => 0,
+			'linesCountBeforeFirstUseWhenFirstInClass' => 1,
 			'linesCountBetweenUses' => 0,
 			'linesCountAfterLastUse' => 1,
 			'linesCountAfterLastUseWhenLastInClass' => 0,

--- a/tests/Sniffs/Classes/data/traitUseSpacingModifiedSettingsWhenUseIsFirstInClassErrors.php
+++ b/tests/Sniffs/Classes/data/traitUseSpacingModifiedSettingsWhenUseIsFirstInClassErrors.php
@@ -1,0 +1,17 @@
+<?php
+
+class Whatever
+{
+
+
+
+	use A;
+	use B;
+
+
+	use C;
+	use D {
+		D::d as dd;
+	}
+
+}

--- a/tests/Sniffs/Classes/data/traitUseSpacingModifiedSettingsWhenUseIsFirstInClassNoErrors.php
+++ b/tests/Sniffs/Classes/data/traitUseSpacingModifiedSettingsWhenUseIsFirstInClassNoErrors.php
@@ -1,0 +1,14 @@
+<?php
+
+class Whatever
+{
+	use A;
+
+	use B;
+
+	use C;
+
+	use D {
+		D::d as dd;
+	}
+}


### PR DESCRIPTION
Hello,

I prepared this PR for my issue #866 from last week.

It adds a `linesCountBeforeFirstUseWhenFirstInClass` setting to the `SlevomatCodingStandard.Classes.TraitUseSpacing` sniff.