### PR TITLE
AbstractPropertyAndConstantSpacing::process(): Next pointer can be null

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Classes/AbstractPropertyAndConstantSpacing.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/AbstractPropertyAndConstantSpacing.php
@@ -73,6 +73,9 @@ abstract class AbstractPropertyAndConstantSpacing implements Sniff
 		$types = [T_COMMENT, T_DOC_COMMENT_OPEN_TAG, T_CONST, T_VAR, T_PUBLIC, T_PROTECTED, T_PRIVATE, T_USE];
 		$nextPointer = TokenHelper::findNext($phpcsFile, $types, $firstOnLinePointer + 1, $tokens[$classPointer]['scope_closer']);
 
+		if ($nextPointer === null) {
+			return 0;
+		}
 		if (!$this->isNextMemberValid($phpcsFile, $nextPointer)) {
 			return $nextPointer;
 		}


### PR DESCRIPTION
Variable `$nextPointer` can be null (and internal logic ignored):

![Snímek obrazovky 2021-01-29 v 19 32 50](https://user-images.githubusercontent.com/4738758/106314085-835e1000-6269-11eb-9f64-cfa5404a8814.png)

Thanks.