### PR TITLE
Don't crash on shorthand nullable return types

### DIFF
--- a/SlevomatCodingStandard/Helpers/AnnotationTypeHelper.php
+++ b/SlevomatCodingStandard/Helpers/AnnotationTypeHelper.php
@@ -298,11 +298,15 @@ class AnnotationTypeHelper
 	}
 
 	/**
-	 * @param UnionTypeNode|IntersectionTypeNode $typeNode
+	 * @param UnionTypeNode|IntersectionTypeNode|NullableTypeNode $typeNode
 	 * @return bool
 	 */
 	public static function containsNullType(TypeNode $typeNode): bool
 	{
+		if ($typeNode instanceof NullableTypeNode) {
+			return true;
+		}
+
 		foreach ($typeNode->types as $innerTypeNode) {
 			if (!$innerTypeNode instanceof IdentifierTypeNode) {
 				continue;
@@ -503,12 +507,20 @@ class AnnotationTypeHelper
 	}
 
 	/**
-	 * @param UnionTypeNode|IntersectionTypeNode $typeNode
+	 * @param UnionTypeNode|IntersectionTypeNode|NullableTypeNode $typeNode
 	 * @return TypeNode
 	 */
 	public static function getTypeFromNullableType(TypeNode $typeNode): TypeNode
 	{
-		return $typeNode->types[0] instanceof IdentifierTypeNode && strtolower($typeNode->types[0]->name) === 'null' ? $typeNode->types[1] : $typeNode->types[0];
+		if ($typeNode instanceof NullableTypeNode) {
+			return $typeNode->type;
+		} elseif (
+			$typeNode->types[0] instanceof IdentifierTypeNode
+			&& strtolower($typeNode->types[0]->name) === 'null'
+		) {
+			return $typeNode->types[1];
+		}
+		return $typeNode->types[0];
 	}
 
 	/**

--- a/SlevomatCodingStandard/Helpers/AnnotationTypeHelper.php
+++ b/SlevomatCodingStandard/Helpers/AnnotationTypeHelper.php
@@ -514,7 +514,9 @@ class AnnotationTypeHelper
 	{
 		if ($typeNode instanceof NullableTypeNode) {
 			return $typeNode->type;
-		} elseif (
+		}
+
+		if (
 			$typeNode->types[0] instanceof IdentifierTypeNode
 			&& strtolower($typeNode->types[0]->name) === 'null'
 		) {

--- a/tests/Sniffs/TypeHints/data/returnTypeHintNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/returnTypeHintNoErrors.php
@@ -79,13 +79,15 @@ class Whatever
 		return null;
 	}
 
+	// phpcs:disable SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
 	/**
 	 * @return ?string
 	 */
-	public function shorthandNullableDocblock(): ?string
+	public function shorthandNullableDocblock()
 	{
 		return rand(0, 1) ? null : '';
 	}
+	// phpcs:enable
 
 	/**
 	 * @return string|int|bool

--- a/tests/Sniffs/TypeHints/data/returnTypeHintNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/returnTypeHintNoErrors.php
@@ -80,6 +80,14 @@ class Whatever
 	}
 
 	/**
+	 * @return ?string
+	 */
+	public function shorthandNullableDocblock(): ?string
+	{
+		return rand(0, 1) ? null : '';
+	}
+
+	/**
 	 * @return string|int|bool
 	 */
 	public function aLotOfTypes()


### PR DESCRIPTION
Previously slevomat/coding-standard would crash (report an Internal.Exception issue) on shorthand nullable return types in a docblock (e.g. `@return ?int`). This change fixes the crash.

Example of a crash
```
FILE: /home/weirdan/src/doctrine-psalm-plugin/stubs/ObjectRepository.php
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 1 | ERROR | An error occurred during processing; checking has been aborted. The error message was: Undefined property: PHPStan\PhpDocParser\Ast\Type\NullableTypeNode::$types in
   |       | /home/weirdan/src/doctrine-psalm-plugin/vendor/slevomat/coding-standard/SlevomatCodingStandard/Helpers/AnnotationTypeHelper.php on line 306 (Internal.Exception)
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```