### PR TITLE
FileLineCountSniff & ClassLineCountSniff

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Reports closures not using `$this` that are not declared `static`.
 
 #### SlevomatCodingStandard.Functions.FunctionLength
 
-Disallows long functions. This sniff provides the following setting:
+Disallows long functions. This sniff provides the following settings:
 
 * `includeComments`: should comments be included in the count (default value is false).
 * `includeWhitespace`: shoud empty lines be included in the count (default value is false).
@@ -493,6 +493,14 @@ Sniff provides the following settings:
 
 * `spacesCountBeforeColon`: the number of spaces before `:`.
 * `spacesCountBeforeType`: the number of spaces before type.
+
+#### SlevomatCodingStandard.Classes.ClassLineCount
+
+Disallows long classes. This sniff provides the following settings:
+
+* `includeComments`: should comments be included in the count (default value is false).
+* `includeWhitespace`: shoud empty lines be included in the count (default value is false).
+* `maxLinesLength`: specifies max allowed function lines length (default value is 250).
 
 #### SlevomatCodingStandard.Classes.ClassMemberSpacing 🔧
 
@@ -773,6 +781,14 @@ Sniff provides the following settings:
 
 However, if you prefer Yoda conditions, you can use `RequireYodaComparisonSniff`.
 
+#### SlevomatCodingStandard.Files.FileLineCount
+
+Disallows long files. This sniff provides the following settings:
+
+* `includeComments`: should comments be included in the count (default value is false).
+* `includeWhitespace`: shoud empty lines be included in the count (default value is false).
+* `maxLinesLength`: specifies max allowed function lines length (default value is 250).
+
 #### SlevomatCodingStandard.Files.LineLength
 
 Enforces maximum length of a single line of code.
@@ -949,7 +965,7 @@ Disallows numeric literal separators.
 
 Requires use of numeric literal separators.
 
-This sniff provides the following setting:
+This sniff provides the following settings:
 
 * `enable`: either to enable or not this sniff. By default, it is enabled for PHP versions 7.4 or higher.
 * `minDigitsBeforeDecimalPoint`: the mininum digits before decimal point to require separator.

--- a/SlevomatCodingStandard/Helpers/FunctionHelper.php
+++ b/SlevomatCodingStandard/Helpers/FunctionHelper.php
@@ -430,15 +430,19 @@ class FunctionHelper
 		if (self::isAbstract($file, $functionPosition)) {
 			return 0;
 		}
+		return self::getLineCount($file, $functionPosition, $flags);
+	}
 
+	public static function getLineCount(File $file, int $tokenPosition, int $flags = 0): int
+	{
 		$includeWhitespace = ($flags & self::LINE_INCLUDE_WHITESPACE) === self::LINE_INCLUDE_WHITESPACE;
 		$includeComments = ($flags & self::LINE_INCLUDE_COMMENT) === self::LINE_INCLUDE_COMMENT;
 
 		$tokens = $file->getTokens();
-		$token = $tokens[$functionPosition];
+		$token = $tokens[$tokenPosition];
 
-		$tokenOpenerPosition = $token['scope_opener'];
-		$tokenCloserPosition = $token['scope_closer'];
+		$tokenOpenerPosition = $token['scope_opener'] ?? $tokenPosition;
+		$tokenCloserPosition = $token['scope_closer'] ?? $file->numTokens - 1;
 		$tokenOpenerLine = $tokens[$tokenOpenerPosition]['line'];
 		$tokenCloserLine = $tokens[$tokenCloserPosition]['line'];
 

--- a/SlevomatCodingStandard/Sniffs/Classes/ClassLineCountSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/ClassLineCountSniff.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+use SlevomatCodingStandard\Helpers\FunctionHelper;
+use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
+use function array_filter;
+use function array_keys;
+use function array_reduce;
+use function array_values;
+use function sprintf;
+
+class ClassLineCountSniff implements Sniff
+{
+
+	public const CODE_CLASS_LINE_COUNT = 'ClassLineCount';
+
+	/** @var int */
+	public $maxLinesLength = 250;
+
+	/** @var bool */
+	public $includeComments = false;
+
+	/** @var bool */
+	public $includeWhitespace = false;
+
+	/**
+	 * @return array<int, (int|string)>
+	 */
+	public function register(): array
+	{
+		return array_values(Tokens::$ooScopeTokens);
+	}
+
+	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+	 * @param int $pointer
+	 */
+	public function process(File $phpcsFile, $pointer): void
+	{
+		$flags = array_keys(array_filter([
+			FunctionHelper::LINE_INCLUDE_COMMENT => $this->includeComments,
+			FunctionHelper::LINE_INCLUDE_WHITESPACE => $this->includeWhitespace,
+		]));
+		$flags = array_reduce($flags, static function ($carry, $flag): int {
+			return $carry | $flag;
+		}, 0);
+
+		$length = FunctionHelper::getLineCount($phpcsFile, $pointer, $flags);
+
+		if ($length <= SniffSettingsHelper::normalizeInteger($this->maxLinesLength)) {
+			return;
+		}
+
+		$errorMessage = sprintf('Your class is too long. Currently using %d lines. Can be up to %d lines.', $length, $this->maxLinesLength);
+
+		$phpcsFile->addError($errorMessage, $pointer, self::CODE_CLASS_LINE_COUNT);
+	}
+
+}

--- a/SlevomatCodingStandard/Sniffs/Files/FileLineCountSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Files/FileLineCountSniff.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Files;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use SlevomatCodingStandard\Helpers\FunctionHelper;
+use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
+use function array_filter;
+use function array_keys;
+use function array_reduce;
+use function sprintf;
+use const T_OPEN_TAG;
+
+class FileLineCountSniff implements Sniff
+{
+
+	public const CODE_FILE_LINE_COUNT = 'FileLineCount';
+
+	/** @var int */
+	public $maxLinesLength = 250;
+
+	/** @var bool */
+	public $includeComments = false;
+
+	/** @var bool */
+	public $includeWhitespace = false;
+
+	/**
+	 * @return array<int, (int|string)>
+	 */
+	public function register(): array
+	{
+		return [T_OPEN_TAG];
+	}
+
+	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+	 * @param int $pointer
+	 */
+	public function process(File $phpcsFile, $pointer): void
+	{
+		$flags = array_keys(array_filter([
+			FunctionHelper::LINE_INCLUDE_COMMENT => $this->includeComments,
+			FunctionHelper::LINE_INCLUDE_WHITESPACE => $this->includeWhitespace,
+		]));
+		$flags = array_reduce($flags, static function ($carry, $flag): int {
+			return $carry | $flag;
+		}, 0);
+
+		$length = FunctionHelper::getLineCount($phpcsFile, $pointer, $flags);
+
+		if ($length <= SniffSettingsHelper::normalizeInteger($this->maxLinesLength)) {
+			return;
+		}
+
+		$errorMessage = sprintf('Your file is too long. Currently using %d lines. Can be up to %d lines.', $length, $this->maxLinesLength);
+
+		$phpcsFile->addError($errorMessage, $pointer, self::CODE_FILE_LINE_COUNT);
+	}
+
+}

--- a/tests/Sniffs/Classes/ClassLineCountSniffTest.php
+++ b/tests/Sniffs/Classes/ClassLineCountSniffTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Classes;
+
+use SlevomatCodingStandard\Sniffs\TestCase;
+
+class ClassLineCountSniffTest extends TestCase
+{
+
+	public function testNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/classLineCount.php');
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/classLineCount.php', [
+			'maxLinesLength' => 5,
+			'includeComments' => true,
+		]);
+
+		self::assertSame(1, $report->getErrorCount());
+
+		self::assertSniffError(
+			$report,
+			5,
+			ClassLineCountSniff::CODE_CLASS_LINE_COUNT,
+			'Your class is too long. Currently using 13 lines. Can be up to 5 lines.'
+		);
+	}
+
+}

--- a/tests/Sniffs/Classes/data/classLineCount.php
+++ b/tests/Sniffs/Classes/data/classLineCount.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Foo\Bar;
+
+class ClassLineCountSniffTest
+{
+	public function __construct()
+	{
+	}
+
+	public function __get($name)
+	{
+	}
+
+	/**
+	 *
+	 */
+	public function someMethod() : string
+	{
+		return 'foo bar';
+	}
+}

--- a/tests/Sniffs/Files/FileLineCountSniffTest.php
+++ b/tests/Sniffs/Files/FileLineCountSniffTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Files;
+
+use SlevomatCodingStandard\Sniffs\TestCase;
+
+class FileLineCountSniffTest extends TestCase
+{
+
+	public function testNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/fileLineCount.php');
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/fileLineCount.php', [
+			'maxLinesLength' => 5,
+			'includeComments' => true,
+		]);
+
+		self::assertSame(1, $report->getErrorCount());
+
+		self::assertSniffError(
+			$report,
+			1,
+			FileLineCountSniff::CODE_FILE_LINE_COUNT,
+			'Your file is too long. Currently using 12 lines. Can be up to 5 lines.'
+		);
+	}
+
+}

--- a/tests/Sniffs/Files/data/fileLineCount.php
+++ b/tests/Sniffs/Files/data/fileLineCount.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Foo\Bar;
+
+class FileLineCountSniffTest
+{
+	/**
+	 *
+	 */
+	public function someMethod() : string
+	{
+		return 'foo bar';
+	}
+}


### PR DESCRIPTION
Adds two new sniffs:
* SlevomatCodingStandard.Files.FileLineCount
* SlevomatCodingStandard.Classes.ClassLineCount

both sniffs have same options as existing SlevomatCodingStandard.Functions.FunctionLength
* maxLinesLength = 250
* includeComments = false
* includeWhitespace = false

resolves #1290