### PR TITLE
UnusedVariableSniff: add scope lookup cache to improve performance

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Variables/UnusedVariableSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Variables/UnusedVariableSniff.php
@@ -155,7 +155,7 @@ class UnusedVariableSniff implements Sniff
 			return;
 		}
 
-		$scopeOwnerPointer = TokenHelper::findPrevious($phpcsFile, T_OPEN_TAG, $variablePointer - 1);
+		$scopeOwnerPointer = ScopeHelper::getRootPointer($phpcsFile, $variablePointer - 1);
 		foreach (array_reverse($tokens[$variablePointer]['conditions'], true) as $conditionPointer => $conditionTokenCode) {
 			if (in_array($conditionTokenCode, TokenHelper::$functionTokenCodes, true)) {
 				$scopeOwnerPointer = $conditionPointer;


### PR DESCRIPTION
Increase performance of UnusedVariableSniff by introducing scope lookup cache in ScopeHelper.

For 8kloc test file time dropped from 9s to 0.6s