### PR TITLE
FunctionLengthSniff / FunctionHelper:: getFunctionLengthInLines

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,8 @@ Reports closures not using `$this` that are not declared `static`.
 
 Disallows long functions. This sniff provides the following setting:
 
+* `includeComments`: should comments be included in the count (default value is false).
+* `includeWhitespace`: shoud empty lines be included in the count (default value is false).
 * `maxLinesLength`: specifies max allowed function lines length (default value is 20).
 
 #### SlevomatCodingStandard.PHP.DisallowDirectMagicInvokeCall 🔧

--- a/SlevomatCodingStandard/Sniffs/Functions/FunctionLengthSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Functions/FunctionLengthSniff.php
@@ -6,6 +6,9 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use SlevomatCodingStandard\Helpers\FunctionHelper;
 use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
+use function array_filter;
+use function array_keys;
+use function array_reduce;
 use function sprintf;
 use const T_FUNCTION;
 
@@ -16,6 +19,12 @@ class FunctionLengthSniff implements Sniff
 
 	/** @var int */
 	public $maxLinesLength = 20;
+
+	/** @var bool */
+	public $includeComments = false;
+
+	/** @var bool */
+	public $includeWhitespace = false;
 
 	/**
 	 * @return array<int, (int|string)>
@@ -32,7 +41,15 @@ class FunctionLengthSniff implements Sniff
 	 */
 	public function process(File $file, $functionPointer): void
 	{
-		$length = FunctionHelper::getFunctionLengthInLines($file, $functionPointer);
+		$flags = array_keys(array_filter([
+			FunctionHelper::LINE_INCLUDE_COMMENT => $this->includeComments,
+			FunctionHelper::LINE_INCLUDE_WHITESPACE => $this->includeWhitespace,
+		]));
+		$flags = array_reduce($flags, static function ($carry, $flag): int {
+			return $carry | $flag;
+		}, 0);
+
+		$length = FunctionHelper::getFunctionLengthInLines($file, $functionPointer, $flags);
 
 		if ($length <= SniffSettingsHelper::normalizeInteger($this->maxLinesLength)) {
 			return;

--- a/tests/Helpers/FunctionHelperTest.php
+++ b/tests/Helpers/FunctionHelperTest.php
@@ -440,6 +440,29 @@ class FunctionHelperTest extends TestCase
 		self::assertSame(['foo', 'boo'], FunctionHelper::getAllFunctionNames($phpcsFile));
 	}
 
+	public function testGetFunctionLengthInLines(): void
+	{
+		$phpcsFile = $this->getCodeSnifferFile(__DIR__ . '/data/functionLength.php');
+		$functionPointer = $this->findFunctionPointerByName($phpcsFile, 'countMe');
+
+		self::assertSame(2, FunctionHelper::getFunctionLengthInLines($phpcsFile, $functionPointer));
+		self::assertSame(7, FunctionHelper::getFunctionLengthInLines(
+			$phpcsFile,
+			$functionPointer,
+			FunctionHelper::LINE_INCLUDE_COMMENT
+		));
+		self::assertSame(3, FunctionHelper::getFunctionLengthInLines(
+			$phpcsFile,
+			$functionPointer,
+			FunctionHelper::LINE_INCLUDE_WHITESPACE
+		));
+		self::assertSame(8, FunctionHelper::getFunctionLengthInLines(
+			$phpcsFile,
+			$functionPointer,
+			FunctionHelper::LINE_INCLUDE_COMMENT | FunctionHelper::LINE_INCLUDE_WHITESPACE
+		));
+	}
+
 	public function testFindClassPointer(): void
 	{
 		$phpcsFile = $this->getCodeSnifferFile(__DIR__ . '/data/functionNames.php');

--- a/tests/Helpers/data/functionLength.php
+++ b/tests/Helpers/data/functionLength.php
@@ -1,0 +1,16 @@
+<?php
+
+class FooClass
+{
+
+	public function countMe(): string
+	{
+		/*
+		   block comment
+		*/
+		1 + 1; // slash comment
+		# hash comment
+
+		return 'This is the only line that matters (by default)'; /* inline comment */
+	/* inline comment */ }
+}

--- a/tests/Sniffs/Functions/FunctionLengthSniffTest.php
+++ b/tests/Sniffs/Functions/FunctionLengthSniffTest.php
@@ -19,7 +19,35 @@ class FunctionLengthSniffTest extends TestCase
 
 		self::assertSame(1, $report->getErrorCount());
 
-		self::assertSniffError($report, 3, FunctionLengthSniff::CODE_FUNCTION_LENGTH);
+		self::assertSniffError($report, 3, FunctionLengthSniff::CODE_FUNCTION_LENGTH, 'Currently using 21 lines');
+	}
+
+	public function testWithComments(): void
+	{
+		$report = self::checkFile(
+			__DIR__ . '/data/functionLengthErrors.php',
+			[
+				'includeComments' => true,
+			]
+		);
+
+		self::assertSame(1, $report->getErrorCount());
+
+		self::assertSniffError($report, 3, FunctionLengthSniff::CODE_FUNCTION_LENGTH, 'Currently using 24 lines');
+	}
+
+	public function testWithWhitespace(): void
+	{
+		$report = self::checkFile(
+			__DIR__ . '/data/functionLengthErrors.php',
+			[
+				'includeWhitespace' => true,
+			]
+		);
+
+		self::assertSame(1, $report->getErrorCount());
+
+		self::assertSniffError($report, 3, FunctionLengthSniff::CODE_FUNCTION_LENGTH, 'Currently using 22 lines');
 	}
 
 }

--- a/tests/Sniffs/Functions/data/functionLengthErrors.php
+++ b/tests/Sniffs/Functions/data/functionLengthErrors.php
@@ -2,6 +2,10 @@
 
 function dummyFunctionWithTooManyLines()
 {
+	/*
+		Block comment
+	*/
+
 	echo 'line 1';
 	echo 'line 2';
 	echo 'line 3';


### PR DESCRIPTION
Resolves #1285

Update Helpers/FunctionHelper::getFunctionLengthInLines() to not include comments and blank lines in line count by default

new `$flags` param allows including comments and/or blank lines