### PR TITLE
Loose phpstan/phpdoc-parser version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	"require": {
 		"php": "^7.1 || ^8.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
-		"phpstan/phpdoc-parser": "0.5.1",
+		"phpstan/phpdoc-parser": "^0.4.12",
 		"squizlabs/php_codesniffer": "dev-master"
 	},
 	"require-dev": {


### PR DESCRIPTION
Loose too strict phpstan/phpdoc-parser version requirement introduced in https://github.com/slevomat/coding-standard/commit/86075faacd93899034b6a99fb36bddbea6a7c988, because it is runtime dependency and therefore makes conflicts with other widely used libraries which depend on the same package, e.g.:
* https://packagist.org/packages/jms/serializer: `phpstan/phpdoc-parser: ^0.4`
* https://packagist.org/packages/rector/rector: `phpstan/phpdoc-parser: ^0.4.9`

Mentioned above commit makes impossible to use 6.x-dev version (to be able to use PHP 8 features) in the majority of the projects, because jms/serializer is very popular package. On the other hand I think we shouldn't require specific version of runtime (not dev) dependency and use more compatible versions like `^0.4.12`, `~0.4.12` and so on.