### PR TITLE
Prevent ternary sniff from introducing logic errors

### DIFF
--- a/SlevomatCodingStandard/Sniffs/ControlStructures/RequireTernaryOperatorSniff.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/RequireTernaryOperatorSniff.php
@@ -14,6 +14,9 @@ use const T_ELSE;
 use const T_EQUAL;
 use const T_IF;
 use const T_INLINE_THEN;
+use const T_LOGICAL_AND;
+use const T_LOGICAL_OR;
+use const T_LOGICAL_XOR;
 use const T_RETURN;
 use const T_SEMICOLON;
 use const T_WHITESPACE;
@@ -84,6 +87,7 @@ class RequireTernaryOperatorSniff implements Sniff
 	{
 		$ifContainsComment = $this->containsComment($phpcsFile, $ifPointer);
 		$elseContainsComment = $this->containsComment($phpcsFile, $elsePointer);
+		$conditionContainsLogicalOperators = $this->containsLogicalOperators($phpcsFile, $ifPointer);
 
 		$errorParameters = [
 			'Use ternary operator.',
@@ -91,7 +95,7 @@ class RequireTernaryOperatorSniff implements Sniff
 			self::CODE_TERNARY_OPERATOR_NOT_USED,
 		];
 
-		if ($ifContainsComment || $elseContainsComment) {
+		if ($ifContainsComment || $elseContainsComment || $conditionContainsLogicalOperators) {
 			$phpcsFile->addError(...$errorParameters);
 			return;
 		}
@@ -177,6 +181,7 @@ class RequireTernaryOperatorSniff implements Sniff
 
 		$ifContainsComment = $this->containsComment($phpcsFile, $ifPointer);
 		$elseContainsComment = $this->containsComment($phpcsFile, $elsePointer);
+		$conditionContainsLogicalOperators = $this->containsLogicalOperators($phpcsFile, $ifPointer);
 
 		$errorParameters = [
 			'Use ternary operator.',
@@ -184,7 +189,7 @@ class RequireTernaryOperatorSniff implements Sniff
 			self::CODE_TERNARY_OPERATOR_NOT_USED,
 		];
 
-		if ($ifContainsComment || $elseContainsComment) {
+		if ($ifContainsComment || $elseContainsComment || $conditionContainsLogicalOperators) {
 			$phpcsFile->addError(...$errorParameters);
 			return;
 		}
@@ -253,6 +258,17 @@ class RequireTernaryOperatorSniff implements Sniff
 			Tokens::$commentTokens,
 			$tokens[$scopeOwnerPointer]['scope_opener'] + 1,
 			$tokens[$scopeOwnerPointer]['scope_closer']
+		) !== null;
+	}
+
+	private function containsLogicalOperators(File $phpcsFile, int $scopeOwnerPointer): bool
+	{
+		$tokens = $phpcsFile->getTokens();
+		return TokenHelper::findNext(
+			$phpcsFile,
+			[T_LOGICAL_AND, T_LOGICAL_OR, T_LOGICAL_XOR],
+			$tokens[$scopeOwnerPointer]['parenthesis_opener'] + 1,
+			$tokens[$scopeOwnerPointer]['parenthesis_closer']
 		) !== null;
 	}
 

--- a/tests/Sniffs/ControlStructures/RequireTernaryOperatorSniffTest.php
+++ b/tests/Sniffs/ControlStructures/RequireTernaryOperatorSniffTest.php
@@ -16,7 +16,7 @@ class RequireTernaryOperatorSniffTest extends TestCase
 	{
 		$report = self::checkFile(__DIR__ . '/data/requireTernaryOperatorErrors.php');
 
-		self::assertSame(8, $report->getErrorCount());
+		self::assertSame(10, $report->getErrorCount());
 
 		self::assertSniffError($report, 4, RequireTernaryOperatorSniff::CODE_TERNARY_OPERATOR_NOT_USED);
 		self::assertSniffError($report, 12, RequireTernaryOperatorSniff::CODE_TERNARY_OPERATOR_NOT_USED);
@@ -26,6 +26,8 @@ class RequireTernaryOperatorSniffTest extends TestCase
 		self::assertSniffError($report, 42, RequireTernaryOperatorSniff::CODE_TERNARY_OPERATOR_NOT_USED);
 		self::assertSniffError($report, 54, RequireTernaryOperatorSniff::CODE_TERNARY_OPERATOR_NOT_USED);
 		self::assertSniffError($report, 63, RequireTernaryOperatorSniff::CODE_TERNARY_OPERATOR_NOT_USED);
+		self::assertSniffError($report, 75, RequireTernaryOperatorSniff::CODE_TERNARY_OPERATOR_NOT_USED);
+		self::assertSniffError($report, 82, RequireTernaryOperatorSniff::CODE_TERNARY_OPERATOR_NOT_USED);
 
 		self::assertAllFixedInFile($report);
 	}

--- a/tests/Sniffs/ControlStructures/data/requireTernaryOperatorErrors.fixed.php
+++ b/tests/Sniffs/ControlStructures/data/requireTernaryOperatorErrors.fixed.php
@@ -55,3 +55,17 @@ $a = ! (
 	&& $association->getInversedBy()
 	&& $association instanceof OneToOneAssociationMetadata
  ? 'a' : 'aa';
+
+if (doAnything() and doNothing()) {
+	$a = 'a';
+} else {
+	$a = 'aa';
+}
+
+function () {
+	if (doAnything() and doNothing()) {
+		return 'a';
+	} else {
+		return 'aa';
+	}
+};

--- a/tests/Sniffs/ControlStructures/data/requireTernaryOperatorErrors.php
+++ b/tests/Sniffs/ControlStructures/data/requireTernaryOperatorErrors.php
@@ -71,3 +71,17 @@ if (! (
 } else {
 	$a = 'aa';
 }
+
+if (doAnything() and doNothing()) {
+	$a = 'a';
+} else {
+	$a = 'aa';
+}
+
+function () {
+	if (doAnything() and doNothing()) {
+		return 'a';
+	} else {
+		return 'aa';
+	}
+};


### PR DESCRIPTION
This PR prevents `RequireTernaryOperatorSniff` from changing `if`-statements if they contain `and`, `or`, or `xor`.

Such code is problematic, since these operators have lower precedence then the ternary operator (https://www.php.net/manual/en/language.operators.precedence.php).

Currently, code like this:

```php
if (doAnything() and doNothing()) {
  $a =  'a';
} else {
  $a = 'aa';
}
```
 becomes this:
```php
$a = doAnything() and doNothing() ? 'a' : 'aa';
```

when it should become:
```php
$a = (doAnything() and doNothing()) ? 'a' : 'aa';
```
Otherwise the order of operations is incorrect.

The reason I prevent changes instead of fixing them is that it is unclear if the parentheses are necessary or not (they might not be, if `and` is already part of a nested condition and wrapped in parentheses.

Alternatively the parentheses could always be set, if the condition contains one of these operators and leave the removal of the parentheses to the `UselessParentheses`-sniff.

What do you think?
