### PR TITLE
Add "dev" Composer keyword

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
 	"description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
 	"license": "MIT",
 	"type": "phpcodesniffer-standard",
+	"keywords": [ "phpcs", "dev" ],
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"config": {


### PR DESCRIPTION
As per https://getcomposer.org/doc/04-schema.md#keywords by including "dev" as a keyword in the `composer.json` file, Composer 2.4.0-RC1 and later will prompt users if the package is installed with `composer require` instead of `composer require --dev`. See https://github.com/composer/composer/pull/10960 for more info.

The "phpcs" is added to match several other coding standards packages.