### PR TITLE
Fix: exclude provided base path in TypeNameMatchesFileNameSniff

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Files/TypeNameMatchesFileNameSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Files/TypeNameMatchesFileNameSniff.php
@@ -15,8 +15,11 @@ use function min;
 use function sprintf;
 use function str_replace;
 use function strcasecmp;
+use function strlen;
+use function substr;
 use function ucfirst;
 use function uksort;
+use const DIRECTORY_SEPARATOR;
 use const T_CLASS;
 use const T_INTERFACE;
 use const T_STRING;
@@ -88,8 +91,14 @@ class TypeNameMatchesFileNameSniff implements Sniff
 			return;
 		}
 
+		$filename = str_replace('/', DIRECTORY_SEPARATOR, $phpcsFile->getFilename());
+		$basePath = str_replace('/', DIRECTORY_SEPARATOR, $phpcsFile->config->basepath ?? '');
+		if ($basePath !== '' && StringHelper::startsWith($filename, $basePath)) {
+			$filename = substr($filename, strlen($basePath));
+		}
+
 		$expectedTypeName = $this->getNamespaceExtractor()->getTypeNameFromProjectPath(
-			$phpcsFile->getFilename()
+			$filename
 		);
 		if ($typeName === $expectedTypeName) {
 			return;

--- a/SlevomatCodingStandard/Sniffs/TestCase.php
+++ b/SlevomatCodingStandard/Sniffs/TestCase.php
@@ -8,7 +8,10 @@ use PHP_CodeSniffer\Files\LocalFile;
 use PHP_CodeSniffer\Runner;
 use ReflectionClass;
 use function array_map;
+use function array_merge;
 use function count;
+use function define;
+use function defined;
 use function implode;
 use function in_array;
 use function preg_replace;
@@ -28,14 +31,16 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 	 * @param string $filePath
 	 * @param (string|int|bool|array<int|string, (string|int|bool|null)>)[] $sniffProperties
 	 * @param string[] $codesToCheck
+	 * @param string[] $cliArgs
 	 * @return File
 	 */
-	protected static function checkFile(string $filePath, array $sniffProperties = [], array $codesToCheck = []): File
+	protected static function checkFile(string $filePath, array $sniffProperties = [], array $codesToCheck = [], array $cliArgs = []): File
 	{
+		if (defined('PHP_CODESNIFFER_CBF') === false) {
+			define('PHP_CODESNIFFER_CBF', false);
+		}
 		$codeSniffer = new Runner();
-		$codeSniffer->config = new Config([
-			'-s',
-		]);
+		$codeSniffer->config = new Config(array_merge(['-s'], $cliArgs));
 		$codeSniffer->init();
 
 		if (count($sniffProperties) > 0) {

--- a/tests/Sniffs/Files/TypeNameMatchesFileNameSniffTest.php
+++ b/tests/Sniffs/Files/TypeNameMatchesFileNameSniffTest.php
@@ -84,4 +84,11 @@ class TypeNameMatchesFileNameSniffTest extends TestCase
 		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/rootNamespace2/Xxx/Boo.php', $sniffProperties2));
 	}
 
+	public function testWithProvidedBasePathAndNestedSameDirName(): void
+	{
+		self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/data/Foo/Bar.php', [
+			'rootNamespaces' => ['data' => 'Data'],
+		], [], ['--basepath=' . __DIR__ . '/data']));
+	}
+
 }

--- a/tests/Sniffs/Files/data/data/Foo/Bar.php
+++ b/tests/Sniffs/Files/data/data/Foo/Bar.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Data\Foo;
+
+class Bar
+{
+}


### PR DESCRIPTION
TypeNameMatchesFileNameSniff fails if app code is in the same directory as analyzed directory, threfore base path must be omited if provided