### PR TITLE
LineLengthSniff: speedup by caching use statements

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Files/LineLengthSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Files/LineLengthSniff.php
@@ -14,7 +14,6 @@ use function strrpos;
 use const T_COMMENT;
 use const T_DOC_COMMENT_STRING;
 use const T_OPEN_TAG;
-use const T_USE;
 
 class LineLengthSniff implements Sniff
 {
@@ -123,7 +122,7 @@ class LineLengthSniff implements Sniff
 		}
 
 		if ($this->ignoreImports) {
-			$usePointer = $phpcsFile->findPrevious(T_USE, $pointer - 1);
+			$usePointer = UseStatementHelper::getUseStatementPointer($phpcsFile, $pointer - 1);
 			if (is_int($usePointer)
 				&& $tokens[$usePointer]['line'] === $tokens[$pointer]['line']
 				&& !UseStatementHelper::isTraitUse($phpcsFile, $usePointer)) {

--- a/tests/Sniffs/Files/LineLengthSniffTest.php
+++ b/tests/Sniffs/Files/LineLengthSniffTest.php
@@ -54,4 +54,18 @@ class LineLengthSniffTest extends TestCase
 		self::assertSniffError($report, 22, LineLengthSniff::CODE_LINE_TOO_LONG);
 	}
 
+	public function testErrorsWithoutUseStatements(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/LineLengthSniffErrorsWithoutUseStatements.php');
+
+		self::assertSame(6, $report->getErrorCount());
+
+		self::assertSniffError($report, 5, LineLengthSniff::CODE_LINE_TOO_LONG);
+		self::assertSniffError($report, 8, LineLengthSniff::CODE_LINE_TOO_LONG);
+		self::assertSniffError($report, 10, LineLengthSniff::CODE_LINE_TOO_LONG);
+		self::assertSniffError($report, 13, LineLengthSniff::CODE_LINE_TOO_LONG);
+		self::assertSniffError($report, 17, LineLengthSniff::CODE_LINE_TOO_LONG);
+		self::assertSniffError($report, 18, LineLengthSniff::CODE_LINE_TOO_LONG);
+	}
+
 }

--- a/tests/Sniffs/Files/data/LineLengthSniffErrorsWithoutUseStatements.php
+++ b/tests/Sniffs/Files/data/LineLengthSniffErrorsWithoutUseStatements.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Foo\Bar;
+
+class FooLoremIpsumDolorSitAmetConsecteturAdipiscingElitBonumIncolumisAciesMiseraCaecitasMateriamVeroRerumEtCopiamApudHosExilemApud
+{
+	/**
+	 * @see http://www.loremIpsumDolorSitAmetConsecteturAdipiscingElitBonumIncolumis.cz and @see http://www.aciesMiseraCaecitasMateriamVeroRerumEtCopiamApudHosExilemApud.cz
+	 */
+	public function someMethodNameHereLoremIpsumDolorSitAmetConsecteturAdipiscingElitBonumIncolumisAciesMiseraCaecitasMateriamVeroRerum() : string
+	{
+		// http://www.loremIpsumDolorSitAmetConsecteturAdipiscingElitBonumIncolumisAciesMiseraCaecitasMateriamVeroRerumEtCopiamApudHosExilemApud.cz
+		return 'LoremIpsumDolorSitAmetConsecteturAdipiscingElitBonumIncolumisAciesMiseraCaecitasMateriamVeroRerumEtCopiamApudHosExilemApud';
+	}
+}
+
+$foo = new Foo(); // Urgent tamen et nihil remittunt. Neque enim civitas in seditione beata esse potest nec in discordia dominorum domus; Sint modo partes vitae beatae.
+echo $foo->someMethodNameHereLoremIpsumDolorSitAmetConsecteturAdipiscingElitBonumIncolumisAciesMiseraCaecitasMateriamVeroRerum();


### PR DESCRIPTION
Introduce use statement pointers cache for UserStatementHelper.
Speedup for LineLengthSniff on test file from 0.7s to 0.3s