### PR TITLE
Add support for disabling trailing multiline ternary operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Slevomat Coding Standard for [PHP_CodeSniffer](https://github.com/squizlabs/PHP_
  - [SlevomatCodingStandard.ControlStructures.DisallowEmpty](doc/control-structures.md#slevomatcodingstandardcontrolstructuresdisallowempty)
  - [SlevomatCodingStandard.ControlStructures.DisallowNullSafeObjectOperator](doc/control-structures.md#slevomatcodingstandardcontrolstructuresdisallownullsafeobjectoperator)
  - [SlevomatCodingStandard.ControlStructures.DisallowShortTernaryOperator](doc/control-structures.md#slevomatcodingstandardcontrolstructuresdisallowshortternaryoperator-) 🔧
+ - [SlevomatCodingStandard.ControlStructures.DisallowTrailingMultiLineTernaryOperatorSniff](doc/control-structures.md#slevomatcodingstandardcontrolstructuresdisallowtrailingmultilineternaryoperator-) 🔧
  - [SlevomatCodingStandard.ControlStructures.DisallowYodaComparison](doc/control-structures.md#slevomatcodingstandardcontrolstructuresdisallowyodacomparison-) 🔧
  - [SlevomatCodingStandard.ControlStructures.EarlyExit](doc/control-structures.md#slevomatcodingstandardcontrolstructuresearlyexit-) 🔧
  - [SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing](doc/control-structures.md#slevomatcodingstandardcontrolstructuresjumpstatementsspacing-) 🔧

--- a/SlevomatCodingStandard/Sniffs/ControlStructures/DisallowTrailingMultiLineTernaryOperatorSniff.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/DisallowTrailingMultiLineTernaryOperatorSniff.php
@@ -1,0 +1,152 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\ControlStructures;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use SlevomatCodingStandard\Helpers\FixerHelper;
+use SlevomatCodingStandard\Helpers\IndentationHelper;
+use SlevomatCodingStandard\Helpers\TernaryOperatorHelper;
+use SlevomatCodingStandard\Helpers\TokenHelper;
+use function array_merge;
+use function in_array;
+use function strlen;
+use function substr;
+use function trim;
+use const T_INLINE_ELSE;
+use const T_INLINE_THEN;
+use const T_OPEN_TAG;
+use const T_OPEN_TAG_WITH_ECHO;
+use const T_WHITESPACE;
+
+class DisallowTrailingMultiLineTernaryOperatorSniff implements Sniff
+{
+
+	public const CODE_TRAILING_MULTI_LINE_TERNARY_OPERATOR_USED = 'TrailingMultiLineTernaryOperatorUsed';
+
+	/**
+	 * @return array<int, (int|string)>
+	 */
+	public function register(): array
+	{
+		return [
+			T_INLINE_THEN,
+		];
+	}
+
+	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+	 * @param int $inlineThenPointer
+	 */
+	public function process(File $phpcsFile, $inlineThenPointer): void
+	{
+		$tokens = $phpcsFile->getTokens();
+
+		$nextPointer = TokenHelper::findNextEffective($phpcsFile, $inlineThenPointer + 1);
+		if ($tokens[$nextPointer]['code'] === T_INLINE_ELSE) {
+			return;
+		}
+
+		$inlineElsePointer = TernaryOperatorHelper::getElsePointer($phpcsFile, $inlineThenPointer);
+
+		if ($tokens[$inlineThenPointer]['line'] === $tokens[$inlineElsePointer]['line']) {
+			return;
+		}
+
+		$endOfLineBeforeInlineThenPointer = $this->getEndOfLineBefore($phpcsFile, $inlineThenPointer);
+		$endOfLineBeforeInlineElsePointer = $this->getEndOfLineBefore($phpcsFile, $inlineElsePointer);
+
+		$contentBeforeThen = TokenHelper::getContent($phpcsFile, $endOfLineBeforeInlineThenPointer + 1, $inlineThenPointer - 1);
+		$contentBeforeElse = TokenHelper::getContent($phpcsFile, $endOfLineBeforeInlineElsePointer + 1, $inlineElsePointer - 1);
+		if (trim($contentBeforeElse) === '' && trim($contentBeforeThen) === '') {
+			return;
+		}
+
+		$fix = $phpcsFile->addFixableError(
+			'Ternary operator should be reformatted as leading the line.',
+			$inlineThenPointer,
+			self::CODE_TRAILING_MULTI_LINE_TERNARY_OPERATOR_USED
+		);
+
+		if (!$fix) {
+			return;
+		}
+
+		$indentation = $this->getIndentation($phpcsFile, $endOfLineBeforeInlineThenPointer);
+		$pointerBeforeInlineThen = TokenHelper::findPreviousEffective($phpcsFile, $inlineThenPointer - 1);
+		$pointerAfterInlineThen = TokenHelper::findNextExcluding($phpcsFile, [T_WHITESPACE], $inlineThenPointer + 1);
+		$pointerBeforeInlineElse = TokenHelper::findPreviousEffective($phpcsFile, $inlineElsePointer - 1);
+		$pointerAfterInlineElse = TokenHelper::findNextExcluding($phpcsFile, [T_WHITESPACE], $inlineElsePointer + 1);
+
+		$phpcsFile->fixer->beginChangeset();
+
+		FixerHelper::removeBetween($phpcsFile, $pointerBeforeInlineThen, $inlineThenPointer);
+		FixerHelper::removeBetween($phpcsFile, $inlineThenPointer, $pointerAfterInlineThen);
+
+		$phpcsFile->fixer->addContentBefore($inlineThenPointer, $phpcsFile->eolChar . $indentation);
+		$phpcsFile->fixer->addContentBefore($pointerAfterInlineThen, ' ');
+
+		FixerHelper::removeBetween($phpcsFile, $pointerBeforeInlineElse, $inlineElsePointer);
+		FixerHelper::removeBetween($phpcsFile, $inlineElsePointer, $pointerAfterInlineElse);
+
+		$phpcsFile->fixer->addContentBefore($inlineElsePointer, $phpcsFile->eolChar . $indentation);
+		$phpcsFile->fixer->addContentBefore($pointerAfterInlineElse, ' ');
+
+		$phpcsFile->fixer->endChangeset();
+	}
+
+	private function getEndOfLineBefore(File $phpcsFile, int $pointer): int
+	{
+		$tokens = $phpcsFile->getTokens();
+
+		$endOfLineBefore = null;
+
+		$startPointer = $pointer - 1;
+		while (true) {
+			$possibleEndOfLinePointer = TokenHelper::findPrevious(
+				$phpcsFile,
+				array_merge([T_WHITESPACE, T_OPEN_TAG, T_OPEN_TAG_WITH_ECHO], TokenHelper::$inlineCommentTokenCodes),
+				$startPointer
+			);
+			if (
+				$tokens[$possibleEndOfLinePointer]['code'] === T_WHITESPACE
+				&& $tokens[$possibleEndOfLinePointer]['content'] === $phpcsFile->eolChar
+			) {
+				$endOfLineBefore = $possibleEndOfLinePointer;
+				break;
+			}
+
+			if (
+				in_array($tokens[$possibleEndOfLinePointer]['code'], TokenHelper::$inlineCommentTokenCodes, true)
+				&& substr($tokens[$possibleEndOfLinePointer]['content'], -1) === $phpcsFile->eolChar
+			) {
+				$endOfLineBefore = $possibleEndOfLinePointer;
+				break;
+			}
+
+			$startPointer = $possibleEndOfLinePointer - 1;
+		}
+
+		/** @var int $endOfLineBefore */
+		$endOfLineBefore = $endOfLineBefore;
+		return $endOfLineBefore;
+	}
+
+	private function getIndentation(File $phpcsFile, int $endOfLinePointer): string
+	{
+		$pointerAfterWhitespace = TokenHelper::findNextNonWhitespace($phpcsFile, $endOfLinePointer + 1);
+		$actualIndentation = TokenHelper::getContent($phpcsFile, $endOfLinePointer + 1, $pointerAfterWhitespace - 1);
+
+		if (strlen($actualIndentation) !== 0) {
+			return $actualIndentation . (
+				substr($actualIndentation, -1) === IndentationHelper::TAB_INDENT
+					? IndentationHelper::TAB_INDENT
+					: IndentationHelper::SPACES_INDENT
+			);
+		}
+
+		$tabPointer = TokenHelper::findPreviousContent($phpcsFile, T_WHITESPACE, IndentationHelper::TAB_INDENT, $endOfLinePointer - 1);
+		return $tabPointer !== null ? IndentationHelper::TAB_INDENT : IndentationHelper::SPACES_INDENT;
+	}
+
+}

--- a/doc/control-structures.md
+++ b/doc/control-structures.md
@@ -111,6 +111,22 @@ Sniff provides the following settings:
 
 * `fixable`: the sniff is fixable by default, however in strict code it makes sense to forbid this weakly typed form of ternary altogether, you can disable fixability with this option.
 
+#### SlevomatCodingStandard.ControlStructures.DisallowTrailingMultiLineTernaryOperator 🔧
+
+Ternary operator has to be reformatted when the operator is not leading the line.
+
+```php
+# wrong
+$t = $someCondition ?
+  $thenThis :
+  $otherwiseThis;
+
+# correct
+$t = $someCondition
+  ? $thenThis
+  : $otherwiseThis;
+```
+
 #### SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing 🔧
 
 Enforces configurable number of lines around jump statements (continue, return, ...).

--- a/tests/Sniffs/ControlStructures/DisallowTrailingMultiLineTernaryOperatorSniffTest.php
+++ b/tests/Sniffs/ControlStructures/DisallowTrailingMultiLineTernaryOperatorSniffTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\ControlStructures;
+
+use SlevomatCodingStandard\Sniffs\TestCase;
+
+class DisallowTrailingMultiLineTernaryOperatorSniffTest extends TestCase
+{
+
+	public function testNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/disallowTrailingMultiLineTernaryOperatorNoErrors.php');
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/disallowTrailingMultiLineTernaryOperatorErrors.php');
+
+		self::assertSame(8, $report->getErrorCount());
+
+		self::assertSniffError($report, 4, DisallowTrailingMultiLineTernaryOperatorSniff::CODE_TRAILING_MULTI_LINE_TERNARY_OPERATOR_USED);
+		self::assertSniffError($report, 9, DisallowTrailingMultiLineTernaryOperatorSniff::CODE_TRAILING_MULTI_LINE_TERNARY_OPERATOR_USED);
+		self::assertSniffError($report, 13, DisallowTrailingMultiLineTernaryOperatorSniff::CODE_TRAILING_MULTI_LINE_TERNARY_OPERATOR_USED);
+		self::assertSniffError($report, 17, DisallowTrailingMultiLineTernaryOperatorSniff::CODE_TRAILING_MULTI_LINE_TERNARY_OPERATOR_USED);
+		self::assertSniffError($report, 21, DisallowTrailingMultiLineTernaryOperatorSniff::CODE_TRAILING_MULTI_LINE_TERNARY_OPERATOR_USED);
+		self::assertSniffError($report, 25, DisallowTrailingMultiLineTernaryOperatorSniff::CODE_TRAILING_MULTI_LINE_TERNARY_OPERATOR_USED);
+		self::assertSniffError($report, 29, DisallowTrailingMultiLineTernaryOperatorSniff::CODE_TRAILING_MULTI_LINE_TERNARY_OPERATOR_USED);
+
+		self::assertAllFixedInFile($report);
+	}
+
+}

--- a/tests/Sniffs/ControlStructures/data/disallowTrailingMultiLineTernaryOperatorErrors.fixed.php
+++ b/tests/Sniffs/ControlStructures/data/disallowTrailingMultiLineTernaryOperatorErrors.fixed.php
@@ -1,0 +1,35 @@
+<?php
+
+if (true) {
+	return $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+		? 'bbbb'
+		: 'cccccccccccccc';
+}
+
+$a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+	? 'bbbb'
+	: 'cccccccccccccc';
+
+$a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+	? 'bbbb'
+	: func(1, 2);
+
+$a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+	? 'bbbb'
+	: func([]);
+
+$a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+	? 'bbbb'
+	: func([1 => 2]);
+
+$a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+	? 'bbbb'
+	: function () { return; };
+
+$a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+	? 'bbbb'
+	: (false ? 1 : 2);
+
+$array[$b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+	? 'bbbb'
+	: 'ccccccc'] = 'b';

--- a/tests/Sniffs/ControlStructures/data/disallowTrailingMultiLineTernaryOperatorErrors.php
+++ b/tests/Sniffs/ControlStructures/data/disallowTrailingMultiLineTernaryOperatorErrors.php
@@ -1,0 +1,34 @@
+<?php
+
+if (true) {
+	return $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' ?
+		'bbbb' :
+		'cccccccccccccc';
+}
+
+$a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' ?
+	'bbbb' :
+	'cccccccccccccc';
+
+$a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' ?
+	'bbbb' :
+	func(1, 2);
+
+$a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' ?
+	'bbbb' :
+	func([]);
+
+$a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' ?
+	'bbbb' :
+	func([1 => 2]);
+
+$a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' ?
+	'bbbb' :
+	function () { return; };
+
+$a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' ?
+	'bbbb' :
+	(false ? 1 : 2);
+
+$array[$b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' ? 'bbbb'
+	: 'ccccccc'] = 'b';

--- a/tests/Sniffs/ControlStructures/data/disallowTrailingMultiLineTernaryOperatorNoErrors.php
+++ b/tests/Sniffs/ControlStructures/data/disallowTrailingMultiLineTernaryOperatorNoErrors.php
@@ -1,0 +1,58 @@
+<?php $a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' ? 'bbbb' : 'ccccccc';
+
+$a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' ? 'bbbb' : 'ccccccc';
+
+$a = $b ?: true;
+
+$a = $b
+	? true
+	: false;
+
+$a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' ? 'bbbb' : 'ccccccccccccc';
+
+$array[$b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' ? 'bbbb' : 'ccccccc'] = 'b';
+
+doSomething($b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' ? 'bbbb' : 'ccccccc');
+
+$x = doSomething(
+	sprintf(
+		'String %s %s',
+		$y,
+		$z !== 1 ? 's' : ''
+	),
+	$typeHintPointer,
+	Whatever::XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+);
+
+$x = doSomething(
+	[
+		$z !== 1 ? 's' : ''
+	],
+	$typeHintPointer,
+	Whatever::XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+);
+
+$order = [
+	UseStatement::TYPE_DEFAULT => 1,
+	UseStatement::TYPE_FUNCTION => $this->psr12Compatible ? 2 : 3,
+	UseStatement::TYPE_CONSTANT => $this->psr12Compatible ? 3 : 2,
+];
+
+// Comment
+$a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' ? 'bbbb' : 'ccccccccccccc';
+
+// phpcs:disable ABC
+$a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' ? 'bbbb' : 'ccccccccccccc';
+
+$a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+	? 'bbbb'
+	: 'ccccccccccccc';
+
+$a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+	// with comments
+	? 'bbbb'
+	// with comments
+	: 'ccccccccccccc';
+
+$a = $b === 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' ? 'bbbb' :
+	'ccccccccccccc';


### PR DESCRIPTION
Add support to enforce that operators lead when using multi-line ternary operators