### PR TITLE
Fix non-detected private typed properties in PHP 7.4

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Classes/UnusedPrivateElementsSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/UnusedPrivateElementsSniff.php
@@ -39,6 +39,7 @@ use const T_MINUS_EQUAL;
 use const T_MOD_EQUAL;
 use const T_MUL_EQUAL;
 use const T_NEW;
+use const T_NULLABLE;
 use const T_OBJECT_OPERATOR;
 use const T_OPEN_PARENTHESIS;
 use const T_OR_EQUAL;
@@ -620,6 +621,16 @@ class UnusedPrivateElementsSniff implements Sniff
 		$visibilityModifiedToken = $tokens[$visibilityModifiedTokenPointer];
 		if (in_array($visibilityModifiedToken['code'], [T_PUBLIC, T_PROTECTED, T_PRIVATE], true)) {
 			return $visibilityModifiedTokenPointer;
+		}
+
+		if (in_array($visibilityModifiedToken['code'], [T_SELF, T_STRING], true)) {
+			$mightBeNullableTokenPointer = TokenHelper::findPreviousEffective($phpcsFile, $visibilityModifiedTokenPointer - 1);
+			$mightBeNullableToken = $tokens[$mightBeNullableTokenPointer];
+			if ($mightBeNullableToken['code'] === T_NULLABLE) {
+				$visibilityModifiedTokenPointer = $mightBeNullableTokenPointer;
+			}
+
+			return $this->findVisibilityModifierTokenPointer($phpcsFile, $tokens, $visibilityModifiedTokenPointer);
 		}
 
 		if (in_array($visibilityModifiedToken['code'], [T_ABSTRACT, T_STATIC], true)) {

--- a/tests/Sniffs/Classes/UnusedPrivateElementsSniffTest.php
+++ b/tests/Sniffs/Classes/UnusedPrivateElementsSniffTest.php
@@ -231,4 +231,14 @@ class UnusedPrivateElementsSniffTest extends TestCase
 		}
 	}
 
+	public function testClassWithTypedProperties(): void
+	{
+		$resultFile = self::checkFile(__DIR__ . '/data/classWithTypedProperties.php');
+
+		self::assertNoSniffError($resultFile, 6);
+		self::assertSniffError($resultFile, 7, UnusedPrivateElementsSniff::CODE_WRITE_ONLY_PROPERTY);
+		self::assertSniffError($resultFile, 8, UnusedPrivateElementsSniff::CODE_WRITE_ONLY_PROPERTY);
+		self::assertSniffError($resultFile, 9, UnusedPrivateElementsSniff::CODE_WRITE_ONLY_PROPERTY);
+	}
+
 }

--- a/tests/Sniffs/Classes/data/classWithTypedProperties.php
+++ b/tests/Sniffs/Classes/data/classWithTypedProperties.php
@@ -1,0 +1,24 @@
+<?php // lint >= 7.4
+
+class ClassWithTypedProperties
+{
+
+	private self $self;
+	private ?self $empty;
+	private ClassWithTypedProperties $static;
+	private int $int;
+
+	public function __construct()
+	{
+		$this->self = $this;
+		$this->empty = null;
+		$this->static = $this;
+		$this->int = 0;
+	}
+
+	public function getSelf(): self
+	{
+		return $this->self;
+	}
+
+}


### PR DESCRIPTION
Private typed properties are not detected, thus sniffs likes WriteOnly do not detect them.

I had to handle php7.4 vs php7.3 in the build script to exclude php7.4 specific files from `lint` target.