### PR TITLE
Fix `DisallowAttributesJoiningSniff` for Attribute with trailing comma

### DIFF
--- a/SlevomatCodingStandard/Helpers/AttributeHelper.php
+++ b/SlevomatCodingStandard/Helpers/AttributeHelper.php
@@ -58,6 +58,11 @@ class AttributeHelper
 
 		do {
 			$attributeNameStartPointer = TokenHelper::findNextEffective($phpcsFile, $actualPointer + 1, $attributeCloserPointer);
+
+			if ($attributeNameStartPointer === null) {
+				break;
+			}
+
 			$attributeNameEndPointer = TokenHelper::findNextExcluding(
 				$phpcsFile,
 				TokenHelper::getNameTokenCodes(),

--- a/tests/Sniffs/Attributes/data/disallowedAttributesJoiningNoErrors.php
+++ b/tests/Sniffs/Attributes/data/disallowedAttributesJoiningNoErrors.php
@@ -15,6 +15,7 @@ $object = new #[Attribute1] #[Attribute2('var')]
 
 #[Attribute1] #[Attribute2('var')]
 #[Attribute3(option: PDO::class, option2: true, option3: 'False')]
+#[Attribute4,]
 function testFunc($test)
 {
 }


### PR DESCRIPTION
Fixes the following exception in `DisallowAttributesJoiningSniff` when the attribute ends with trailing comma (see test), because it's allowed in PHP:
```php
TypeError: SlevomatCodingStandard\Helpers\TokenHelper::getContent(): Argument #2 ($startPointer) must be of type int, null given, called in SlevomatCodingStandard/Helpers/AttributeHelper.php on line 71

SlevomatCodingStandard/Helpers/TokenHelper.php:426
SlevomatCodingStandard/Helpers/AttributeHelper.php:71
SlevomatCodingStandard/Sniffs/Attributes/DisallowAttributesJoiningSniff.php:35
vendor/squizlabs/php_codesniffer/src/Files/File.php:498
vendor/squizlabs/php_codesniffer/src/Files/LocalFile.php:92
SlevomatCodingStandard/Sniffs/TestCase.php:68
tests/Sniffs/Attributes/DisallowAttributesJoiningSniffTest.php:12
```