### PR TITLE
Wrong resolving of the first type from union type list

### DIFF
--- a/SlevomatCodingStandard/Helpers/ReferencedNameHelper.php
+++ b/SlevomatCodingStandard/Helpers/ReferencedNameHelper.php
@@ -276,6 +276,10 @@ class ReferencedNameHelper
 			}
 		}
 
+		if ($tokens[$nextTokenAfterEndPointer]['code'] === T_TYPE_UNION) {
+			return ReferencedName::TYPE_CLASS;
+		}
+
 		return ReferencedName::TYPE_CONSTANT;
 	}
 

--- a/tests/Helpers/ReferencedNameHelperTest.php
+++ b/tests/Helpers/ReferencedNameHelperTest.php
@@ -47,6 +47,8 @@ class ReferencedNameHelperTest extends TestCase
 			['\SecondExtendedInterface', false, false],
 			['\ThirdExtendedInterface', false, false],
 			['SomeTrait', false, false],
+			['LoremClass', false, false],
+			['IpsumClass', false, false],
 			['OPENSSL_ALGO_SHA256', false, true],
 			['OPENSSL_ALGO_SHA512', false, true],
 			['SomeTrait', false, false],

--- a/tests/Helpers/data/lotsOfReferencedNames.php
+++ b/tests/Helpers/data/lotsOfReferencedNames.php
@@ -99,6 +99,10 @@ final class SomeClass
 		return $this->someClass2::get();
 	}
 
+	public function unionTypes(LoremClass|IpsumClass $param)
+	{
+	}
+
 }
 
 class OpenSsl


### PR DESCRIPTION
I use your standard (which is vey cool) and also `SlevomatCodingStandard.Namespaces.UnusedUses` sniff.

Today I noticed that it's not working properly with the PHP8 union types.

```php
use App\ClassA;
use App\ClassB;

class SomeClass
{
    public function someMethod(ClassA|ClassB $someParam)
    {
    }    
}
```
In the above example `ClassB` is resolved properly as a class type, but `ClassA` is resolved as a constant type which is wrong. They both should be class types.

I've made fix and unit test adjustment to cover this case.