### PR TITLE
Add proof of concept test for multiline comments in heredoc bug

### DIFF
--- a/tests/Helpers/data/lotsOfReferencedNames.php
+++ b/tests/Helpers/data/lotsOfReferencedNames.php
@@ -177,6 +177,14 @@ class SomeController
 	}
 }
 
+<<<MULTILINE_COMMENT_HEREDOC
+/**
+ * I'm a multiline comment in HEREDOC.
+ * Why?
+ * Because one can make a sniff that checks copyright correctness.
+ */
+MULTILINE_COMMENT_HEREDOC;
+
 <<<XML
 	<string>Hello world and {$this->wrap(ClassInHeredoc::EXAMPLE)}</string>
 XML;


### PR DESCRIPTION
Hello!

Adding this triggers he bug described in #1355.

