### PR TITLE
Add missing header in docs for SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses

### DIFF
--- a/README.md
+++ b/README.md
@@ -857,6 +857,8 @@ This sniff provides the following setting:
 
 * `enable`: either to enable or not this sniff. By default, it is enabled for PHP versions 8.0 or higher.
 
+#### SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses 🔧
+
 Checks whether uses at the top of a file are alphabetically sorted. Follows natural sorting and takes edge cases with special symbols into consideration. The following code snippet is an example of correctly sorted uses:
 
 ```php


### PR DESCRIPTION
noticed by luck while I was searching for the docs of that sniff