### PR TITLE
Add a sniff to avoid public properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ constants, properties, static properties, methods, all public methods, all prote
 
 Disallows late static binding for constants.
 
+#### SlevomatCodingStandard.Classes.ForbiddenPublicProperty
+
+Disallows using public properties.
+
 #### SlevomatCodingStandard.Classes.UselessLateStaticBinding 🔧
 
 Reports useless late static binding.

--- a/SlevomatCodingStandard/Sniffs/Classes/ForbiddenPublicPropertySniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/ForbiddenPublicPropertySniff.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+use SlevomatCodingStandard\Helpers\ClassHelper;
+use SlevomatCodingStandard\Helpers\PropertyHelper;
+use SlevomatCodingStandard\Helpers\StringHelper;
+use SlevomatCodingStandard\Helpers\TokenHelper;
+use const T_PUBLIC;
+use const T_VARIABLE;
+
+final class ForbiddenPublicPropertySniff implements Sniff
+{
+
+	public const CODE_FORBIDDEN_PUBLIC_PROPERTY = 'ForbiddenPublicProperty';
+
+	/**
+	 * @return array<int, (int|string)>
+	 */
+	public function register(): array
+	{
+		return [T_VARIABLE];
+	}
+
+	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+	 * @param File $file
+	 * @param int $variablePointer
+	 */
+	public function process(File $file, $variablePointer): void
+	{
+		if (!PropertyHelper::isProperty($file, $variablePointer)) {
+			return;
+		}
+
+		// skip Sniff classes, they have public properties for configuration (unfortunately)
+		if ($this->isSniffClass($file, $variablePointer)) {
+			return;
+		}
+
+		$scopeModifierToken = $this->getPropertyScopeModifier($file, $variablePointer);
+		if ($scopeModifierToken['code'] !== T_PUBLIC) {
+			return;
+		}
+
+		$errorMessage = 'Do not use public properties. Use method access instead.';
+		$file->addError($errorMessage, $variablePointer, self::CODE_FORBIDDEN_PUBLIC_PROPERTY);
+	}
+
+	private function isSniffClass(File $file, int $position): bool
+	{
+		$classTokenPosition = ClassHelper::getClassPointer($file, $position);
+		$classNameToken = ClassHelper::getName($file, $classTokenPosition);
+
+		return StringHelper::endsWith($classNameToken, 'Sniff');
+	}
+
+	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
+	 * @param File $file
+	 * @param int $position
+	 * @return mixed[]
+	 */
+	private function getPropertyScopeModifier(File $file, int $position): array
+	{
+		$scopeModifierPosition = TokenHelper::findPrevious($file, Tokens::$scopeModifiers, $position - 1);
+
+		return $file->getTokens()[$scopeModifierPosition];
+	}
+
+}

--- a/tests/Sniffs/Classes/ForbiddenPublicPropertySniffTest.php
+++ b/tests/Sniffs/Classes/ForbiddenPublicPropertySniffTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Classes;
+
+use SlevomatCodingStandard\Sniffs\TestCase;
+
+class ForbiddenPublicPropertySniffTest extends TestCase
+{
+
+	public function testNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/forbiddenPublicPropertyNoErrors.php');
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/forbiddenPublicPropertyErrors.php');
+
+		self::assertSame(2, $report->getErrorCount());
+
+		self::assertSniffError($report, 5, ForbiddenPublicPropertySniff::CODE_FORBIDDEN_PUBLIC_PROPERTY);
+		self::assertSniffError($report, 6, ForbiddenPublicPropertySniff::CODE_FORBIDDEN_PUBLIC_PROPERTY);
+	}
+
+}

--- a/tests/Sniffs/Classes/data/forbiddenPublicPropertyErrors.php
+++ b/tests/Sniffs/Classes/data/forbiddenPublicPropertyErrors.php
@@ -1,0 +1,7 @@
+<?php
+
+class Test
+{
+	public $one;
+	public $two;
+}

--- a/tests/Sniffs/Classes/data/forbiddenPublicPropertyNoErrors.php
+++ b/tests/Sniffs/Classes/data/forbiddenPublicPropertyNoErrors.php
@@ -1,0 +1,16 @@
+<?php
+
+function add(int $a, int $b)
+{
+	return $a + $b;
+}
+
+class Test
+{
+	private $one, $two;
+}
+
+class TestSniff
+{
+	private $one, $two;
+}


### PR DESCRIPTION
Following this issue #1099, I'm going to add first `phpcs-calisthenics-rules`  rule. Let me know if I need to change anything.