### PR TITLE
Reflect current major version in README and composer.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1371,7 +1371,7 @@ The recommended way to install Slevomat Coding Standard is [through Composer](ht
 ```JSON
 {
 	"require-dev": {
-		"slevomat/coding-standard": "~7.0"
+		"slevomat/coding-standard": "~8.0"
 	}
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "7.x-dev"
+			"dev-master": "8.x-dev"
 		}
 	}
 }


### PR DESCRIPTION
The master branch contains version 8.x, but the documentation and the branch alias in composer.json apparently haven't been updated yet.