### PR TITLE
Support phpstan/phpdoc-parser 0.4.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	"require": {
 		"php": "^7.1",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
-		"phpstan/phpdoc-parser": "0.4.5 - 0.4.8",
+		"phpstan/phpdoc-parser": "0.4.5 - 0.4.9",
 		"squizlabs/php_codesniffer": "^3.5.5"
 	},
 	"require-dev": {


### PR DESCRIPTION
Hi there, we're using `rector/rector` which requires `php/phpdoc-parser:^0.4.9` and we would like to be able to keep using this package as well.