### PR TITLE
Composer: Add branch alias for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,5 +32,10 @@
 			"SlevomatCodingStandard\\PHPStan\\": "build/PHPStan",
 			"SlevomatCodingStandard\\": "tests"
 		}
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-master": "6.x-dev"
+		}
 	}
 }


### PR DESCRIPTION
See https://getcomposer.org/doc/articles/aliases.md for info about aliases in composer. This makes it easier to install dev-master while another package wants a specific version.

See [Monolog as an example](https://github.com/Seldaek/monolog/blob/bec314a9c14ce8a40650cf13923f5941ef1bfe0a/composer.json#L57-L61).