### PR TITLE
Support @covers annotation

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Namespaces/UnusedUsesSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/UnusedUsesSniff.php
@@ -268,7 +268,7 @@ class UnusedUsesSniff implements Sniff
 										}, AnnotationConstantExpressionHelper::getConstantFetchNodes($annotationConstantExpression))
 									);
 								}
-							} elseif ($annotationName === '@see') {
+							} elseif ($annotationName === '@see' || $annotationName === '@covers') {
 								$parts = preg_split('~(\\s+|::)~', $content);
 								if ($parts !== false) {
 									$contentsToCheck[] = $parts[0];


### PR DESCRIPTION
annotation `@covers` can look like someClass::someMethod  -- eh it's non recommended but it can be
and it will be great to identify import from `@covers` annotation :)