### PR TITLE
Fix: resolve false positive in FunctionHelper::isMethod for functions defined within a class method

### DIFF
--- a/SlevomatCodingStandard/Helpers/FunctionHelper.php
+++ b/SlevomatCodingStandard/Helpers/FunctionHelper.php
@@ -9,6 +9,7 @@ use SlevomatCodingStandard\Helpers\Annotation\ReturnAnnotation;
 use function array_filter;
 use function array_map;
 use function array_merge;
+use function array_pop;
 use function array_reverse;
 use function count;
 use function in_array;
@@ -132,15 +133,12 @@ class FunctionHelper
 
 	public static function isMethod(File $phpcsFile, int $functionPointer): bool
 	{
-		foreach (array_reverse($phpcsFile->getTokens()[$functionPointer]['conditions']) as $conditionTokenCode) {
-			if (!in_array($conditionTokenCode, [T_CLASS, T_INTERFACE, T_TRAIT, T_ANON_CLASS], true)) {
-				continue;
-			}
-
-			return true;
+		$functionPointerConditions = $phpcsFile->getTokens()[$functionPointer]['conditions'];
+		if ($functionPointerConditions === []) {
+			return false;
 		}
-
-		return false;
+		$lastFunctionPointerCondition = array_pop($functionPointerConditions);
+		return in_array($lastFunctionPointerCondition, [T_CLASS, T_INTERFACE, T_TRAIT, T_ANON_CLASS], true);
 	}
 
 	public static function findClassPointer(File $phpcsFile, int $functionPointer): ?int

--- a/tests/Helpers/FunctionHelperTest.php
+++ b/tests/Helpers/FunctionHelperTest.php
@@ -64,6 +64,7 @@ class FunctionHelperTest extends TestCase
 		self::assertTrue(FunctionHelper::isMethod($phpcsFile, $this->findFunctionPointerByName($phpcsFile, 'fooMethod')));
 		self::assertFalse(FunctionHelper::isMethod($phpcsFile, $this->findFunctionPointerByName($phpcsFile, 'fooFunction')));
 		self::assertFalse(FunctionHelper::isMethod($phpcsFile, $this->findFunctionPointerByName($phpcsFile, 'fooFunctionInCondition')));
+		self::assertFalse(FunctionHelper::isMethod($phpcsFile, $this->findFunctionPointerByName($phpcsFile, 'fooFunctionInFooMethod')));
 	}
 
 	/**

--- a/tests/Helpers/data/functionOrMethod.php
+++ b/tests/Helpers/data/functionOrMethod.php
@@ -17,7 +17,11 @@ class FooClass
 
 	public function fooMethod()
 	{
+		function fooFunctionInFooMethod()
+		{
 
+		}
+		fooFunctionInCondition();
 	}
 
 }


### PR DESCRIPTION
The helper function `\SlevomatCodingStandard\Helpers\FunctionHelper::isMethod` incorrectly returns `true` for functions that are defined within a class method.

Take the following example:

```php
class Foo
{
    public function classMethod()
    {
        function nonClassMethodFunction()
        {
        }

        return nonClassMethodFunction();
    }
}
```

Here, `FunctionHelper::isMethod` function returns `true` for `classMethod` as well as `nonClassMethodFunction`, while for the latter it should return `false`.

This PR fixes this issue.

