### PR TITLE
Pass error message data to PHPCS in fully qualified reference sniffs

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Namespaces/AbstractFullyQualifiedGlobalReference.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/AbstractFullyQualifiedGlobalReference.php
@@ -14,7 +14,6 @@ use SlevomatCodingStandard\Helpers\UseStatementHelper;
 use function array_flip;
 use function array_key_exists;
 use function array_map;
-use function sprintf;
 use function strtolower;
 use const T_OPEN_TAG;
 
@@ -111,9 +110,10 @@ abstract class AbstractFullyQualifiedGlobalReference implements Sniff
 			}
 
 			$fix = $phpcsFile->addFixableError(
-				sprintf($this->getNotFullyQualifiedMessage(), $tokens[$namePointer]['content']),
+				$this->getNotFullyQualifiedMessage(),
 				$namePointer,
-				self::CODE_NON_FULLY_QUALIFIED
+				self::CODE_NON_FULLY_QUALIFIED,
+				[$tokens[$namePointer]['content']]
 			);
 			if (!$fix) {
 				continue;


### PR DESCRIPTION
AbstractFullyQualifiedGlobalReference->process() makes its own call to sprintf() and then passes on that finalized error message to ->addFixableError. This means that customizations of the message for these sniffs cannot use the name of the function/constant via %s.

Changing the call to let PHPCS do the formatting sends this data downstream for possible customization.