### PR TITLE
UnusedUsesSniff: improve performance in search annotation

### DIFF
--- a/tests/Sniffs/Namespaces/UnusedUsesSniffTest.php
+++ b/tests/Sniffs/Namespaces/UnusedUsesSniffTest.php
@@ -10,11 +10,18 @@ class UnusedUsesSniffTest extends TestCase
 
 	public function testUnusedUse(): void
 	{
+		self::assertEquals(5, $this->getFileReport()->getErrorCount());
 		self::assertSniffError(
 			$this->getFileReport(),
 			5,
 			UnusedUsesSniff::CODE_UNUSED_USE,
 			'First\ObjectPrototype'
+		);
+		self::assertSniffError(
+			$this->getFileReport(),
+			8,
+			UnusedUsesSniff::CODE_UNUSED_USE,
+			'My\ObjectPrototype (as MyObject)'
 		);
 		self::assertSniffError(
 			$this->getFileReport(),
@@ -27,6 +34,12 @@ class UnusedUsesSniffTest extends TestCase
 			14,
 			UnusedUsesSniff::CODE_UNUSED_USE,
 			'FooBar\UNUSED_CONSTANT'
+		);
+		self::assertSniffError(
+			$this->getFileReport(),
+			16,
+			UnusedUsesSniff::CODE_UNUSED_USE,
+			'X'
 		);
 	}
 


### PR DESCRIPTION
As we already have computed T_NAMESPACE pointers, we should use them in searchAnnotation scenario. Applied same optimization as in 9dac280

On my test file 2x (600ms vs 1200ms) speed improvement.