### PR TITLE
changed spaces count around equals sign

### DIFF
--- a/SlevomatCodingStandard/Sniffs/TypeHints/DeclareStrictTypesSniff.php
+++ b/SlevomatCodingStandard/Sniffs/TypeHints/DeclareStrictTypesSniff.php
@@ -38,7 +38,7 @@ class DeclareStrictTypesSniff implements Sniff
 	public $linesCountAfterDeclare = 1;
 
 	/** @var int */
-	public $spacesCountAroundEqualsSign = 1;
+	public $spacesCountAroundEqualsSign = 0;
 
 	/**
 	 * @return array<int, (int|string)>


### PR DESCRIPTION
https://www.php-fig.org/psr/psr-12/

Declare statements MUST contain no spaces and MUST be exactly declare(strict_types=1) (with an optional semi-colon terminator).