### PR TITLE
SlevomatCodingStandard.Functions.RequireSingleLineCallSniff: skip calls with multi-line double-quoted string

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Functions/RequireSingleLineCallSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Functions/RequireSingleLineCallSniff.php
@@ -17,6 +17,7 @@ use function strpos;
 use const T_CLOSURE;
 use const T_CONSTANT_ENCAPSED_STRING;
 use const T_DOUBLE_COLON;
+use const T_DOUBLE_QUOTED_STRING;
 use const T_FN;
 use const T_FUNCTION;
 use const T_NEW;
@@ -71,7 +72,7 @@ class RequireSingleLineCallSniff extends AbstractLineCall
 		}
 
 		for ($i = $parenthesisOpenerPointer + 1; $i < $parenthesisCloserPointer; $i++) {
-			if ($tokens[$i]['code'] !== T_CONSTANT_ENCAPSED_STRING) {
+			if ($tokens[$i]['code'] !== T_CONSTANT_ENCAPSED_STRING && $tokens[$i]['code'] !== T_DOUBLE_QUOTED_STRING) {
 				continue;
 			}
 

--- a/tests/Sniffs/Functions/data/requireSingleLineCallNoErrors.php
+++ b/tests/Sniffs/Functions/data/requireSingleLineCallNoErrors.php
@@ -40,5 +40,10 @@ CODE
 		self::doWithNewLines("
 			Anything
 		");
+		$table = 'aaa';
+		$this->query("
+			INSERT INTO {$table} (id)
+			VALUES (1), (2), (3)
+		");
 	}
 }


### PR DESCRIPTION
I have code like this:

```php
$table = 'aaa';
$this->query("
    INSERT INTO {$table} (id)
    VALUES (1), (2), (3)
");
```

And I got this:

> Call of method query() should be placed on a single line.

In this particular case, it doesn't really matter, but in general the sniff can't be sure if the whitespace is significant or not, so it should be ignored.