### PR TITLE
ReferenceUsedNamesOnly: fix requiring use of global names

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Namespaces/ReferenceUsedNamesOnlySniff.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/ReferenceUsedNamesOnlySniff.php
@@ -242,7 +242,7 @@ class ReferenceUsedNamesOnlySniff implements Sniff
 			}
 
 			if ($isFullyQualified || $isGlobalFunctionFallback || $isGlobalConstantFallback) {
-				if ($isFullyQualified && !$this->isRequiredToBeUsed($name)) {
+				if ($isFullyQualified && !$this->isRequiredToBeUsed($reference)) {
 					continue;
 				}
 
@@ -599,10 +599,27 @@ class ReferenceUsedNamesOnlySniff implements Sniff
 		return $useStatementPlacePointer;
 	}
 
-	private function isRequiredToBeUsed(string $name): bool
+	private function isRequiredToBeUsed(stdClass $reference): bool
 	{
 		if (count($this->namespacesRequiredToUse) === 0) {
 			return true;
+		}
+
+		$name = $reference->name;
+
+		// Reference is in global namespace
+		if (!NamespaceHelper::hasNamespace($name)) {
+			if ($reference->isClass && !$this->allowFullyQualifiedGlobalClasses) {
+				return true;
+			}
+
+			if ($reference->isFunction && !$this->allowFullyQualifiedGlobalFunctions) {
+				return true;
+			}
+
+			if ($reference->isConstant && !$this->allowFullyQualifiedGlobalConstants) {
+				return true;
+			}
 		}
 
 		foreach ($this->getNamespacesRequiredToUse() as $namespace) {

--- a/tests/Sniffs/Namespaces/ReferenceUsedNamesOnlySniffTest.php
+++ b/tests/Sniffs/Namespaces/ReferenceUsedNamesOnlySniffTest.php
@@ -329,12 +329,55 @@ class ReferenceUsedNamesOnlySniffTest extends TestCase
 					'Foo',
 				],
 				'ignoredNames' => $ignoredNames,
+				'allowFullyQualifiedGlobalClasses' => true,
+				'allowFullyQualifiedGlobalFunctions' => true,
+				'allowFullyQualifiedGlobalConstants' => true,
 			]
 		);
 
 		self::assertSniffError($report, 3, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME, '\Foo\Bar');
 		self::assertNoSniffError($report, 4);
 		self::assertNoSniffError($report, 5);
+		self::assertNoSniffError($report, 6);
+		self::assertNoSniffError($report, 7);
+		self::assertNoSniffError($report, 8);
+	}
+
+	/**
+	 * @dataProvider dataIgnoredNamesForIrrelevantTests
+	 * @param string[] $ignoredNames
+	 */
+	public function testUseOnlyWhitelistedNamespacesAndGlobalNamespace(array $ignoredNames): void
+	{
+		$report = self::checkFile(
+			__DIR__ . '/data/whitelistedNamespaces.php',
+			[
+				'namespacesRequiredToUse' => [
+					'Foo',
+				],
+				'ignoredNames' => $ignoredNames,
+				'allowFullyQualifiedGlobalClasses' => false,
+				'allowFullyQualifiedGlobalFunctions' => false,
+				'allowFullyQualifiedGlobalConstants' => false,
+			]
+		);
+
+		self::assertSniffError($report, 3, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME, '\Foo\Bar');
+		self::assertNoSniffError($report, 4);
+		self::assertNoSniffError($report, 5);
+		self::assertSniffError(
+			$report,
+			6,
+			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME_WITHOUT_NAMESPACE,
+			'\DateTimeImmutable'
+		);
+		self::assertSniffError($report, 7, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME_WITHOUT_NAMESPACE, '\min');
+		self::assertSniffError(
+			$report,
+			8,
+			ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME_WITHOUT_NAMESPACE,
+			'\PHP_VERSION'
+		);
 	}
 
 	/**

--- a/tests/Sniffs/Namespaces/data/whitelistedNamespaces.php
+++ b/tests/Sniffs/Namespaces/data/whitelistedNamespaces.php
@@ -3,3 +3,6 @@
 $foo = new \Foo\Bar();
 $foo = new \Fooo\Bar();
 $foo = new \Bar\Lorem();
+$foo = new \DateTimeImmutable();
+$foo = \min(1, 2);
+$foo = \PHP_VERSION;


### PR DESCRIPTION
When allowFullyQualifiedGlobalX is set to false it should require global X to be used. However, this was not the case when used together with non-empty namespacesRequiredToUse.

My use-case for this is that I want to require using my project's namespace and the global namespace.