### PR TITLE
Fix breaking syntax on removing useless one-line return type hint

### DIFF
--- a/SlevomatCodingStandard/Sniffs/TypeHints/ReturnTypeHintSniff.php
+++ b/SlevomatCodingStandard/Sniffs/TypeHints/ReturnTypeHintSniff.php
@@ -31,10 +31,12 @@ use function array_unique;
 use function array_values;
 use function count;
 use function lcfirst;
+use function max;
 use function sprintf;
 use function strtolower;
 use const T_CLOSURE;
 use const T_DOC_COMMENT_CLOSE_TAG;
+use const T_DOC_COMMENT_OPEN_TAG;
 use const T_DOC_COMMENT_STAR;
 use const T_FUNCTION;
 
@@ -394,8 +396,11 @@ class ReturnTypeHintSniff implements Sniff
 			return;
 		}
 
+		$star = TokenHelper::findPrevious($phpcsFile, T_DOC_COMMENT_STAR, $returnAnnotation->getStartPointer() - 1);
+		$commentOpen = TokenHelper::findPrevious($phpcsFile, T_DOC_COMMENT_OPEN_TAG, $returnAnnotation->getStartPointer() - 1) + 1;
 		/** @var int $changeStart */
-		$changeStart = TokenHelper::findPrevious($phpcsFile, T_DOC_COMMENT_STAR, $returnAnnotation->getStartPointer() - 1);
+		$changeStart = max($star, $commentOpen);
+
 		/** @var int $changeEnd */
 		$changeEnd = TokenHelper::findNext($phpcsFile, [T_DOC_COMMENT_CLOSE_TAG, T_DOC_COMMENT_STAR], $returnAnnotation->getEndPointer() + 1) - 1;
 		$phpcsFile->fixer->beginChangeset();

--- a/tests/Sniffs/TypeHints/ReturnTypeHintSniffTest.php
+++ b/tests/Sniffs/TypeHints/ReturnTypeHintSniffTest.php
@@ -22,7 +22,7 @@ class ReturnTypeHintSniffTest extends TestCase
 			'traversableTypeHints' => ['Traversable'],
 		]);
 
-		self::assertSame(31, $report->getErrorCount());
+		self::assertSame(32, $report->getErrorCount());
 
 		self::assertSniffError($report, 6, ReturnTypeHintSniff::CODE_MISSING_ANY_TYPE_HINT);
 		self::assertSniffError($report, 14, ReturnTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
@@ -55,6 +55,7 @@ class ReturnTypeHintSniffTest extends TestCase
 		self::assertSniffError($report, 184, ReturnTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
 		self::assertSniffError($report, 191, ReturnTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
 		self::assertSniffError($report, 198, ReturnTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
+		self::assertSniffError($report, 211, ReturnTypeHintSniff::CODE_USELESS_ANNOTATION);
 
 		self::assertAllFixedInFile($report);
 	}

--- a/tests/Sniffs/TypeHints/data/returnTypeHintErrors.fixed.php
+++ b/tests/Sniffs/TypeHints/data/returnTypeHintErrors.fixed.php
@@ -194,4 +194,17 @@ abstract class Whatever
 	{
 	}
 
+    /**
+     *
+     * Documentation
+     *
+     */
+    public function withComment(): void
+    {
+    }
+
+    /***/
+    public function inlinePhpDoc(): string
+    {
+    }
 }

--- a/tests/Sniffs/TypeHints/data/returnTypeHintErrors.php
+++ b/tests/Sniffs/TypeHints/data/returnTypeHintErrors.php
@@ -199,4 +199,17 @@ abstract class Whatever
 	{
 	}
 
+    /**
+     *
+     * Documentation
+     *
+     */
+    public function withComment(): void
+    {
+    }
+
+    /** @return string */
+    public function inlinePhpDoc(): string
+    {
+    }
 }


### PR DESCRIPTION
Fixing useless return type hint was breaking php syntax
Example
```php
<?php
declare(strict_types=1);
/**
 * Date: 2/16/2018
 * Time: 1:42 PM
 *
 * @package
 * @author
 */
class TestClass
{

    /** @return string */
    public function test(): string
    {
    }
}
```
Transformed into
```php
<?php
declare(strict_types=1);
/**
 * Date: 2/16/2018
 * Time: 1:42 PM
 *
 * @package
 */
    public function test(): string
    {
    }
}
```

Because of error in detecting changeStart offset.