### PR TITLE
Fix typo in exception message

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Attributes/AttributesOrderSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Attributes/AttributesOrderSniff.php
@@ -51,7 +51,7 @@ class AttributesOrderSniff implements Sniff
 		}
 
 		if ($this->order === [] && !$this->orderAlphabetically) {
-			throw new UnexpectedValueException('Nether manual or alphabetical order is set.');
+			throw new UnexpectedValueException('Neither manual or alphabetical order is set.');
 		}
 
 		if ($this->order !== [] && $this->orderAlphabetically) {

--- a/tests/Sniffs/Attributes/AttributesOrderSniffTest.php
+++ b/tests/Sniffs/Attributes/AttributesOrderSniffTest.php
@@ -74,7 +74,7 @@ class AttributesOrderSniffTest extends TestCase
 	public function testNetherOrderIsSet(): void
 	{
 		$this->expectException(UnexpectedValueException::class);
-		$this->expectExceptionMessage('Nether manual or alphabetical order is set.');
+		$this->expectExceptionMessage('Neither manual or alphabetical order is set.');
 
 		self::checkFile(__DIR__ . '/data/attributesOrderNoErrors.php');
 	}


### PR DESCRIPTION
Correct a spelling mistake in `UnexpectedValueException` message string and updated corresponding test.