### PR TITLE
DisallowCommentAfterCodeSniff: don't break multi-line string during auto-fix

### DIFF
--- a/tests/Sniffs/Commenting/DisallowCommentAfterCodeSniffTest.php
+++ b/tests/Sniffs/Commenting/DisallowCommentAfterCodeSniffTest.php
@@ -17,9 +17,9 @@ class DisallowCommentAfterCodeSniffTest extends TestCase
 	{
 		$report = self::checkFile(__DIR__ . '/data/disallowCommentAfterCodeErrors.php');
 
-		self::assertSame(19, $report->getErrorCount());
+		self::assertSame(23, $report->getErrorCount());
 
-		foreach ([7, 9, 11, 13, 15, 19, 25, 27, 30, 35, 36, 39, 40, 41, 42, 43, 44, 45, 48] as $line) {
+		foreach ([7, 9, 11, 13, 15, 19, 25, 27, 30, 35, 36, 39, 40, 41, 42, 43, 44, 45, 50, 53, 58, 61, 63] as $line) {
 			self::assertSniffError($report, $line, DisallowCommentAfterCodeSniff::CODE_DISALLOWED_COMMENT_AFTER_CODE);
 		}
 

--- a/tests/Sniffs/Commenting/data/disallowCommentAfterCodeErrors.fixed.php
+++ b/tests/Sniffs/Commenting/data/disallowCommentAfterCodeErrors.fixed.php
@@ -63,6 +63,25 @@ class Whatever
 				return;
 		}
 
+		// comment
+		doSomething("
+			aaa
+		");
+		// comment
+		doSomething('
+			aaa
+		');
+		$a = rand()
+			? 5
+			// comment
+			: '
+				aaa
+			';
+		// comment
+		doSomething("
+			{$a}
+		");
+
 		// True
 		return true;
 	}

--- a/tests/Sniffs/Commenting/data/disallowCommentAfterCodeErrors.php
+++ b/tests/Sniffs/Commenting/data/disallowCommentAfterCodeErrors.php
@@ -45,6 +45,21 @@ class Whatever
 				return; // Return
 		}
 
+		doSomething("
+			aaa
+		"); // comment
+		doSomething('
+			aaa
+		'); // comment
+		$a = rand()
+			? 5
+			: '
+				aaa
+			'; // comment
+		doSomething("
+			{$a}
+		"); // comment
+
 		return true; // True
 	}
 


### PR DESCRIPTION
There is a bug where
```php
doSomething("
    aaa
"); // comment
```
would be fixed as 
```php
doSomething("
    aaa
// comment
");
```
This is an attempt to fix this scenario.