### PR TITLE
UnusedUsesSniff: improve performance

### DIFF
--- a/SlevomatCodingStandard/Helpers/NamespaceHelper.php
+++ b/SlevomatCodingStandard/Helpers/NamespaceHelper.php
@@ -23,6 +23,15 @@ class NamespaceHelper
 
 	public const NAMESPACE_SEPARATOR = '\\';
 
+	/**
+	 * @param File $phpcsFile
+	 * @return int[]
+	 */
+	public static function getAllNamespacesPointers(File $phpcsFile): array
+	{
+		return TokenHelper::findNextAll($phpcsFile, T_NAMESPACE, 0);
+	}
+
 	public static function isFullyQualifiedName(string $typeName): bool
 	{
 		return StringHelper::startsWith($typeName, self::NAMESPACE_SEPARATOR);

--- a/tests/Helpers/NamespaceHelperTest.php
+++ b/tests/Helpers/NamespaceHelperTest.php
@@ -167,6 +167,15 @@ class NamespaceHelperTest extends TestCase
 		self::assertSame('Lorem\Ipsum', $namespace);
 	}
 
+	public function testGetAllNamespacesWithMultipleNamespacesInFile(): void
+	{
+		$phpcsFile = $this->getCodeSnifferFile(
+			__DIR__ . '/data/multipleNamespaces.php'
+		);
+		$namespaces = NamespaceHelper::getAllNamespacesPointers($phpcsFile);
+		self::assertEquals([2, 16], $namespaces);
+	}
+
 	public function testResolveClassNameWithMoreNamespaces(): void
 	{
 		$phpcsFile = $this->getCodeSnifferFile(

--- a/tests/Sniffs/Namespaces/UnusedUsesSniffTest.php
+++ b/tests/Sniffs/Namespaces/UnusedUsesSniffTest.php
@@ -30,6 +30,50 @@ class UnusedUsesSniffTest extends TestCase
 		);
 	}
 
+	public function testUnusedUseWithMultipleNamespaces(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/unusedUsesMultipleNamespaces.php');
+
+		self::assertEquals(8, $report->getErrorCount());
+		self::assertSniffError(
+			$report,
+			5,
+			UnusedUsesSniff::CODE_UNUSED_USE,
+			'First\ObjectPrototype'
+		);
+		self::assertSniffError(
+			$report,
+			12,
+			UnusedUsesSniff::CODE_UNUSED_USE,
+			'FooBar\UnusedFunction'
+		);
+		self::assertSniffError(
+			$report,
+			14,
+			UnusedUsesSniff::CODE_UNUSED_USE,
+			'FooBar\UNUSED_CONSTANT'
+		);
+		self::assertSniffError(
+			$report,
+			53,
+			UnusedUsesSniff::CODE_UNUSED_USE,
+			'Human\Arm'
+		);
+		self::assertSniffError(
+			$report,
+			55,
+			UnusedUsesSniff::CODE_UNUSED_USE,
+			'Human\Leg'
+		);
+
+		self::assertSniffError(
+			$report,
+			56,
+			UnusedUsesSniff::CODE_UNUSED_USE,
+			'Human\HEAD_SIZE_UNUSED'
+		);
+	}
+
 	public function testUnusedUseNoNamespaceNoErrors(): void
 	{
 		$report = self::checkFile(__DIR__ . '/data/unusedUsesNoNamespaceNoErrors.php');

--- a/tests/Sniffs/Namespaces/data/unusedUsesMultipleNamespaces.php
+++ b/tests/Sniffs/Namespaces/data/unusedUsesMultipleNamespaces.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Foo;
+
+use First\ObjectPrototype;
+use Framework;
+use Framework\Subnamespace;
+use My\ObjectPrototype as MyObject;
+use NewNamespace\ObjectPrototype as NewObject;
+use R\S;
+use T;
+use function FooBar\UnusedFunction;
+use function LoremIpsum\UsedFunction;
+use const FooBar\UNUSED_CONSTANT;
+use const LoremIpsum\USED_CONSTANT;
+use X;
+use Lorem\FirstInterface;
+use Ipsum\SecondInterface;
+use Zetta\Rasmus;
+use My\PartialClass;
+use My\PartialFunction;
+use My\PartialConstant;
+use PartialNamespace;
+
+class TestClass implements FirstInterface, SecondInterface
+{
+
+	public function test(S $s): Rasmus
+	{
+		new \Test\Foo\Bar();
+		$date = T::today();
+		new Framework\FooObject();
+		new Subnamespace\BarObject();
+
+		$functionNameAsClass = new UnusedFunction();
+		$unusedConstant = new UNUSED_CONSTANT();
+		UsedFunction();
+		doFoo(USED_CONSTANT);
+
+		new PartialClass\UsedClass();
+		PartialFunction\usedFunction();
+		PartialConstant\USED_CONSTANT;
+		new PartialNamespace\UsedClass();
+
+		return new NewObject();
+	}
+
+}
+
+namespace Boo;
+
+use Human\Meat;
+use Human\Arm;
+use Human\Brain;
+use Human\Leg;
+use const Human\HEAD_SIZE_UNUSED;
+use const Human\HEAD_SIZE_USED;
+
+class Zombie {
+	public function eatBrain(Brain $brain):Meat {
+		$bite = new Bite();
+		$bite->applyOn($brain, HEAD_SIZE_USED);
+
+		return new Meat;
+	}
+}


### PR DESCRIPTION
As of my test file 8k lines 1 namespace, check was going to be 5s.
With batch namespace lookup check go down to 1s.

Although i don't like that we make extra iterations by referencedNames, but it should be faster without findPrevious() calls.


Relates to #929 