### PR TITLE
Add nullchecks before dereferencing in areTypeHintEqual

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Classes/RequireConstructorPropertyPromotionSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/RequireConstructorPropertyPromotionSniff.php
@@ -327,6 +327,9 @@ class RequireConstructorPropertyPromotionSniff implements Sniff
 		if ($parameterTypeHint === null && $propertyTypeHint === null) {
 			return true;
 		}
+		if ($parameterTypeHint === null || $propertyTypeHint === null) {
+			return false;
+		}
 
 		return $parameterTypeHint->getTypeHint() === $propertyTypeHint->getTypeHint();
 	}


### PR DESCRIPTION
With a new update our CI builds started failing (hooray for check-before-merge :smile: ) on a null-dereference. This patch should fix that.