### PR TITLE
RequireNowdocSniff: accepts escaped sequences

### DIFF
--- a/SlevomatCodingStandard/Sniffs/PHP/RequireNowdocSniff.php
+++ b/SlevomatCodingStandard/Sniffs/PHP/RequireNowdocSniff.php
@@ -39,7 +39,7 @@ class RequireNowdocSniff implements Sniff
 		$heredocContentPointers = [];
 		for ($i = $heredocStartPointer + 1; $i < $heredocEndPointer; $i++) {
 			if ($tokens[$i]['code'] === T_HEREDOC) {
-				if (preg_match('~(?<!\\\\)\$~', $tokens[$i]['content']) > 0) {
+				if (preg_match('~^([^\\\\$]|\\\\[^nrtvef0-7xu])*$~', $tokens[$i]['content']) === 0) {
 					return;
 				}
 

--- a/tests/Sniffs/PHP/data/requireNowdocNoErrors.php
+++ b/tests/Sniffs/PHP/data/requireNowdocNoErrors.php
@@ -13,3 +13,7 @@ HED;
 $c = <<<"HED"
 	{$abc}
 HED;
+
+$c = <<<"HED"
+	\n
+HED;


### PR DESCRIPTION
Heredoc sequences like `\n` or `\x77` cannot be converted do nowdoc.