### PR TITLE
fix(RequireExplicitAssertion): do not throw away `static` type

### DIFF
--- a/SlevomatCodingStandard/Sniffs/PHP/RequireExplicitAssertionSniff.php
+++ b/SlevomatCodingStandard/Sniffs/PHP/RequireExplicitAssertionSniff.php
@@ -329,6 +329,10 @@ class RequireExplicitAssertionSniff implements Sniff
 			return [sprintf('%s instanceof %s', $variableName, $typeNode->name)];
 		}
 
+		if ($typeNode->name === 'static') {
+			return [sprintf('%s instanceof static', $variableName)];
+		}
+
 		if (TypeHintHelper::isSimpleTypeHint($typeNode->name)) {
 			return [sprintf('\is_%s(%s)', $typeNode->name, $variableName)];
 		}

--- a/tests/Sniffs/PHP/RequireExplicitAssertionSniffTest.php
+++ b/tests/Sniffs/PHP/RequireExplicitAssertionSniffTest.php
@@ -17,7 +17,7 @@ class RequireExplicitAssertionSniffTest extends TestCase
 	{
 		$report = self::checkFile(__DIR__ . '/data/requireExplicitAssertionErrors.php');
 
-		self::assertSame(28, $report->getErrorCount());
+		self::assertSame(29, $report->getErrorCount());
 
 		self::assertSniffError($report, 3, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
 		self::assertSniffError($report, 6, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
@@ -27,26 +27,27 @@ class RequireExplicitAssertionSniffTest extends TestCase
 		self::assertSniffError($report, 23, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
 		self::assertSniffError($report, 26, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
 		self::assertSniffError($report, 32, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
-		self::assertSniffError($report, 35, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
 		self::assertSniffError($report, 38, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
 		self::assertSniffError($report, 41, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
 		self::assertSniffError($report, 44, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
 		self::assertSniffError($report, 47, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
-		self::assertSniffError($report, 51, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
-		self::assertSniffError($report, 56, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
+		self::assertSniffError($report, 50, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
+		self::assertSniffError($report, 53, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
 		self::assertSniffError($report, 57, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
 		self::assertSniffError($report, 62, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
-		self::assertSniffError($report, 66, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
-		self::assertSniffError($report, 67, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
-		self::assertSniffError($report, 74, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
-		self::assertSniffError($report, 78, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
-		self::assertSniffError($report, 82, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
+		self::assertSniffError($report, 63, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
+		self::assertSniffError($report, 68, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
+		self::assertSniffError($report, 72, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
+		self::assertSniffError($report, 73, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
+		self::assertSniffError($report, 80, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
+		self::assertSniffError($report, 84, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
 		self::assertSniffError($report, 88, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
-		self::assertSniffError($report, 89, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
-		self::assertSniffError($report, 96, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
-		self::assertSniffError($report, 97, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
+		self::assertSniffError($report, 94, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
+		self::assertSniffError($report, 95, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
 		self::assertSniffError($report, 102, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
-		self::assertSniffError($report, 109, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
+		self::assertSniffError($report, 103, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
+		self::assertSniffError($report, 108, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
+		self::assertSniffError($report, 115, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
 
 		self::assertAllFixedInFile($report);
 	}

--- a/tests/Sniffs/PHP/data/requireExplicitAssertionErrors.fixed.php
+++ b/tests/Sniffs/PHP/data/requireExplicitAssertionErrors.fixed.php
@@ -27,6 +27,12 @@ class Fgh
 		\assert($g instanceof self);
 	}
 
+	public function foo()
+	{
+		$x = call();
+		\assert($x instanceof static || $x === null);
+	}
+
 }
 
 $h = fopen('file.txt', 'r');

--- a/tests/Sniffs/PHP/data/requireExplicitAssertionErrors.php
+++ b/tests/Sniffs/PHP/data/requireExplicitAssertionErrors.php
@@ -27,6 +27,12 @@ class Fgh
 		$g = $this;
 	}
 
+	public function foo()
+	{
+		/** @var static|null $x */
+		$x = call();
+	}
+
 }
 
 /** @var resource $h */


### PR DESCRIPTION
I think this is a bug?