### PR TITLE
`RequireArrowFunctionSniff` requires PHP 7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,7 @@ Requires arrow functions.
 Sniff provides the following settings:
 
 * `allowNested` (defaults to `true`)
+* `enable`: either to enable or no this sniff. By default, it is enabled for PHP versions 7.4 or higher.
 
 #### SlevomatCodingStandard.Functions.TrailingCommaInCall 🔧
 

--- a/SlevomatCodingStandard/Sniffs/Functions/RequireArrowFunctionSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Functions/RequireArrowFunctionSniff.php
@@ -5,6 +5,7 @@ namespace SlevomatCodingStandard\Sniffs\Functions;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use SlevomatCodingStandard\Helpers\ScopeHelper;
+use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
 use SlevomatCodingStandard\Helpers\TokenHelper;
 use function count;
 use const T_BITWISE_AND;
@@ -24,6 +25,9 @@ class RequireArrowFunctionSniff implements Sniff
 	/** @var bool */
 	public $allowNested = true;
 
+	/** @var bool|null  */
+	public $enable = null;
+
 	/**
 	 * @return array<int, (int|string)>
 	 */
@@ -41,6 +45,12 @@ class RequireArrowFunctionSniff implements Sniff
 	 */
 	public function process(File $phpcsFile, $closurePointer): void
 	{
+		$this->enable = SniffSettingsHelper::isEnabledByPhpVersion($this->enable, 70400);
+
+		if (!$this->enable) {
+			return;
+		}
+
 		$tokens = $phpcsFile->getTokens();
 
 		$returnPointer = TokenHelper::findNextEffective($phpcsFile, $tokens[$closurePointer]['scope_opener'] + 1);

--- a/tests/Sniffs/Functions/RequireArrowFunctionSniffTest.php
+++ b/tests/Sniffs/Functions/RequireArrowFunctionSniffTest.php
@@ -11,6 +11,7 @@ class RequireArrowFunctionSniffTest extends TestCase
 	{
 		$report = self::checkFile(__DIR__ . '/data/requireArrowFunctionDisallowNestedNoErrors.php', [
 			'allowNested' => false,
+			'enable' => true,
 		]);
 		self::assertNoSniffErrorInFile($report);
 	}
@@ -19,6 +20,7 @@ class RequireArrowFunctionSniffTest extends TestCase
 	{
 		$report = self::checkFile(__DIR__ . '/data/requireArrowFunctionDisallowNestedErrors.php', [
 			'allowNested' => false,
+			'enable' => true,
 		]);
 
 		self::assertSame(4, $report->getErrorCount());
@@ -35,6 +37,7 @@ class RequireArrowFunctionSniffTest extends TestCase
 	{
 		$report = self::checkFile(__DIR__ . '/data/requireArrowFunctionAllowNestedNoErrors.php', [
 			'allowNested' => true,
+			'enable' => true,
 		]);
 		self::assertNoSniffErrorInFile($report);
 	}
@@ -43,6 +46,7 @@ class RequireArrowFunctionSniffTest extends TestCase
 	{
 		$report = self::checkFile(__DIR__ . '/data/requireArrowFunctionAllowNestedErrors.php', [
 			'allowNested' => true,
+			'enable' => true,
 		]);
 
 		self::assertSame(3, $report->getErrorCount());
@@ -52,6 +56,17 @@ class RequireArrowFunctionSniffTest extends TestCase
 		self::assertSniffError($report, 4, RequireArrowFunctionSniff::CODE_REQUIRED_ARROW_FUNCTION);
 
 		self::assertAllFixedInFile($report);
+	}
+
+	public function testShouldNotReportIfSniffIsDisabled(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/requireArrowFunctionAllowNestedErrors.php', [
+			'allowNested' => true,
+			'enable' => false,
+		]);
+
+		self::assertSame(0, $report->getErrorCount());
+		self::assertNoSniffErrorInFile($report);
 	}
 
 }


### PR DESCRIPTION
Fix #924