### PR TITLE
Fix: correct FunctionLength sniff name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Some functions have `$strict` parameter. This sniff reports calls to these funct
 
 Reports closures not using `$this` that are not declared `static`.
 
-#### SlevomatCodingStandard.Functions.FunctionLength
+#### SlevomatCodingStandard.Files.FunctionLength
 
 Disallows long functions. This sniff provides the following setting:
 


### PR DESCRIPTION
This PR fixes the documentation of the `FunctionLength` sniff to mention the correct sniff name: `SlevomatCodingStandard.Files.FunctionLength` instead of `SlevomatCodingStandard.Functions.FunctionLength`.
