### PR TITLE
RequireCombinedAssignmentOperatorSniff: prevents fatal error

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Operators/RequireCombinedAssignmentOperatorSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Operators/RequireCombinedAssignmentOperatorSniff.php
@@ -52,7 +52,10 @@ class RequireCombinedAssignmentOperatorSniff implements Sniff
 		$variableStartPointer = TokenHelper::findNextEffective($phpcsFile, $equalPointer + 1);
 		$variableEndPointer = IdentificatorHelper::findEndPointer($phpcsFile, $variableStartPointer);
 
-		if ($variableEndPointer === null) {
+		if (
+			$variableEndPointer === null
+			|| $tokens[$variableEndPointer]['code'] === T_CLOSE_SQUARE_BRACKET
+		) {
 			return;
 		}
 

--- a/tests/Sniffs/Operators/data/requireCombinedAssignmentOperatorNoErrors.php
+++ b/tests/Sniffs/Operators/data/requireCombinedAssignmentOperatorNoErrors.php
@@ -38,5 +38,10 @@ class Whatever
 		$a = $a / $b / $c;
 	}
 
+	public function stringOffsets($a)
+	{
+		$a[0] = $a[0] | '';
+	}
+
 }
 


### PR DESCRIPTION
Duplicate of  #1114, because it was not merged (or fixed).

https://3v4l.org/BWmHf