### PR TITLE
RequireMultiLineTernaryOperatorSniff: accepts expressions in else part

### DIFF
--- a/SlevomatCodingStandard/Sniffs/ControlStructures/RequireMultiLineTernaryOperatorSniff.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/RequireMultiLineTernaryOperatorSniff.php
@@ -73,7 +73,11 @@ class RequireMultiLineTernaryOperatorSniff implements Sniff
 				[T_CLOSE_TAG, T_SEMICOLON, T_COMMA, T_DOUBLE_ARROW, T_CLOSE_SHORT_ARRAY, T_COALESCE],
 				true
 			)) {
-				break;
+				$parenthesis = $tokens[$pointerAfterInlineElseEnd]['nested_parenthesis'] ?? [];
+				$lastParenthesis = array_slice($parenthesis, -1, 1, true);
+				if (!$lastParenthesis || key($lastParenthesis) < $inlineElsePointer) {
+					break;
+				}
 			}
 
 			if (

--- a/tests/Sniffs/ControlStructures/data/requireMultiLineTernaryOperatorNoErrors.php
+++ b/tests/Sniffs/ControlStructures/data/requireMultiLineTernaryOperatorNoErrors.php
@@ -17,3 +17,6 @@ $a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' ? 'bbbb' : 'ccccccccccccc';
 
 // phpcs:disable ABC
 $a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' ? 'bbbb' : 'ccccccccccccc';
+
+// comma, double arrow, close array, semicolon in parenthesis
+$a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' ? 'bbbb' : func([], [1 => 2], function () { return; });


### PR DESCRIPTION
Adds support for these statements:

```php
$a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' ? 'bbbb' : func(1, 2); // T_COMMA

$a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' ? 'bbbb' : func([]); // T_CLOSE_SHORT_ARRAY

$a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' ? 'bbbb' : func([1 => 2]);  // T_CLOSE_SHORT_ARRAY

$a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' ? 'bbbb' : function () { return; }); // T_SEMICOLON
```

Unfortunately, I did not understand how to write tests for this…