### PR TITLE
Update disallowEmptyNoErrors.php

### DIFF
--- a/tests/Sniffs/ControlStructures/data/disallowEmptyNoErrors.php
+++ b/tests/Sniffs/ControlStructures/data/disallowEmptyNoErrors.php
@@ -9,6 +9,6 @@ if (!$foo) {
 class X {
     public static function empty(): self
     {
-		return $this;
+		return new self();
 	}
 }

--- a/tests/Sniffs/ControlStructures/data/disallowEmptyNoErrors.php
+++ b/tests/Sniffs/ControlStructures/data/disallowEmptyNoErrors.php
@@ -5,3 +5,10 @@ $boo = isset($foo) ? false : true;
 if (!$foo) {
 
 }
+
+class X {
+    public static function empty(): self
+    {
+		return $this;
+	}
+}


### PR DESCRIPTION
I'm getting "Use of empty() is disallowed" errors. However I'm not using `empty()`. I just have a method named `empty()` defined.

Hopefully the updated file will trigger a bug in test.