### PR TITLE
Fix issue with custom values and int cast

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Classes/AbstractPropertyAndConstantSpacing.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/AbstractPropertyAndConstantSpacing.php
@@ -4,6 +4,7 @@ namespace SlevomatCodingStandard\Sniffs\Classes;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
+use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
 use SlevomatCodingStandard\Helpers\TokenHelper;
 use function assert;
 use function in_array;
@@ -69,11 +70,11 @@ abstract class AbstractPropertyAndConstantSpacing implements Sniff
 
 		$linesBetween = $tokens[$nextPointer]['line'] - $tokens[$nextSemicolon]['line'] - 1;
 		if (in_array($tokens[$nextPointer]['code'], [T_DOC_COMMENT_OPEN_TAG, T_COMMENT], true)) {
-			$minExpectedLines = $this->minLinesCountBeforeWithComment;
-			$maxExpectedLines = $this->maxLinesCountBeforeWithComment;
+			$minExpectedLines = SniffSettingsHelper::normalizeInteger($this->minLinesCountBeforeWithComment);
+			$maxExpectedLines = SniffSettingsHelper::normalizeInteger($this->maxLinesCountBeforeWithComment);
 		} else {
-			$minExpectedLines = $this->minLinesCountBeforeWithoutComment;
-			$maxExpectedLines = $this->maxLinesCountBeforeWithoutComment;
+			$minExpectedLines = SniffSettingsHelper::normalizeInteger($this->minLinesCountBeforeWithoutComment);
+			$maxExpectedLines = SniffSettingsHelper::normalizeInteger($this->maxLinesCountBeforeWithoutComment);
 		}
 
 		if ($linesBetween >= $minExpectedLines && $linesBetween <= $maxExpectedLines) {


### PR DESCRIPTION
When specifying custom value, it's not casted as a string.
Thus we ensure we compare integers together with other integers and fix issue with bad addError() call with string param instead of int.

Fixed error : 
`
PHP Fatal error:  Uncaught TypeError: Argument 4 passed to SlevomatCodingStandard\Sniffs\Classes\PropertySpacingSniff::addError() must be of the type int, string given, called in vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/Classes/AbstractPropertyAndConstantSpacing.php on line 83 and defined in vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/Classes/PropertySpacingSniff.php:25
`