### PR TITLE
Improve performance of searching references

### DIFF
--- a/SlevomatCodingStandard/Helpers/ReferencedNameHelper.php
+++ b/SlevomatCodingStandard/Helpers/ReferencedNameHelper.php
@@ -136,7 +136,7 @@ class ReferencedNameHelper
 			}
 
 			// Attributes are parsed in specific method
-			$attributeStartPointerBefore = TokenHelper::findPrevious($phpcsFile, T_ATTRIBUTE, $nameStartPointer - 1);
+			$attributeStartPointerBefore = TokenHelper::findPrevious($phpcsFile, T_ATTRIBUTE, $nameStartPointer - 1, $beginSearchAtPointer);
 			if ($attributeStartPointerBefore !== null) {
 				if ($tokens[$attributeStartPointerBefore]['attribute_closer'] > $nameStartPointer) {
 					$beginSearchAtPointer = $tokens[$attributeStartPointerBefore]['attribute_closer'] + 1;


### PR DESCRIPTION
When searching for previous attribute
we were searching always up to open tag,
so in case of no attributes it was scanning file
many many times. We add restriction to search up to
 previous scanned pointer so that we scan file only once.
 Performance increased by order of magnitude in specific cases.
 Affected sniffs:
 - FullyQualifiedExceptions
 - UnusedUses
 - FullyQualifiedGlobalConstants
 - FullyQualifiedGlobalFunctions
 - ReferenceThrowableOnly