### PR TITLE
add .editorconfig to help ide detect project settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = tab
+insert_final_newline = true
+tab_width = 4
+trim_trailing_whitespace = true
+
+[.travis.yml]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
https://editorconfig.org/
Ease contributing to project by enabling ide detection of project settings from editorconfig.
I am using different projects with tabs and spaces setup, this config allows to not reconfigure ide between switching projects.