### PR TITLE
TokenHelper: fix findFirstNonWhitespaceOnLine 1st line

### DIFF
--- a/SlevomatCodingStandard/Helpers/TokenHelper.php
+++ b/SlevomatCodingStandard/Helpers/TokenHelper.php
@@ -309,7 +309,7 @@ class TokenHelper
 
 		do {
 			$pointer--;
-		} while ($tokens[$pointer]['line'] === $line);
+		} while ($pointer >= 0 && $tokens[$pointer]['line'] === $line);
 
 		return self::findNextExcluding($phpcsFile, [T_WHITESPACE, T_DOC_COMMENT_WHITESPACE], $pointer + 1);
 	}

--- a/tests/Helpers/TokenHelperTest.php
+++ b/tests/Helpers/TokenHelperTest.php
@@ -6,6 +6,7 @@ use function sprintf;
 use const T_CLASS;
 use const T_CLOSE_PARENTHESIS;
 use const T_CLOSURE;
+use const T_COMMENT;
 use const T_DOC_COMMENT_OPEN_TAG;
 use const T_DOC_COMMENT_WHITESPACE;
 use const T_EQUAL;
@@ -232,6 +233,19 @@ class TokenHelperTest extends TestCase
 		$firstNonWhiteSpaceTokenPointer = TokenHelper::findFirstNonWhitespaceOnLine($phpcsFile, $openParenthesisPointer);
 		self::assertTokenPointer(T_STRING, 4, $phpcsFile, $firstNonWhiteSpaceTokenPointer);
 		self::assertSame('foo', $tokens[$firstNonWhiteSpaceTokenPointer]['content']);
+	}
+
+	public function testFindFirstNonWhitespaceOnFirstLine(): void
+	{
+		$phpcsFile = $this->getCodeSnifferFile(__DIR__ . '/data/useStatements.php');
+		$tokens = $phpcsFile->getTokens();
+
+		$comment = $this->findPointerByLineAndType($phpcsFile, 1, T_COMMENT);
+		self::assertNotNull($comment);
+
+		$firstNonWhiteSpaceTokenPointer = TokenHelper::findFirstNonWhitespaceOnLine($phpcsFile, $comment);
+		self::assertTokenPointer(T_OPEN_TAG, 1, $phpcsFile, $firstNonWhiteSpaceTokenPointer);
+		self::assertSame('<?php ', $tokens[$firstNonWhiteSpaceTokenPointer]['content']);
 	}
 
 	public function testFindFirstTokenOnNextLineEndingWithAComment(): void

--- a/tests/Sniffs/Commenting/data/disallowCommentAfterCodeNoErrors.php
+++ b/tests/Sniffs/Commenting/data/disallowCommentAfterCodeNoErrors.php
@@ -1,3 +1,4 @@
+<?php /** @var Token $token */ ?>
 <?php
 
 // Comment


### PR DESCRIPTION
I'm getting issues like this:

```
An error occurred during processing; checking has been aborted. The error
message was: Undefined array key -1 in
.../SlevomatCodingStandard/Helpers/TokenHelper.php
on line 312 (Internal.Exception)
```

The code that triggered this for me had something like this on the first line:

```php
<?php /** @var Abc $abc */ ?>
```

So I also added a test for DisallowCommentAfterCodeSniff.