### PR TITLE
Bug fix: select sniffs would not run

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,15 +22,10 @@
 		"phpunit/phpunit": "7.5.20|8.5.2|9.0.2",
 		"dealerdirect/phpcodesniffer-composer-installer": "0.6.2"
 	},
-	"autoload": {
-		"psr-4": {
-			"SlevomatCodingStandard\\": "SlevomatCodingStandard"
-		}
-	},
 	"autoload-dev": {
 		"psr-4": {
-			"SlevomatCodingStandard\\PHPStan\\": "build/PHPStan",
-			"SlevomatCodingStandard\\": "tests"
+			"SlevomatCodingStandard\\": ["SlevomatCodingStandard", "tests"],
+			"SlevomatCodingStandard\\PHPStan\\": "build/PHPStan"
 		}
 	},
 	"extra": {


### PR DESCRIPTION
Ok, complex one to explain again, but the short of it is that PHPCS does the file name to sniff name translation when autoloading sniffs.

Now for sniffs which extend other sniffs and/or abstracts, when the first sniff which extends such an abstract is requested, the PHPCS autoloader would kick in and then the Composer autoloader would also kick in the `extends`, with the end result being that the PHPCS autoloader would return the name of the _abstract_ class to the originating call, which in effect meant that the sniff could never be referenced/included by name as PHPCS would not know which file went with that name.

As the PHPCS autoloader can handle any loading any files within the "standard" directory, loading those files should be left to the PHPCS autoloader so it can do the file to sniffname translation correctly.

Removing the `autoload` directive for `--no-dev` installs fixes the issue.

To reproduce the issue:
* Clone the SlevomatCS repo at `master`
* Run `composer install --no-dev` in the root of the SlevomatCS clone.
* Clone PHPCS
* Register the `PHP_CodeSniffer/bin` directory to the system path.
* Run `phpcs --config-set installed_paths path/to/slevomatCS_clone
* Go to a directory with some files which can be used for testing.
* Run `. --standard=slevomatcodingstandard --extensions=php --ignore=/vendor/* --sniffs=SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalConstants`

The response will be:
```
ERROR: No sniffs were registered

Run "phpcs --help" for usage information
```

* Now, switch to this PR branch.
* Run `composer install --no-dev` in the root of the SlevomatCS clone.
* Go to a directory with some files which can be used for testing.
* Run `. --standard=slevomatcodingstandard --extensions=php --ignore=/vendor/* --sniffs=SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalConstants`

PHPCS will run as expected.

While the test instructions are for a stand-alone install, I expect this same issue exists when the standard is installed via Composer as a project dependency, though I haven't tested that.

Also, while the test instructions mention one particular sniff the problem affects several sniffs.

Note that when the sniff is included in a ruleset `<rule ref="`..."/>` and PHPCS can not find it, PHPCS will just silently ignore the sniff, so it would just seem as if there are no violations, while in actual fact the sniff is not being run.