### PR TITLE
FilepathNamespaceExtractor must omit current working dir

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Files/FilepathNamespaceExtractor.php
+++ b/SlevomatCodingStandard/Sniffs/Files/FilepathNamespaceExtractor.php
@@ -10,10 +10,12 @@ use function array_shift;
 use function array_unshift;
 use function count;
 use function explode;
+use function getcwd;
 use function implode;
 use function in_array;
 use function pathinfo;
 use function preg_split;
+use function str_replace;
 use function strlen;
 use function strtolower;
 use function substr;
@@ -53,7 +55,7 @@ class FilepathNamespaceExtractor
 		}
 
 		/** @var string[] $pathParts */
-		$pathParts = preg_split('~[/\\\]~', $path);
+		$pathParts = preg_split('~[/\\\]~', str_replace($this->getCurrentDir(), '', $path));
 		$rootNamespace = null;
 		while (count($pathParts) > 0) {
 			array_shift($pathParts);
@@ -83,6 +85,13 @@ class FilepathNamespaceExtractor
 		}));
 
 		return substr($typeName, 0, -strlen('.' . $extension));
+	}
+
+	protected function getCurrentDir(): string
+	{
+		$dir = getcwd();
+
+		return $dir !== false ? $dir : '';
 	}
 
 }

--- a/tests/Sniffs/Files/FilepathNamespaceExtractorStub.php
+++ b/tests/Sniffs/Files/FilepathNamespaceExtractorStub.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Files;
+
+class FilepathNamespaceExtractorStub extends FilepathNamespaceExtractor
+{
+
+	/** @var string */
+	private $currentDir;
+
+	/**
+	 * @param string[] $rootNamespaces directory(string) => namespace
+	 * @param string[] $skipDirs
+	 * @param string[] $extensions index(integer) => extension
+	 * @param string $currentDir
+	 */
+	public function __construct(array $rootNamespaces, array $skipDirs, array $extensions, string $currentDir)
+	{
+		parent::__construct($rootNamespaces, $skipDirs, $extensions);
+
+		$this->currentDir = $currentDir;
+	}
+
+	protected function getCurrentDir(): string
+	{
+		return $this->currentDir;
+	}
+
+}

--- a/tests/Sniffs/Files/FilepathNamespaceExtractorTest.php
+++ b/tests/Sniffs/Files/FilepathNamespaceExtractorTest.php
@@ -21,81 +21,103 @@ class FilepathNamespaceExtractorTest extends TestCase
 				'unknown.php',
 				null,
 				['php'],
+				'',
 			],
 			[
 				$root . '/unknown',
 				null,
 				['php'],
+				$root,
 			],
 			[
 				$root . '/app',
 				null,
 				['php'],
+				$root,
 			],
 			[
 				$root . '/app/components',
 				null,
 				['php'],
+				$root,
 			],
 			[
 				$root . '/app/components.php',
 				'Slevomat\\components',
 				['php'],
+				$root,
 			],
 			[
 				$root . '/app/Foo/Foo.swift',
 				null,
 				['php'],
+				$root,
 			],
 			[
 				$root . '/app/Foo/Foo.php',
 				'Slevomat\\Foo\\Foo',
 				['php'],
+				$root,
 			],
 			[
 				$root . '/tests/UnitTestCase.php',
 				'Slevomat\\UnitTestCase',
 				['php'],
+				$root,
 			],
 			[
 				$root . '/app/model/Auth/DatabaseAuthenticator.php',
 				'Slevomat\\Auth\\DatabaseAuthenticator',
 				['php'],
+				$root,
 			],
 			[
 				$root . '/app/services/Delivery/Premise/AbstractPremiseImporter.php',
 				'Slevomat\\Delivery\\Premise\\AbstractPremiseImporter',
 				['php'],
+				$root,
 			],
 			[
 				$root . '/app/ui/Admin/Newsletter/CreatePresenter.php',
 				'Slevomat\\UI\\Admin\\Newsletter\\CreatePresenter',
 				['php'],
+				$root,
 			],
 			[
 				$root . '/tests/services/Delivery/Goods3rd/data/StatusEnum.php',
 				'Slevomat\\Delivery\\Goods3rd\\StatusEnum',
 				['php'],
+				$root,
 			],
 			[
 				$root . '/tests/services/Delivery/Goods3rd/data/StatusEnum.PHP',
 				'Slevomat\\Delivery\\Goods3rd\\StatusEnum',
 				['php'],
+				$root,
 			],
 			[
 				$root . '/tests/services/Delivery/Goods3rd/data/StatusEnum.php',
 				'Slevomat\\Delivery\\Goods3rd\\StatusEnum',
 				['PHP'],
+				$root,
 			],
 			[
 				$root . '/tests/services/Delivery/Goods3rd/data/StatusEnum.php',
 				'Slevomat\\Delivery\\Goods3rd\\StatusEnum',
 				['php', 'lsp'],
+				$root,
 			],
 			[
 				$root . '/app/Foo/FooTest.phpt',
 				'Slevomat\\Foo\\FooTest',
 				['php', 'phpt'],
+				$root,
+			],
+			[
+				'/www/src/src/Foo/FooTest.php',
+				'Slevomat\\Foo\\FooTest',
+				['php', 'phpt'],
+				'/www/src',
 			],
 		];
 	}
@@ -105,17 +127,20 @@ class FilepathNamespaceExtractorTest extends TestCase
 	 * @param string $path
 	 * @param string|null $expectedNamespace
 	 * @param string[] $extensions
+	 * @param string $currentDir
 	 */
-	public function testGetTypeNameFromProjectPath(string $path, ?string $expectedNamespace, array $extensions): void
+	public function testGetTypeNameFromProjectPath(string $path, ?string $expectedNamespace, array $extensions, string $currentDir): void
 	{
-		$extractor = new FilepathNamespaceExtractor(
+		$extractor = new FilepathNamespaceExtractorStub(
 			[
 				'app/ui' => 'Slevomat\\UI',
 				'app' => 'Slevomat',
 				'tests' => 'Slevomat',
+				'src' => 'Slevomat',
 			],
 			['components', 'forms', 'model', 'models', 'services', 'stubs', 'data'],
-			$extensions
+			$extensions,
+			$currentDir
 		);
 		$path = str_replace('/', DIRECTORY_SEPARATOR, $path);
 		self::assertSame($expectedNamespace, $extractor->getTypeNameFromProjectPath($path));


### PR DESCRIPTION
Currently TypeNameMatchesFileNameSniff fails if file path is `/www/src/src/Foo/FooTest.php` and defined root namespace is `'src' => 'Slevomat'`. By removing current working dir path from files path, we can assure that filepath namspace extractor will do its job correctly.