### PR TITLE
Fix `Classes.ParentCallSpacing` documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ Enforces configurable number of lines around parent method call.
 Sniff provides the following settings:
 
 * `linesCountBeforeParentCall`: allows to configure the number of lines before parent call.
-* `linesCountBeforeFirstControlParentCalle`: allows to configure the number of lines before first parent call.
+* `linesCountBeforeFirstParentCall`: allows to configure the number of lines before first parent call.
 * `linesCountAfterParentCall`: allows to configure the number of lines after parent call.
 * `linesCountAfterLastParentCall`: allows to configure the number of lines after last parent call.
 


### PR DESCRIPTION
Changed the probably misstyped `linesCountBeforeFirstControlParentCalle` sniff property name to `linesCountBeforeFirstParentCall`.