### PR TITLE
update to latest shivammathur/setup-php Github Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         uses: "actions/checkout@v2.0.0"
 
       - name: "Install PHP"
-        uses: "shivammathur/setup-php@1.8.2"
+        uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"


### PR DESCRIPTION
using the recommended style of depdency declaration promoted by the Github Action author.

also getting a current php8 version with it.