### PR TITLE
Makes RequireTrailingCommaInCallSniff check if the closing paren is on the same line

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Functions/RequireTrailingCommaInCallSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Functions/RequireTrailingCommaInCallSniff.php
@@ -79,7 +79,7 @@ class RequireTrailingCommaInCallSniff implements Sniff
 			return;
 		}
 
-		if ($pointerBeforeParenthesisCloser + 1 === $parenthesisCloserPointer) {
+		if ($tokens[$parenthesisCloserPointer]['line'] === $tokens[$pointerBeforeParenthesisCloser]['line']) {
 			return;
 		}
 

--- a/tests/Sniffs/Functions/data/requireTrailingCommaInCallNoErrors.php
+++ b/tests/Sniffs/Functions/data/requireTrailingCommaInCallNoErrors.php
@@ -64,3 +64,10 @@ $array[
 doSomething([
 	$a,
 ]);
+
+doSomething( $a,
+	$b );
+
+doSomething( doSomething(
+	$foo,
+) );


### PR DESCRIPTION
Makes RequireTrailingCommaInCallSniff check if the closing paren is on the same line as the item before, and skip it if it is.

It's already doing so if there's no whitespace, but if there's whitespace on the line it adds a comma. I don't imagine this is a desired behaviour.

---

Right now RequireTrailingCommaInCallSniff will leave this code alone:

```php
doSomething($a,
	$b);

doSomething(doSomething(
	$foo,
));
```

but turn these

```php
doSomething( $a,
	$b );

doSomething( doSomething(
	$foo,
) );
```

into

```php
doSomething( $a,
	$b, );

doSomething( doSomething(
	$foo,
), );
```

I've basically fixed it so it leaves these instances alone.