### PR TITLE
Useless variable false-positive with trigger_error()

### DIFF
--- a/tests/Sniffs/Variables/data/uselessVariableNoErrors.php
+++ b/tests/Sniffs/Variables/data/uselessVariableNoErrors.php
@@ -152,6 +152,14 @@ function assigmentInCondition() {
 
 }
 
+function triggerError($file) {
+	if (file_exists($path = realpath($file))) {
+		@trigger_error('foo', E_USER_DEPRECATED);
+		return $path;
+	}
+	return null;
+}
+
 class Foo
 {
 


### PR DESCRIPTION
I have discovered a strange false-positive in the useless variable check in conjunction with `trigger_error()`. So far, the PR only contains a failing unit test to outline the problem. Without the `trigger_error()` call, the test does not fail.

@m-vo /cc