### PR TITLE
Make sure we have a classPointer to fetch a token for

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Classes/MethodSpacingSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/MethodSpacingSniff.php
@@ -54,6 +54,9 @@ class MethodSpacingSniff implements Sniff
 			: TokenHelper::findNext($phpcsFile, T_SEMICOLON, $methodPointer + 1);
 
 		$classPointer = ClassHelper::getClassPointer($phpcsFile, $methodPointer);
+		if ($classPointer === null) {
+			return;
+		}
 
 		$nextMethodPointer = TokenHelper::findNext($phpcsFile, T_FUNCTION, $methodEndPointer + 1, $tokens[$classPointer]['scope_closer']);
 		if ($nextMethodPointer === null) {


### PR DESCRIPTION
When `ClassHelper::getClassPointer` returns `null`, the next statement would fail because we would attempt to fetch `$tokens[null]`.