### PR TITLE
Fix: resolve false positives in UnusedVariable sniff with increment/decrement operators

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Variables/UnusedVariableSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Variables/UnusedVariableSniff.php
@@ -32,7 +32,10 @@ use const T_DOUBLE_COLON;
 use const T_DOUBLE_QUOTED_STRING;
 use const T_ECHO;
 use const T_ELSEIF;
+use const T_EMPTY;
 use const T_EQUAL;
+use const T_EVAL;
+use const T_EXIT;
 use const T_FOR;
 use const T_FOREACH;
 use const T_GLOBAL;
@@ -51,6 +54,8 @@ use const T_OPEN_TAG;
 use const T_OR_EQUAL;
 use const T_PLUS_EQUAL;
 use const T_POW_EQUAL;
+use const T_PRINT;
+use const T_RETURN;
 use const T_SL_EQUAL;
 use const T_SR_EQUAL;
 use const T_STATIC;
@@ -647,7 +652,12 @@ class UnusedVariableSniff implements Sniff
 
 		return in_array(
 			$tokens[$previousPointer]['code'],
-			array_merge([T_STRING_CONCAT, T_ECHO], Tokens::$operators, Tokens::$assignmentTokens, Tokens::$booleanOperators),
+			array_merge(
+				[T_STRING_CONCAT, T_ECHO, T_RETURN, T_EXIT, T_PRINT, T_COMMA, T_EMPTY, T_EVAL],
+				Tokens::$operators,
+				Tokens::$assignmentTokens,
+				Tokens::$booleanOperators
+			),
 			true
 		);
 	}

--- a/tests/Sniffs/Variables/data/unusedVariableNoErrors.php
+++ b/tests/Sniffs/Variables/data/unusedVariableNoErrors.php
@@ -406,3 +406,27 @@ function ($path, $name) {
 
 	return $name;
 };
+
+function ($i) {
+	return ++$i;
+};
+
+function ($i) {
+	exit(++$i);
+};
+
+function ($i) {
+	print ++$i;
+};
+
+function ($i) {
+	echo $i, ++$i;
+};
+
+function ($i) {
+	return empty(++$i);
+};
+
+function ($i) {
+	eval(++$i . ' !== 1 ?: exit("zero");');
+};


### PR DESCRIPTION
The `SlevomatCodingStandard.Variables.UnusedVariable` sniff returns false positives when a increment/decrement expression is prefixed with one the following tokens: `T_RETURN`, `T_EXIT`, `T_PRINT`, `T_COMMA`, `T_EMPTY`, and `T_EVAL`.

After merging this PR, the following code should not report any violations against the `SlevomatCodingStandard.Variables.UnusedVariable` sniff anymore:

```php
<?php
function inc(int $a): int
{
    return ++$a;
}

function stop(int $b): void
{
    exit(++$b);
}

function show(int $c): void
{
    print ++$c;
}

function commas(int $d): void
{
    echo $d, ++$d;
}

function one(int $e): bool
{
    return empty(++$e);
}

function evil(int $f): void
{
    eval(++$f . ' !== 1 ?: exit("zero");');
}
```

This PR fixes issue #1358.