### PR TITLE
Fix: allow increment/decrement operator after yield in UnusedVariable sniff

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Variables/UnusedVariableSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Variables/UnusedVariableSniff.php
@@ -653,7 +653,7 @@ class UnusedVariableSniff implements Sniff
 		return in_array(
 			$tokens[$previousPointer]['code'],
 			array_merge(
-				[T_STRING_CONCAT, T_ECHO, T_RETURN, T_EXIT, T_PRINT, T_COMMA, T_EMPTY, T_EVAL],
+				[T_STRING_CONCAT, T_ECHO, T_RETURN, T_EXIT, T_PRINT, T_COMMA, T_EMPTY, T_EVAL, T_YIELD],
 				Tokens::$operators,
 				Tokens::$assignmentTokens,
 				Tokens::$booleanOperators

--- a/tests/Sniffs/Variables/data/unusedVariableNoErrors.php
+++ b/tests/Sniffs/Variables/data/unusedVariableNoErrors.php
@@ -430,3 +430,7 @@ function ($i) {
 function ($i) {
 	eval(++$i . ' !== 1 ?: exit("zero");');
 };
+
+function ($i) {
+	yield ++$i;
+};


### PR DESCRIPTION
The `SlevomatCodingStandard.Variables.UnusedVariable` sniff returns a false positive when using an increment/decrement operator on a variable directly after a `yield`.

After merging this PR, the following code should not report any violation against the `SlevomatCodingStandard.Variables.UnusedVariable` sniff anymore:

```php
<?php
function yieldinc($i)
{
    yield ++$i;
}
```