### PR TITLE
SlevomatCodingStandard.TypeHints.PropertyTypeHint: fix inconsistent enableIntersectionTypeHint

### DIFF
--- a/SlevomatCodingStandard/Sniffs/TypeHints/PropertyTypeHintSniff.php
+++ b/SlevomatCodingStandard/Sniffs/TypeHints/PropertyTypeHintSniff.php
@@ -305,7 +305,7 @@ class PropertyTypeHintSniff implements Sniff
 		}
 		$typeHintsWithConvertedUnion = array_unique($typeHintsWithConvertedUnion);
 
-		if (count($typeHintsWithConvertedUnion) > 1 && !$canTryUnionTypeHint && !$this->enableUnionTypeHint) {
+		if (count($typeHintsWithConvertedUnion) > 1 && !$canTryUnionTypeHint && !$this->enableIntersectionTypeHint) {
 			$this->reportUselessSuppress($phpcsFile, $propertyPointer, $isSuppressedNativeTypeHint, $suppressNameNativeTypeHint);
 			return;
 		}

--- a/tests/Sniffs/TypeHints/data/parameterTypeHintWithUnionNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/parameterTypeHintWithUnionNoErrors.php
@@ -21,4 +21,18 @@ class Whatever
 	{
 	}
 
+	/**
+	 * @param A&B $a
+	 */
+	public function intersectionWithoutNativeTypeHint($a)
+	{
+	}
+
+	/**
+	 * @param A&B $a
+	 */
+	public function intersectionWithBroadNativeTypeHint(A $a)
+	{
+	}
+
 }

--- a/tests/Sniffs/TypeHints/data/propertyTypeHintEnabledNativeWithUnionNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/propertyTypeHintEnabledNativeWithUnionNoErrors.php
@@ -13,4 +13,10 @@ class Whatever
 	 */
 	protected $arrayAndArrayHash;
 
+	/** @var A&B */
+	public $intersectionWithoutNativeTypeHint;
+
+	/** @var A&B */
+	public A $intersectionWitBroadNativeTypeHint;
+
 }

--- a/tests/Sniffs/TypeHints/data/returnTypeHintWithUnionNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/returnTypeHintWithUnionNoErrors.php
@@ -19,4 +19,18 @@ class Whatever
 	{
 	}
 
+	/**
+	 * @return A&B
+	 */
+	public function intersectionWithoutNativeTypeHint()
+	{
+	}
+
+	/**
+	 * @return A&B
+	 */
+	public function intersectionWithBroadNativeTypeHint(): A
+	{
+	}
+
 }


### PR DESCRIPTION
PropertyTypeHintSniff handled enableIntersectionTypeHint differently than ReturnTypeHintSniff and ParameterTypeHintSniff. This appears to be an unintentional (i.e. using enableUnionTypeHint instead). See [ReturnTypeHintSniff](https://github.com/slevomat/coding-standard/blob/c5cf9b5c1a44b8abba1279a199dcac206d1266c3/SlevomatCodingStandard/Sniffs/TypeHints/ReturnTypeHintSniff.php#L375) vs [PropertyTypeHintSniff](https://github.com/slevomat/coding-standard/blob/c5cf9b5c1a44b8abba1279a199dcac206d1266c3/SlevomatCodingStandard/Sniffs/TypeHints/PropertyTypeHintSniff.php#L308)

It lead to it suggesting to replace an interesection annotation with a native typehint with enableNativeTypeHint=true, enableUnionTypeHint=true and enableIntersectionTypeHint=false.

Here is a test example:

```php
<?php

class Test
{
    /** @var A&B */
    private A $a;

    /** @var A&B */
    private $b;

    /** @var array<int>&Traversable<int> */
    private $c;

    /** @param A&B $a */
    public function aa(A $a): void
    {
        var_dump($a);
    }

    /** @param A&B $a */
    public function ab($a): void
    {
        var_dump($a);
    }

    /** @param array<int>&Traversable<int> $a */
    public function ac($a): void
    {
        var_dump($a);
    }

    /** @return A&B */
    public function ba(): A
    {
        die;
    }

    /** @return A&B */
    public function bb()
    {
        die;
    }

    /** @return array<int>&Traversable<int> */
    public function bc()
    {
        die;
    }
}
```
These are the settings I used for the relevant sniffs:

```xml
    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
        <properties>
            <property name="enableObjectTypeHint" value="true" />
            <property name="enableMixedTypeHint" value="true" />
            <property name="enableUnionTypeHint" value="true" />
            <property name="enableIntersectionTypeHint" value="false" />
        </properties>
    </rule>
    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
        <properties>
            <property name="enableObjectTypeHint" value="true" />
            <property name="enableMixedTypeHint" value="true" />
            <property name="enableUnionTypeHint" value="true" />
            <property name="enableIntersectionTypeHint" value="false" />
        </properties>
    </rule>
    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
        <properties>
            <property name="enableObjectTypeHint" value="true" />
            <property name="enableMixedTypeHint" value="true" />
            <property name="enableUnionTypeHint" value="true" />
            <property name="enableIntersectionTypeHint" value="false" />
        </properties>
    </rule>
```
The code sniffer output is as follows:

```
  9 | ERROR | [x] Property \Test::$b does not have native type hint for its value but it
    |       |     should be possible to add it based on @var annotation "A&B".
 12 | ERROR | [x] Property \Test::$c does not have native type hint for its value but it
    |       |     should be possible to add it based on @var annotation
    |       |     "array<int>&Traversable<int>".
```
The suggested fix is this:
```diff
--- test.php
+++ PHP_CodeSniffer
@@ -5,11 +5,10 @@
     /** @var A&B */
     private A $a;
 
-    /** @var A&B */
-    private $b;
+    private A&B $b;
 
     /** @var array<int>&Traversable<int> */
-    private $c;
+    private array&Traversable $c;
 
     /** @param A&B $a */
     public function aa(A $a): void
```

So it is clear that PropertyTypeHintSniff behaves differently than the other two sniffs. I added similar test cases to all 3 sniffs to make sure that it doesn't break in the future.

-------------
Motivation: I'm on php 8.1, so I could use intersection types. But in our project we abuse them to provide additional information for phpstorm/phpstan. There are some legacy classes with dynamically set fields. So we create "typedef" classes where the fields are specified (and typed) statically. And then we use `Dynamic&Static` in phpdocs. But OFC at runtime it's just `Dynamic`, so the annotation cannot be converted to a native intersection type. Therefore, I want to keep it up to the programmer to decide whether to use native intersection types.