### PR TITLE
UnusedUse bug when import is used in a docBlock

### DIFF
--- a/tests/Sniffs/Namespaces/UnusedUsesSniffTest.php
+++ b/tests/Sniffs/Namespaces/UnusedUsesSniffTest.php
@@ -281,4 +281,14 @@ class UnusedUsesSniffTest extends TestCase
 		self::assertNoSniffErrorInFile($report);
 	}
 
+	public function testUsesInDocBlock(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/collidingUnusedUse.php', [
+			'searchAnnotations' => true,
+			'allowFullyQualifiedGlobalFunctions' => true,
+			'allowFullyQualifiedGlobalConstants' => true,
+		], [UnusedUsesSniff::CODE_UNUSED_USE]);
+
+		self::assertSniffError($report, 6, UnusedUsesSniff::CODE_UNUSED_USE, 'Type Baz is not used in this file.');
+	}
 }

--- a/tests/Sniffs/Namespaces/data/collidingUnusedUse.php
+++ b/tests/Sniffs/Namespaces/data/collidingUnusedUse.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Alpha;
+
+use \Bar\Foo\Bar;
+use Baz;
+
+class Beta {
+
+	/**
+	 * @param \Bar\Foo\Bar $foo Some parameter.
+	 * @return bool|Baz Some return.
+	 */
+	public function barFoo(Bar $foo)
+	{
+		return $foo instanceof Bar;
+	}
+}


### PR DESCRIPTION
Closes #1472 

I've made a test for the bug described in the issue. So far no fix has been done on this, this is just to showcase the issue I am experiencing with the particular sniff.