### PR TITLE
FileLineCountSniff

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,6 +781,14 @@ Sniff provides the following settings:
 
 However, if you prefer Yoda conditions, you can use `RequireYodaComparisonSniff`.
 
+#### SlevomatCodingStandard.Files.FileLength
+
+Disallows long files. This sniff provides the following settings:
+
+* `includeComments`: should comments be included in the count (default value is false).
+* `includeWhitespace`: shoud empty lines be included in the count (default value is false).
+* `maxLinesLength`: specifies max allowed function lines length (default value is 250).
+
 #### SlevomatCodingStandard.Files.LineLength
 
 Enforces maximum length of a single line of code.

--- a/SlevomatCodingStandard/Helpers/FunctionHelper.php
+++ b/SlevomatCodingStandard/Helpers/FunctionHelper.php
@@ -468,15 +468,19 @@ class FunctionHelper
 		if (self::isAbstract($file, $functionPosition)) {
 			return 0;
 		}
+		return self::getLineCount($file, $functionPosition, $flags);
+	}
 
+	public static function getLineCount(File $file, int $tokenPosition, int $flags = 0): int
+	{
 		$includeWhitespace = ($flags & self::LINE_INCLUDE_WHITESPACE) === self::LINE_INCLUDE_WHITESPACE;
 		$includeComments = ($flags & self::LINE_INCLUDE_COMMENT) === self::LINE_INCLUDE_COMMENT;
 
 		$tokens = $file->getTokens();
-		$token = $tokens[$functionPosition];
+		$token = $tokens[$tokenPosition];
 
-		$tokenOpenerPosition = $token['scope_opener'];
-		$tokenCloserPosition = $token['scope_closer'];
+		$tokenOpenerPosition = $token['scope_opener'] ?? $tokenPosition;
+		$tokenCloserPosition = $token['scope_closer'] ?? $file->numTokens - 1;
 		$tokenOpenerLine = $tokens[$tokenOpenerPosition]['line'];
 		$tokenCloserLine = $tokens[$tokenCloserPosition]['line'];
 

--- a/SlevomatCodingStandard/Sniffs/Files/FileLengthSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Files/FileLengthSniff.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Files;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use SlevomatCodingStandard\Helpers\FunctionHelper;
+use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
+use function array_filter;
+use function array_keys;
+use function array_reduce;
+use function sprintf;
+use const T_OPEN_TAG;
+
+class FileLengthSniff implements Sniff
+{
+
+	public const CODE_FILE_TOO_LONG = 'FileTooLong';
+
+	/** @var int */
+	public $maxLinesLength = 250;
+
+	/** @var bool */
+	public $includeComments = false;
+
+	/** @var bool */
+	public $includeWhitespace = false;
+
+	/**
+	 * @return array<int, (int|string)>
+	 */
+	public function register(): array
+	{
+		return [T_OPEN_TAG];
+	}
+
+	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+	 * @param int $pointer
+	 */
+	public function process(File $phpcsFile, $pointer): void
+	{
+		$this->maxLinesLength = SniffSettingsHelper::normalizeInteger($this->maxLinesLength);
+		$flags = array_keys(array_filter([
+			FunctionHelper::LINE_INCLUDE_COMMENT => $this->includeComments,
+			FunctionHelper::LINE_INCLUDE_WHITESPACE => $this->includeWhitespace,
+		]));
+		$flags = array_reduce($flags, static function ($carry, $flag): int {
+			return $carry | $flag;
+		}, 0);
+
+		$length = FunctionHelper::getLineCount($phpcsFile, $pointer, $flags);
+
+		if ($length <= $this->maxLinesLength) {
+			return;
+		}
+
+		$errorMessage = sprintf('Your file is too long. Currently using %d lines. Can be up to %d lines.', $length, $this->maxLinesLength);
+
+		$phpcsFile->addError($errorMessage, $pointer, self::CODE_FILE_TOO_LONG);
+	}
+
+}

--- a/tests/Sniffs/Files/FileLengthSniffTest.php
+++ b/tests/Sniffs/Files/FileLengthSniffTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Files;
+
+use SlevomatCodingStandard\Sniffs\TestCase;
+
+class FileLengthSniffTest extends TestCase
+{
+
+	public function testNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/fileLength.php');
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/fileLength.php', [
+			'maxLinesLength' => 5,
+			'includeComments' => true,
+		]);
+
+		self::assertSame(1, $report->getErrorCount());
+
+		self::assertSniffError(
+			$report,
+			1,
+			FileLengthSniff::CODE_FILE_TOO_LONG,
+			'Your file is too long. Currently using 12 lines. Can be up to 5 lines.'
+		);
+	}
+
+}

--- a/tests/Sniffs/Files/data/fileLength.php
+++ b/tests/Sniffs/Files/data/fileLength.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Foo\Bar;
+
+class FileLineCountSniffTest
+{
+	/**
+	 *
+	 */
+	public function someMethod() : string
+	{
+		return 'foo bar';
+	}
+}


### PR DESCRIPTION
Adds new sniff:
* SlevomatCodingStandard.Files.**FileLength**

has same options as existing SlevomatCodingStandard.Functions.FunctionLength
* maxLinesLength = 250
* includeComments = false
* includeWhitespace = false

resolves #1290