### PR TITLE
DisallowCommentAfterCodeSniff: Fixed internal error

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Commenting/DisallowCommentAfterCodeSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Commenting/DisallowCommentAfterCodeSniff.php
@@ -54,6 +54,7 @@ class DisallowCommentAfterCodeSniff implements Sniff
 
 		if (
 			$nextNonWhitespacePointer !== null
+			&& $commentEndPointer !== null
 			&& $tokens[$nextNonWhitespacePointer]['line'] === $tokens[$commentEndPointer]['line']
 
 		) {

--- a/tests/Sniffs/Commenting/data/disallowCommentAfterCodeNoErrors.php
+++ b/tests/Sniffs/Commenting/data/disallowCommentAfterCodeNoErrors.php
@@ -24,7 +24,7 @@ function () {
 // phpcs:enable
 
 /**
- *
+ * phpcs:disable SomeSniff
  */
 class Whatever
 {


### PR DESCRIPTION
Given the following code:
```php
/**
 * phpcs:disable SomeSniff
 */
function ipsum() {
}
```
Using the command:
```
phpcs --standard=SlevomatCodingStandard --sniffs=SlevomatCodingStandard.Commenting.DisallowCommentAfterCode test.php
```

I get the following error:
```
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 1 | ERROR | An error occurred during processing; checking has been aborted. The error message was: Undefined index:  in /project/coding-standard/SlevomatCodingStandard/Sniffs/Commenting/DisallowCommentAfterCodeSniff.php on line 57
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```