### PR TITLE
Improve class structure sniff

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Classes/ClassStructureSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/ClassStructureSniff.php
@@ -12,13 +12,14 @@ use SlevomatCodingStandard\Helpers\PropertyHelper;
 use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
 use SlevomatCodingStandard\Helpers\TokenHelper;
 use function array_diff;
+use function array_filter;
 use function array_flip;
 use function array_key_exists;
 use function array_keys;
 use function array_merge;
 use function array_values;
 use function assert;
-use function count;
+use function implode;
 use function in_array;
 use function preg_replace;
 use function preg_split;
@@ -132,8 +133,19 @@ class ClassStructureSniff implements Sniff
 				continue;
 			}
 
+			$expectedGroups = array_filter(
+				$groupsOrder,
+				static function (int $order) use ($groupsOrder, $expectedGroup): bool {
+					return $order >= $groupsOrder[$expectedGroup];
+				}
+			);
 			$fix = $phpcsFile->addFixableError(
-				sprintf('The placement of "%s" group is invalid.', $group),
+				sprintf(
+					'The placement of "%s" group is invalid. Last group was "%s" and one of these is expected after it: %s',
+					$group,
+					$expectedGroup,
+					implode(', ', array_keys($expectedGroups))
+				),
 				$groupFirstMemberPointer,
 				self::CODE_INCORRECT_GROUP_ORDER
 			);

--- a/SlevomatCodingStandard/Sniffs/Classes/ClassStructureSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/ClassStructureSniff.php
@@ -11,8 +11,10 @@ use SlevomatCodingStandard\Helpers\FunctionHelper;
 use SlevomatCodingStandard\Helpers\PropertyHelper;
 use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
 use SlevomatCodingStandard\Helpers\TokenHelper;
+use function array_diff;
 use function array_flip;
 use function array_key_exists;
+use function array_keys;
 use function array_merge;
 use function array_values;
 use function assert;
@@ -471,16 +473,12 @@ class ClassStructureSniff implements Sniff
 				$order++;
 			}
 
-			if (count($normalizedGroups) === 0) {
+			if ($normalizedGroups === []) {
 				$normalizedGroups = array_flip($supportedGroups);
 			} else {
-				$missingGroupsOrder = count($normalizedGroups) + 1;
-				foreach ($supportedGroups as $supportedGroup) {
-					if (array_key_exists($supportedGroup, $normalizedGroups)) {
-						continue;
-					}
-
-					$normalizedGroups[$supportedGroup] = $missingGroupsOrder;
+				$missingGroups = array_diff($supportedGroups, array_keys($normalizedGroups));
+				if ($missingGroups !== []) {
+					throw new MissingClassGroupsException($missingGroups);
 				}
 			}
 

--- a/SlevomatCodingStandard/Sniffs/Classes/MissingClassGroupsException.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/MissingClassGroupsException.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Classes;
+
+use Exception;
+use function implode;
+use function sprintf;
+
+class MissingClassGroupsException extends Exception
+{
+
+	/** @param string[] $groups */
+	public function __construct(array $groups)
+	{
+		parent::__construct(
+			sprintf(
+				'You need configure all class groups. These groups are missing from your configuration: %s.',
+				implode(', ', $groups)
+			)
+		);
+	}
+
+}

--- a/build/phpcs.xml
+++ b/build/phpcs.xml
@@ -52,8 +52,10 @@
 				<element value="private properties"/>
 				<element value="private static properties"/>
 				<element value="public abstract methods, public static abstract methods"/>
-				<element value="protected abstract methods, protected abstract methods"/>
+				<element value="protected abstract methods, protected static abstract methods"/>
 				<element value="constructor"/>
+				<element value="static constructors"/>
+				<element value="destructor"/>
 				<element value="public methods"/>
 				<element value="public static methods"/>
 				<element value="protected methods"/>

--- a/tests/Sniffs/Classes/ClassStructureSniffTest.php
+++ b/tests/Sniffs/Classes/ClassStructureSniffTest.php
@@ -11,11 +11,11 @@ class ClassStructureSniffTest extends TestCase
 		'uses',
 		'public constants, protected constants, private constants',
 		'public static properties, protected static properties, private static properties',
-		'public static methods, protected static methods, private static methods',
+		'public static abstract methods, public static methods, protected static abstract methods, protected static methods, private static methods',
 		'public properties, protected properties, private properties',
 		'magic methods',
-		'public methods, protected methods, private methods',
-		'constructor',
+		'public abstract methods, public methods, protected abstract methods, protected methods, private methods',
+		'constructor, destructor',
 		'static constructors',
 	];
 
@@ -101,7 +101,7 @@ class ClassStructureSniffTest extends TestCase
 		self::assertAllFixedInFile($report);
 	}
 
-	public function testThrowExceptionForUnsupportedSection(): void
+	public function testThrowExceptionForUnsupportedGroup(): void
 	{
 		try {
 			self::checkFile(
@@ -111,6 +111,19 @@ class ClassStructureSniffTest extends TestCase
 			self::fail();
 		} catch (UnsupportedClassGroupException $e) {
 			self::assertStringContainsString('whatever', $e->getMessage());
+		}
+	}
+
+	public function testThrowExceptionForMissingGroups(): void
+	{
+		try {
+			self::checkFile(
+				__DIR__ . '/data/classStructureSniffNoErrors.php',
+				['groups' => ['uses']]
+			);
+			self::fail();
+		} catch (MissingClassGroupsException $e) {
+			self::assertStringContainsString(', constructor, static constructors, destructor, ', $e->getMessage());
 		}
 	}
 


### PR DESCRIPTION
Example of new error message:
`The placement of "protected static abstract methods" group is invalid. Last group was "public methods" and one of these is expected after it: public methods, public static methods, protected methods, protected static methods, private methods, private static methods, magic methods`