### PR TITLE
RequireMultiLineTernaryOperatorSniff: added minimal length of 'then & else' expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,6 +648,7 @@ Ternary operator has to be reformatted to more lines when the line length exceed
 Sniff provides the following settings:
 
 * `lineLengthLimit` (defaults to `0`)
+* `expressionsMinLength` (defaults to `null`)
 
 #### SlevomatCodingStandard.ControlStructures.RequireSingleLineCondition 🔧
 

--- a/SlevomatCodingStandard/Sniffs/ControlStructures/RequireMultiLineTernaryOperatorSniff.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/RequireMultiLineTernaryOperatorSniff.php
@@ -35,6 +35,9 @@ class RequireMultiLineTernaryOperatorSniff implements Sniff
 	/** @var int */
 	public $lineLengthLimit = 0;
 
+	/** @var int|null */
+	public $expressionsMinLength = null;
+
 	/**
 	 * @return array<int, (int|string)>
 	 */
@@ -103,6 +106,14 @@ class RequireMultiLineTernaryOperatorSniff implements Sniff
 		$actualLineLength = strlen(TokenHelper::getContent($phpcsFile, $endOfLineBeforeInlineThenPointer + 1, $pointerAfterInlineElseEnd));
 
 		if ($actualLineLength <= $lineLengthLimit) {
+			return;
+		}
+
+		$expressionsLength = strlen(TokenHelper::getContent($phpcsFile, $inlineThenPointer + 1, $pointerAfterInlineElseEnd));
+
+		if ($this->expressionsMinLength !== null
+			&& SniffSettingsHelper::normalizeInteger($this->expressionsMinLength) >= $expressionsLength
+		) {
 			return;
 		}
 


### PR DESCRIPTION
It is useful to prevent transformation when 'then & else' part is really short, like this

```php
$stats->coveredMethodCount += $lineCount === $coveredLineCount ? 1 : 0;
```

to

```php
$stats->coveredMethodCount += $lineCount === $coveredLineCount
	? 1
	: 0;
```