### PR TITLE
Add IntersectionTypeHintSniff

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Slevomat Coding Standard for [PHP_CodeSniffer](https://github.com/squizlabs/PHP_
  - [SlevomatCodingStandard.TypeHints.DeclareStrictTypes](doc/type-hints.md#slevomatcodingstandardtypehintsdeclarestricttypes-) 🔧
  - [SlevomatCodingStandard.TypeHints.DisallowArrayTypeHintSyntax](doc/type-hints.md#slevomatcodingstandardtypehintsdisallowarraytypehintsyntax-) 🔧
  - [SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint](doc/type-hints.md#slevomatcodingstandardtypehintsdisallowmixedtypehint)
+ - [SlevomatCodingStandard.TypeHints.IntersectionTypeHintFormat](doc/type-hints.md#slevomatcodingstandardtypehintsintersectiontypehintformat-) 🔧
  - [SlevomatCodingStandard.TypeHints.LongTypeHints](doc/type-hints.md#slevomatcodingstandardtypehintslongtypehints-) 🔧
  - [SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition](doc/type-hints.md#slevomatcodingstandardtypehintsnulltypehintonlastposition-) 🔧
  - [SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue](doc/type-hints.md#slevomatcodingstandardtypehintsnullabletypefornulldefaultvalue-) 🔧🚧

--- a/SlevomatCodingStandard/Sniffs/TypeHints/IntersectionTypeHintFormatSniff.php
+++ b/SlevomatCodingStandard/Sniffs/TypeHints/IntersectionTypeHintFormatSniff.php
@@ -1,0 +1,158 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\TypeHints;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use SlevomatCodingStandard\Helpers\FixerHelper;
+use SlevomatCodingStandard\Helpers\FunctionHelper;
+use SlevomatCodingStandard\Helpers\PropertyHelper;
+use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
+use SlevomatCodingStandard\Helpers\TokenHelper;
+use SlevomatCodingStandard\Helpers\TypeHint;
+use function array_merge;
+use function explode;
+use function implode;
+use function sprintf;
+use function substr_count;
+use const T_TYPE_INTERSECTION;
+use const T_VARIABLE;
+use const T_WHITESPACE;
+
+class IntersectionTypeHintFormatSniff implements Sniff
+{
+
+	public const CODE_DISALLOWED_WHITESPACE = 'DisallowedWhitespace';
+	public const CODE_REQUIRED_WHITESPACE = 'RequiredWhitespace';
+
+	private const YES = 'yes';
+	private const NO = 'no';
+
+	/** @var bool|null */
+	public $enable = null;
+
+	/** @var string|null */
+	public $withSpaces = null;
+
+	/**
+	 * @return array<int, (int|string)>
+	 */
+	public function register(): array
+	{
+		return array_merge(
+			[T_VARIABLE],
+			TokenHelper::$functionTokenCodes
+		);
+	}
+
+	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+	 * @param int $pointer
+	 */
+	public function process(File $phpcsFile, $pointer): void
+	{
+		$this->enable = SniffSettingsHelper::isEnabledByPhpVersion($this->enable, 80100);
+
+		if (!$this->enable) {
+			return;
+		}
+
+		$tokens = $phpcsFile->getTokens();
+
+		if ($tokens[$pointer]['code'] === T_VARIABLE) {
+			if (!PropertyHelper::isProperty($phpcsFile, $pointer)) {
+				return;
+			}
+
+			$propertyTypeHint = PropertyHelper::findTypeHint($phpcsFile, $pointer);
+			if ($propertyTypeHint !== null) {
+				$this->checkTypeHint($phpcsFile, $propertyTypeHint);
+			}
+
+			return;
+		}
+
+		$returnTypeHint = FunctionHelper::findReturnTypeHint($phpcsFile, $pointer);
+		if ($returnTypeHint !== null) {
+			$this->checkTypeHint($phpcsFile, $returnTypeHint);
+		}
+
+		foreach (FunctionHelper::getParametersTypeHints($phpcsFile, $pointer) as $parameterTypeHint) {
+			if ($parameterTypeHint !== null) {
+				$this->checkTypeHint($phpcsFile, $parameterTypeHint);
+			}
+		}
+	}
+
+	private function checkTypeHint(File $phpcsFile, TypeHint $typeHint): void
+	{
+		$tokens = $phpcsFile->getTokens();
+
+		$typeHintsCount = substr_count($typeHint->getTypeHint(), '&') + 1;
+
+		if ($typeHintsCount <= 1) {
+			return;
+		}
+
+		if ($this->withSpaces === self::NO) {
+			$whitespacePointer = TokenHelper::findNext(
+				$phpcsFile,
+				T_WHITESPACE,
+				$typeHint->getStartPointer() + 1,
+				$typeHint->getEndPointer()
+			);
+			if ($whitespacePointer !== null) {
+				$originalTypeHint = TokenHelper::getContent($phpcsFile, $typeHint->getStartPointer(), $typeHint->getEndPointer());
+				$fix = $phpcsFile->addFixableError(
+					sprintf('Spaces in type hint "%s" are disallowed.', $originalTypeHint),
+					$typeHint->getStartPointer(),
+					self::CODE_DISALLOWED_WHITESPACE
+				);
+				if ($fix) {
+					$this->fixTypeHint($phpcsFile, $typeHint, $typeHint->getTypeHint());
+				}
+			}
+		} elseif ($this->withSpaces === self::YES) {
+			$error = false;
+			foreach (TokenHelper::findNextAll(
+				$phpcsFile,
+				[T_TYPE_INTERSECTION],
+				$typeHint->getStartPointer(),
+				$typeHint->getEndPointer()
+			) as $intersectionSeparator) {
+				if ($tokens[$intersectionSeparator - 1]['content'] !== ' ') {
+					$error = true;
+					break;
+				}
+				if ($tokens[$intersectionSeparator + 1]['content'] !== ' ') {
+					$error = true;
+					break;
+				}
+			}
+
+			if ($error) {
+				$originalTypeHint = TokenHelper::getContent($phpcsFile, $typeHint->getStartPointer(), $typeHint->getEndPointer());
+				$fix = $phpcsFile->addFixableError(
+					sprintf('One space required before and after each "&" in type hint "%s".', $originalTypeHint),
+					$typeHint->getStartPointer(),
+					self::CODE_REQUIRED_WHITESPACE
+				);
+				if ($fix) {
+					$fixedTypeHint = implode(' & ', explode('&', $typeHint->getTypeHint()));
+					$this->fixTypeHint($phpcsFile, $typeHint, $fixedTypeHint);
+				}
+			}
+		}
+	}
+
+	private function fixTypeHint(File $phpcsFile, TypeHint $typeHint, string $fixedTypeHint): void
+	{
+		$phpcsFile->fixer->beginChangeset();
+
+		$phpcsFile->fixer->replaceToken($typeHint->getStartPointer(), $fixedTypeHint);
+		FixerHelper::removeBetweenIncluding($phpcsFile, $typeHint->getStartPointer() + 1, $typeHint->getEndPointer());
+
+		$phpcsFile->fixer->endChangeset();
+	}
+
+}

--- a/doc/type-hints.md
+++ b/doc/type-hints.md
@@ -23,6 +23,15 @@ Sniff provides the following settings:
 
 Disallows usage of "mixed" type hint in phpDocs.
 
+#### SlevomatCodingStandard.TypeHints.IntersectionTypeHintFormat 🔧
+
+Checks format of intersection type hints.
+
+Sniff provides the following settings:
+
+* `enable`: either to enable or not this sniff. By default, it is enabled for PHP versions 8.1 or higher.
+* `withSpaces`: `yes` requires spaces around `&`, `no` requires no space around `&`. None is set by default so both are enabled.
+
 #### SlevomatCodingStandard.TypeHints.LongTypeHints 🔧
 
 Enforces using shorthand scalar typehint variants in phpDocs: `int` instead of `integer` and `bool` instead of `boolean`. This is for consistency with native scalar typehints which also allow shorthand variants only.

--- a/tests/Sniffs/TypeHints/IntersectionTypeHintFormatSniffTest.php
+++ b/tests/Sniffs/TypeHints/IntersectionTypeHintFormatSniffTest.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\TypeHints;
+
+use SlevomatCodingStandard\Sniffs\TestCase;
+
+class IntersectionTypeHintFormatSniffTest extends TestCase
+{
+
+	public function testWhitespaceNotSetNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/intersectionTypeHintFormatWhitespaceNotSetNoErrors.php', [
+			'enable' => true,
+		]);
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testWhitespaceDisallowedNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/intersectionTypeHintFormatWhitespaceDisallowedNoErrors.php', [
+			'enable' => true,
+			'withSpaces' => 'no',
+		]);
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testWhitespaceDisallowedErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/intersectionTypeHintFormatWhitespaceDisallowedErrors.php', [
+			'enable' => true,
+			'withSpaces' => 'no',
+		]);
+
+		self::assertSame(3, $report->getErrorCount());
+
+		self::assertSniffError($report, 6, IntersectionTypeHintFormatSniff::CODE_DISALLOWED_WHITESPACE);
+		self::assertSniffError(
+			$report,
+			8,
+			IntersectionTypeHintFormatSniff::CODE_DISALLOWED_WHITESPACE,
+			'Spaces in type hint "\ArrayAccess& \Traversable" are disallowed.'
+		);
+		self::assertSniffError(
+			$report,
+			8,
+			IntersectionTypeHintFormatSniff::CODE_DISALLOWED_WHITESPACE,
+			'Spaces in type hint "\ArrayAccess  & \Traversable &  \Stringable" are disallowed.'
+		);
+
+		self::assertAllFixedInFile($report);
+	}
+
+	public function testWhitespaceEnabledNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/intersectionTypeHintFormatWhitespaceEnabledNoErrors.php', [
+			'enable' => true,
+			'withSpaces' => 'yes',
+		]);
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testWhitespaceEnabledErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/intersectionTypeHintFormatWhitespaceEnabledErrors.php', [
+			'enable' => true,
+			'withSpaces' => 'yes',
+		]);
+
+		self::assertSame(4, $report->getErrorCount());
+
+		self::assertSniffError(
+			$report,
+			6,
+			IntersectionTypeHintFormatSniff::CODE_REQUIRED_WHITESPACE,
+			'One space required before and after each "&" in type hint "\ArrayAccess&\Traversable".'
+		);
+		self::assertSniffError(
+			$report,
+			8,
+			IntersectionTypeHintFormatSniff::CODE_REQUIRED_WHITESPACE,
+			'One space required before and after each "&" in type hint "\ArrayAccess& \Traversable".'
+		);
+		self::assertSniffError(
+			$report,
+			8,
+			IntersectionTypeHintFormatSniff::CODE_REQUIRED_WHITESPACE,
+			'One space required before and after each "&" in type hint "\Stringable &\Traversable".'
+		);
+		self::assertSniffError(
+			$report,
+			8,
+			IntersectionTypeHintFormatSniff::CODE_REQUIRED_WHITESPACE,
+			'One space required before and after each "&" in type hint "\ArrayAccess  &    \Traversable &\Stringable".'
+		);
+
+		self::assertAllFixedInFile($report);
+	}
+
+	public function testShouldNotReportIfSniffIsDisabled(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/intersectionTypeHintFormatWhitespaceNotSetNoErrors.php', [
+			'enable' => false,
+		]);
+		self::assertNoSniffErrorInFile($report);
+	}
+
+}

--- a/tests/Sniffs/TypeHints/data/intersectionTypeHintFormatWhitespaceDisallowedErrors.fixed.php
+++ b/tests/Sniffs/TypeHints/data/intersectionTypeHintFormatWhitespaceDisallowedErrors.fixed.php
@@ -1,0 +1,12 @@
+<?php // lint >= 8.1
+
+class Whatever
+{
+
+	public \ArrayAccess&\Traversable $property;
+
+	public function method(\ArrayAccess&\Traversable $parameter): \ArrayAccess&\Traversable&\Stringable
+	{
+	}
+
+}

--- a/tests/Sniffs/TypeHints/data/intersectionTypeHintFormatWhitespaceDisallowedErrors.php
+++ b/tests/Sniffs/TypeHints/data/intersectionTypeHintFormatWhitespaceDisallowedErrors.php
@@ -1,0 +1,12 @@
+<?php // lint >= 8.1
+
+class Whatever
+{
+
+	public \ArrayAccess &\Traversable $property;
+
+	public function method(\ArrayAccess& \Traversable $parameter): \ArrayAccess  & \Traversable &  \Stringable
+	{
+	}
+
+}

--- a/tests/Sniffs/TypeHints/data/intersectionTypeHintFormatWhitespaceDisallowedNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/intersectionTypeHintFormatWhitespaceDisallowedNoErrors.php
@@ -1,0 +1,14 @@
+<?php // lint >= 8.1
+
+class Whatever
+{
+
+	public \ArrayAccess $notIntersection;
+
+	public \ArrayAccess&\Traversable $property;
+
+	public function method(\ArrayAccess&\Traversable $parameter): \ArrayAccess&\Stringable
+	{
+	}
+
+}

--- a/tests/Sniffs/TypeHints/data/intersectionTypeHintFormatWhitespaceEnabledErrors.fixed.php
+++ b/tests/Sniffs/TypeHints/data/intersectionTypeHintFormatWhitespaceEnabledErrors.fixed.php
@@ -1,0 +1,12 @@
+<?php // lint >= 8.1
+
+class Whatever
+{
+
+	public \ArrayAccess & \Traversable $property;
+
+	public function method(\ArrayAccess & \Traversable $parameter, \Stringable & \Traversable $parameter2): \ArrayAccess & \Traversable & \Stringable
+	{
+	}
+
+}

--- a/tests/Sniffs/TypeHints/data/intersectionTypeHintFormatWhitespaceEnabledErrors.php
+++ b/tests/Sniffs/TypeHints/data/intersectionTypeHintFormatWhitespaceEnabledErrors.php
@@ -1,0 +1,12 @@
+<?php // lint >= 8.1
+
+class Whatever
+{
+
+	public \ArrayAccess&\Traversable $property;
+
+	public function method(\ArrayAccess& \Traversable $parameter, \Stringable &\Traversable $parameter2): \ArrayAccess  &    \Traversable &\Stringable
+	{
+	}
+
+}

--- a/tests/Sniffs/TypeHints/data/intersectionTypeHintFormatWhitespaceEnabledNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/intersectionTypeHintFormatWhitespaceEnabledNoErrors.php
@@ -1,0 +1,12 @@
+<?php // lint >= 8.1
+
+class Whatever
+{
+
+	public \ArrayAccess & \Traversable $property;
+
+	public function method(\ArrayAccess & \Traversable $parameter): \ArrayAccess & \Traversable & \Stringable
+	{
+	}
+
+}

--- a/tests/Sniffs/TypeHints/data/intersectionTypeHintFormatWhitespaceNotSetNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/intersectionTypeHintFormatWhitespaceNotSetNoErrors.php
@@ -1,0 +1,14 @@
+<?php // lint >= 8.1
+
+class Whatever
+{
+
+	public \ArrayAccess $notIntersection;
+
+	public \ArrayAccess&\Iterator $property;
+
+	public function method(\ArrayAcess&  \Iterator $parameter): \ArrayAccess  &\Stringable
+	{
+	}
+
+}


### PR DESCRIPTION
Add `IntersectionTypeHintSniff` to control the whitespaces of intersection types.

I copied and cleaned all the logic from `UnionTypeHintFormatSniff` and its tests.