### PR TITLE
AssignmentInConditionSniff: add option ignoreAssignmentsInsideFunctionCalls

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,15 @@ Assignment in `while` loop condition is specifically allowed because it's common
 
 This is a great addition to already existing `SlevomatCodingStandard.ControlStructures.DisallowYodaComparison` because it prevents the danger of assigning something by mistake instead of using comparison operator like `===`.
 
+Sniff provides the following settings:
+* `ignoreAssignmentsInsideFunctionCalls`: ignores assignment inside function calls, like this:
+
+```php
+if (in_array(1, $haystack, $strict = true) {
+
+}
+```
+
 #### SlevomatCodingStandard.ControlStructures.DisallowContinueWithoutIntegerOperandInSwitch 🔧
 
 Disallows use of `continue` without integer operand in `switch` because it emits a warning in PHP 7.3 and higher.

--- a/SlevomatCodingStandard/Sniffs/ControlStructures/AssignmentInConditionSniff.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/AssignmentInConditionSniff.php
@@ -5,17 +5,23 @@ namespace SlevomatCodingStandard\Sniffs\ControlStructures;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use SlevomatCodingStandard\Helpers\TokenHelper;
+use function array_keys;
+use function max;
 use function sprintf;
 use const T_DO;
 use const T_ELSEIF;
 use const T_EQUAL;
 use const T_IF;
+use const T_STRING;
 use const T_WHILE;
 
 class AssignmentInConditionSniff implements Sniff
 {
 
 	public const CODE_ASSIGNMENT_IN_CONDITION = 'AssignmentInCondition';
+
+	/** @var bool */
+	public $ignoreAssignmentsInsideFunctionCalls = false;
 
 	/**
 	 * @return array<int, (int|string)>
@@ -54,11 +60,37 @@ class AssignmentInConditionSniff implements Sniff
 
 	private function processCondition(File $phpcsFile, int $parenthesisOpener, int $parenthesisCloser, string $conditionType): void
 	{
-		$equalsTokenPointer = TokenHelper::findNext($phpcsFile, T_EQUAL, $parenthesisOpener + 1, $parenthesisCloser);
-		if ($equalsTokenPointer === null) {
+		$equalsTokenPointers = TokenHelper::findNextAll($phpcsFile, T_EQUAL, $parenthesisOpener + 1, $parenthesisCloser);
+		$tokens = $phpcsFile->getTokens();
+		if ($equalsTokenPointers === []) {
 			return;
 		}
 
+		if (!$this->ignoreAssignmentsInsideFunctionCalls) {
+			$this->error($phpcsFile, $conditionType, $equalsTokenPointers[0]);
+			return;
+		}
+
+		foreach ($equalsTokenPointers as $equalsTokenPointer) {
+			$parenthesisStarts = array_keys($tokens[$equalsTokenPointer]['nested_parenthesis']);
+
+			$insideParenthesis = max($parenthesisStarts);
+			if ($insideParenthesis === $parenthesisOpener) {
+				$this->error($phpcsFile, $conditionType, $equalsTokenPointer);
+				continue;
+			}
+
+			$functionCall = TokenHelper::findPrevious($phpcsFile, T_STRING, $insideParenthesis, $parenthesisOpener);
+			if ($functionCall !== null) {
+				continue;
+			}
+
+			$this->error($phpcsFile, $conditionType, $equalsTokenPointer);
+		}
+	}
+
+	private function error(File $phpcsFile, string $conditionType, int $equalsTokenPointer): void
+	{
 		$phpcsFile->addError(
 			sprintf('Assignment in %s condition is not allowed.', $conditionType),
 			$equalsTokenPointer,

--- a/build/PHPStan/phpstan.neon
+++ b/build/PHPStan/phpstan.neon
@@ -27,6 +27,10 @@ parameters:
 			message: '#Access to an undefined property PHP_CodeSniffer\\Config::\$tabWidth#'
 			count: 1
 			path: %currentWorkingDirectory%/SlevomatCodingStandard/Sniffs/Whitespaces/DuplicateSpacesSniff.php
+		-
+			message: '#Offset ''nested_parenthesis'' does not exist on array#'
+			count: 1
+			path: %currentWorkingDirectory%/SlevomatCodingStandard/Sniffs/ControlStructures/AssignmentInConditionSniff.php
 
 services:
 	-

--- a/tests/Sniffs/ControlStructures/AssignmentInConditionSniffTest.php
+++ b/tests/Sniffs/ControlStructures/AssignmentInConditionSniffTest.php
@@ -17,7 +17,34 @@ class AssignmentInConditionSniffTest extends TestCase
 	public function testIncorrectFile(): void
 	{
 		$resultFile = self::checkFile(__DIR__ . '/data/allAssignmentsInConditions.php');
-		foreach (range(3, 6) as $lineNumber) {
+		self::assertEquals(6, $resultFile->getErrorCount());
+		foreach (range(3, 8) as $lineNumber) {
+			self::assertSniffError($resultFile, $lineNumber, AssignmentInConditionSniff::CODE_ASSIGNMENT_IN_CONDITION);
+		}
+	}
+
+	public function testNoErrorsWithIgnoreAssignmentsInsideFunctionCalls(): void
+	{
+		$report = self::checkFile(
+			__DIR__ . '/data/noAssignmentsInConditionsIgnoreAssignmentsInsideFunctionCalls.php',
+			[
+				'ignoreAssignmentsInsideFunctionCalls' => true,
+			]
+		);
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testErrorsWithIgnoreAssignmentsInsideFunctionCalls(): void
+	{
+		$resultFile = self::checkFile(
+			__DIR__ . '/data/allAssignmentsInConditions.php',
+			[
+				'ignoreAssignmentsInsideFunctionCalls' => true,
+			]
+		);
+
+		self::assertEquals(7, $resultFile->getErrorCount());
+		foreach (range(3, 8) as $lineNumber) {
 			self::assertSniffError($resultFile, $lineNumber, AssignmentInConditionSniff::CODE_ASSIGNMENT_IN_CONDITION);
 		}
 	}

--- a/tests/Sniffs/ControlStructures/data/allAssignmentsInConditions.php
+++ b/tests/Sniffs/ControlStructures/data/allAssignmentsInConditions.php
@@ -4,3 +4,5 @@ if ($foo = 5) { }
 if ($foo) {} elseif ($foo = 5) {}
 do { } while ($foo = 5);
 if (($line = fgets($fp)) !== null) { }
+if (($a = readfile($file = 'test'))) { }
+if ($a = 1 && $b = 2) {}

--- a/tests/Sniffs/ControlStructures/data/noAssignmentsInConditionsIgnoreAssignmentsInsideFunctionCalls.php
+++ b/tests/Sniffs/ControlStructures/data/noAssignmentsInConditionsIgnoreAssignmentsInsideFunctionCalls.php
@@ -1,0 +1,53 @@
+<?php
+
+if ($foo == 5) {
+
+} elseif ($foo == 10) {
+
+}
+
+if ($foo === 5) {
+
+} elseif ($foo === 10) {
+
+}
+
+if ($foo != 5) {
+
+} elseif ($foo != 10) {
+
+}
+
+if ($foo !== 5) {
+
+} elseif ($foo !== 10) {
+
+}
+
+while ($foo == 5) {
+
+}
+
+while ($foo === 5) {
+
+}
+
+while ($foo = 5) {
+
+}
+
+while (($row = $db->fetch()) !== null) {
+
+}
+
+do {
+
+} while ($foo === 5);
+
+if (in_array($a = 1, [], $strict = true)) {
+
+}
+
+if ($this->call($a = 1)) {
+
+}


### PR DESCRIPTION
PR adds option to allow such assignments inside calls:

```php
if (in_array(1, $haystack, $strict = true) {

}
```