### PR TITLE
Fix: resolve off-by-one error in function length sniff

### DIFF
--- a/SlevomatCodingStandard/Helpers/FunctionHelper.php
+++ b/SlevomatCodingStandard/Helpers/FunctionHelper.php
@@ -442,7 +442,7 @@ class FunctionHelper
 		$firstToken = $tokens[$token['scope_opener']];
 		$lastToken = $tokens[$token['scope_closer']];
 
-		return $lastToken['line'] - $firstToken['line'];
+		return $lastToken['line'] - $firstToken['line'] - 1;
 	}
 
 	/**

--- a/tests/Sniffs/Functions/data/functionLengthErrors.php
+++ b/tests/Sniffs/Functions/data/functionLengthErrors.php
@@ -1,25 +1,26 @@
 <?php
 
-function dummyFunctionWith32Lines()
+function dummyFunctionWithTooManyLines()
 {
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+	echo 'line 1';
+	echo 'line 2';
+	echo 'line 3';
+	echo 'line 4';
+	echo 'line 5';
+	echo 'line 6';
+	echo 'line 7';
+	echo 'line 8';
+	echo 'line 9';
+	echo 'line 10';
+	echo 'line 11';
+	echo 'line 12';
+	echo 'line 13';
+	echo 'line 14';
+	echo 'line 15';
+	echo 'line 16';
+	echo 'line 17';
+	echo 'line 18';
+	echo 'line 19';
+	echo 'line 20';
+	echo 'line 21';
 }

--- a/tests/Sniffs/Functions/data/functionLengthNoErrors.php
+++ b/tests/Sniffs/Functions/data/functionLengthNoErrors.php
@@ -7,7 +7,31 @@ abstract class DummyClass
 
 function dummyFunctionWithThreeLines()
 {
+	echo 'line 1';
+	echo 'line 2';
+	echo 'line 3';
+}
 
-
-
+function dummyFunctionWithMaximumNumberOfLines()
+{
+	echo 'line 1';
+	echo 'line 2';
+	echo 'line 3';
+	echo 'line 4';
+	echo 'line 5';
+	echo 'line 6';
+	echo 'line 7';
+	echo 'line 8';
+	echo 'line 9';
+	echo 'line 10';
+	echo 'line 11';
+	echo 'line 12';
+	echo 'line 13';
+	echo 'line 14';
+	echo 'line 15';
+	echo 'line 16';
+	echo 'line 17';
+	echo 'line 18';
+	echo 'line 19';
+	echo 'line 20';
 }


### PR DESCRIPTION
In almost all standards, function line counting starts at the line after the opening brace and stops at the line before the closing brace.

So in case the opening brace is on line `l` and the closing brace is on line `k`, we need to count lines `l+1` up to and including `k-1`, which is `(k-1) - (l+1) + 1`, which is the same as `k - l - 1`.