### PR TITLE
Composer: update PHPCS Composer plugin dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 	},
 	"require": {
 		"php": "^7.1",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.6.2",
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
 		"phpstan/phpdoc-parser": "0.4.5 - 0.4.8",
 		"squizlabs/php_codesniffer": "^3.5.5"
 	},


### PR DESCRIPTION
The DealerDirect Composer plugin has just released version `0.7.0`.
This new version includes support for Composer 2.0.0 (upcoming) and allows for installation of the plugin in combination with PHP 8 and PHPCS 4.x-dev (for testing).

As Composer treats minors < 1.0 as majors, updating to this version requires an update to the `composer.json` requirements.

> For pre-1.0 versions it also acts with safety in mind and treats `^0.3` as `>=0.3.0 <0.4.0`.

Note:
This standard can be combined by end-users with other PHPCS standards which may also include the Dealerdirect Composer plugin. Also: projects which _require_ this standard, may also require the plugin directly.
With that in mind, it is strongly recommended to allow a wider range or versions to prevent conflicts, as per this PR.

Refs:
* https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases/tag/v0.7.0
* https://getcomposer.org/doc/articles/versions.md#caret-version-range-