### PR TITLE
ModernClassNameReference: don't flag method declarations

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Classes/ModernClassNameReferenceSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/ModernClassNameReferenceSniff.php
@@ -14,6 +14,7 @@ use function sprintf;
 use function strtolower;
 use const T_CLASS_C;
 use const T_DOUBLE_COLON;
+use const T_FUNCTION;
 use const T_NS_SEPARATOR;
 use const T_OBJECT_OPERATOR;
 use const T_OPEN_PARENTHESIS;
@@ -97,7 +98,7 @@ class ModernClassNameReferenceSniff implements Sniff
 		}
 
 		$previousPointer = TokenHelper::findPreviousEffective($phpcsFile, $functionPointer - 1);
-		if (in_array($tokens[$previousPointer]['code'], [T_OBJECT_OPERATOR, T_DOUBLE_COLON], true)) {
+		if (in_array($tokens[$previousPointer]['code'], [T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_FUNCTION], true)) {
 			return;
 		}
 

--- a/tests/Sniffs/Classes/data/modernClassNameReferenceNoErrors.php
+++ b/tests/Sniffs/Classes/data/modernClassNameReferenceNoErrors.php
@@ -54,4 +54,13 @@ class Whatever
 		return get_parent_class($this);
 	}
 
+	/*
+	 * Prevent false positives for methods called get_class(), get_parent_class(), get_called_class().
+	 */
+
+	public function get_class() {}
+
+	public function get_parent_class() {}
+
+	public function get_called_class() {}
 }


### PR DESCRIPTION
The sniff was throwing false positives as per the code examples added to the tests.