### PR TITLE
Remove the basepath from the filename first.

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Files/TypeNameMatchesFileNameSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Files/TypeNameMatchesFileNameSniff.php
@@ -88,9 +88,12 @@ class TypeNameMatchesFileNameSniff implements Sniff
 			return;
 		}
 
-		$expectedTypeName = $this->getNamespaceExtractor()->getTypeNameFromProjectPath(
-			$phpcsFile->getFilename()
-		);
+        $filename = $phpcsFile->getFilename();
+        if ($phpcsFile->config->basepath !== null && StringHelper::startsWith($filename, $phpcsFile->config->basepath)) {
+            $filename = substr($filename, strlen($phpcsFile->config->basepath));
+        }
+
+        $expectedTypeName = $this->getNamespaceExtractor()->getTypeNameFromProjectPath($filename);
 		if ($typeName === $expectedTypeName) {
 			return;
 		}


### PR DESCRIPTION
This will ensure to extract the correct expected type name.

---

I had a Laravel project inside a Docker container, and place the project in the folder `app`.
But since Laravel's source folder for the application, is also `app`, since gave me the path `/app/app`.

The sniff `TypeNameMatchesFileNameSniff` couldn't parse the correct expected type name, since both directories is called `app`.
So for the `App` namespace it was: `App\app\...` and for the `Tests` namespace: `Tests\tests\...`

I tried to add `app` to `skipDirs`, but since that is parsed after extracting the root namespace, it only helped on the `app` folder and not on the `tests` folder.

First I just changed the keys for the paths in `rootNamespaces` to be `app/app` and `app/tests`, but I don't think that's very pretty.

Therefor I looked at the source, and added this check on the basepath, and removed it before extrating the expected type name.