### PR TITLE
MethodSpacingSniff: add class lookup cache to improve performance

### DIFF
--- a/SlevomatCodingStandard/Helpers/ClassHelper.php
+++ b/SlevomatCodingStandard/Helpers/ClassHelper.php
@@ -2,9 +2,8 @@
 
 namespace SlevomatCodingStandard\Helpers;
 
-use Generator;
 use PHP_CodeSniffer\Files\File;
-use function iterator_to_array;
+use function array_reverse;
 use function sprintf;
 use const T_ANON_CLASS;
 use const T_FINAL;
@@ -13,6 +12,18 @@ use const T_USE;
 
 class ClassHelper
 {
+
+	public static function getClassPointer(File $phpcsFile, int $pointer): ?int
+	{
+		$classPointers = array_reverse(self::getAllClassPointers($phpcsFile));
+		foreach ($classPointers as $classPointer) {
+			if ($classPointer < $pointer) {
+				return $classPointer;
+			}
+		}
+
+		return null;
+	}
 
 	public static function isFinal(File $phpcsFile, int $classPointer): bool
 	{
@@ -50,11 +61,9 @@ class ClassHelper
 	 */
 	public static function getAllNames(File $phpcsFile): array
 	{
-		$previousClassPointer = 0;
-
 		$names = [];
 		/** @var int $classPointer */
-		foreach (iterator_to_array(self::getAllClassPointers($phpcsFile, $previousClassPointer)) as $classPointer) {
+		foreach (self::getAllClassPointers($phpcsFile) as $classPointer) {
 			$names[$classPointer] = self::getName($phpcsFile, $classPointer);
 		}
 
@@ -90,21 +99,18 @@ class ClassHelper
 
 	/**
 	 * @param File $phpcsFile
-	 * @param int $previousClassPointer
-	 * @return Generator<int>
+	 * @return array<int>
 	 */
-	private static function getAllClassPointers(File $phpcsFile, int &$previousClassPointer): Generator
+	private static function getAllClassPointers(File $phpcsFile): array
 	{
-		do {
-			$nextClassPointer = TokenHelper::findNext($phpcsFile, TokenHelper::$typeKeywordTokenCodes, $previousClassPointer + 1);
-			if ($nextClassPointer === null) {
-				break;
-			}
+		static $cache;
+		$cache = $cache ?? new SniffLocalCache();
 
-			$previousClassPointer = $nextClassPointer;
+		$lazyValue = static function () use ($phpcsFile): array {
+			return TokenHelper::findNextAll($phpcsFile, TokenHelper::$typeKeywordTokenCodes, 0);
+		};
 
-			yield $nextClassPointer;
-		} while (true);
+		return $cache->getAndSetIfNotCached($phpcsFile, $lazyValue);
 	}
 
 }

--- a/SlevomatCodingStandard/Sniffs/Classes/MethodSpacingSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/MethodSpacingSniff.php
@@ -4,6 +4,7 @@ namespace SlevomatCodingStandard\Sniffs\Classes;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
+use SlevomatCodingStandard\Helpers\ClassHelper;
 use SlevomatCodingStandard\Helpers\DocCommentHelper;
 use SlevomatCodingStandard\Helpers\FunctionHelper;
 use SlevomatCodingStandard\Helpers\IndentationHelper;
@@ -52,7 +53,7 @@ class MethodSpacingSniff implements Sniff
 			? $tokens[$methodPointer]['scope_closer']
 			: TokenHelper::findNext($phpcsFile, T_SEMICOLON, $methodPointer + 1);
 
-		$classPointer = TokenHelper::findPrevious($phpcsFile, TokenHelper::$typeKeywordTokenCodes, $methodPointer - 1);
+		$classPointer = ClassHelper::getClassPointer($phpcsFile, $methodPointer - 1);
 
 		$actualPointer = $methodEndPointer;
 		do {

--- a/tests/Helpers/ClassHelperTest.php
+++ b/tests/Helpers/ClassHelperTest.php
@@ -52,4 +52,24 @@ class ClassHelperTest extends TestCase
 		self::assertSame([], ClassHelper::getAllNames($phpcsFile));
 	}
 
+	public function testGetClassPointerWithoutClass(): void
+	{
+		$phpcsFile = $this->getCodeSnifferFile(__DIR__ . '/data/namespacedFile.php');
+		self::assertNull(ClassHelper::getClassPointer($phpcsFile, 5));
+	}
+
+	public function testGetClassPointerWithClass(): void
+	{
+		$phpcsFile = $this->getCodeSnifferFile(__DIR__ . '/data/classWithoutNamespace.php');
+		self::assertEquals(2, ClassHelper::getClassPointer($phpcsFile, 5));
+	}
+
+	public function testGetClassPointerWithMultipleClasses(): void
+	{
+		$phpcsFile = $this->getCodeSnifferFile(__DIR__ . '/data/multipleClasses.php');
+		self::assertEquals(2, ClassHelper::getClassPointer($phpcsFile, 5));
+		self::assertEquals(26, ClassHelper::getClassPointer($phpcsFile, 30));
+		self::assertEquals(51, ClassHelper::getClassPointer($phpcsFile, 52));
+	}
+
 }

--- a/tests/Helpers/data/multipleClasses.php
+++ b/tests/Helpers/data/multipleClasses.php
@@ -1,0 +1,26 @@
+<?php
+
+class Foo {
+	public function test()
+	{
+	}
+}
+
+class Bar
+{
+	public function test()
+ 	{
+ 	}
+}
+
+
+class Zoo
+{
+	public function test()
+	{
+	}
+
+	public function test1()
+	{
+	}
+}


### PR DESCRIPTION
Increase performance of MethodSpacingSniff by introducing class lookup cache in ClassHelper.

For 8kloc test file time dropped from 2s to 0.4s