### PR TITLE
Fixed TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Slevomat Coding Standard for [PHP_CodeSniffer](https://github.com/squizlabs/PHP_
 2. [Installation](#installation)
 3. [How to run the sniffs](#how-to-run-the-sniffs)
   - [Choose which sniffs to run](#choose-which-sniffs-to-run)
-  - [Using all sniffs from the standard](#using-all-sniffs-from-the-standard)
+  - [Exclude sniffs you don't want to run](#exclude-sniffs-you-dont-want-to-run)
 4. [Fixing errors automatically](#fixing-errors-automatically)
 5. [Suppressing sniffs locally](#suppressing-sniffs-locally)
 6. [Contributing](#contributing)


### PR DESCRIPTION
In the Table of content was a "Using all sniffs from the standard" Headline. This didn't exists anymore. 
I replaced it with the new "Exclude sniffs you don't want to run" section