### PR TITLE
RequireCombinedAssignmentOperatorSniff: prevents fatal error

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Operators/RequireCombinedAssignmentOperatorSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Operators/RequireCombinedAssignmentOperatorSniff.php
@@ -46,16 +46,20 @@ class RequireCombinedAssignmentOperatorSniff implements Sniff
 	 */
 	public function process(File $phpcsFile, $equalPointer): void
 	{
+		$tokens = $phpcsFile->getTokens();
+
 		/** @var int $variableStartPointer */
 		$variableStartPointer = TokenHelper::findNextEffective($phpcsFile, $equalPointer + 1);
 		$variableEndPointer = IdentificatorHelper::findEndPointer($phpcsFile, $variableStartPointer);
 
-		if ($variableEndPointer === null) {
+		if (
+			$variableEndPointer === null
+			|| $tokens[$variableEndPointer]['code'] === T_CLOSE_SQUARE_BRACKET
+		) {
 			return;
 		}
 
 		$operatorPointer = TokenHelper::findNextEffective($phpcsFile, $variableEndPointer + 1);
-		$tokens = $phpcsFile->getTokens();
 
 		$operators = [
 			T_BITWISE_AND => '&=',

--- a/tests/Sniffs/Operators/data/requireCombinedAssignmentOperatorNoErrors.php
+++ b/tests/Sniffs/Operators/data/requireCombinedAssignmentOperatorNoErrors.php
@@ -38,5 +38,10 @@ class Whatever
 		$a = $a / $b / $c;
 	}
 
+	public function stringOffsets($a)
+	{
+		$a[0] = $a[0] | '';
+	}
+
 }
 


### PR DESCRIPTION
Prevents fatal error 'Cannot use assign-op operators with string offsets' when changes `$m[0] = $m[0] | 'x'` to `$m[0] |= $m[0]'`