### PR TITLE
Fix allow method overriding for the method getSniffClassName

### DIFF
--- a/SlevomatCodingStandard/Sniffs/TestCase.php
+++ b/SlevomatCodingStandard/Sniffs/TestCase.php
@@ -46,7 +46,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 			$codeSniffer->ruleset->ruleset[self::getSniffName()]['properties'] = $sniffProperties;
 		}
 
-		$sniffClassName = self::getSniffClassName();
+		$sniffClassName = static::getSniffClassName();
 		/** @var Sniff $sniff */
 		$sniff = new $sniffClassName();
 
@@ -147,7 +147,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 				'',
 				'',
 			],
-			self::getSniffClassName()
+			static::getSniffClassName()
 		);
 	}
 
@@ -155,7 +155,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 	{
 		static $reflections = [];
 
-		$className = self::getSniffClassName();
+		$className = static::getSniffClassName();
 
 		return $reflections[$className] ?? $reflections[$className] = new ReflectionClass($className);
 	}

--- a/SlevomatCodingStandard/Sniffs/TestCase.php
+++ b/SlevomatCodingStandard/Sniffs/TestCase.php
@@ -123,6 +123,17 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 		self::assertStringEqualsFile(preg_replace('~(\\.php)$~', '.fixed\\1', $phpcsFile->getFilename()), $phpcsFile->fixer->getContents());
 	}
 
+	/**
+	 * @return class-string
+	 */
+	protected static function getSniffClassName(): string
+	{
+		/** @var class-string $sniffClassName */
+		$sniffClassName = substr(static::class, 0, -strlen('Test'));
+
+		return $sniffClassName;
+	}
+
 	private static function getSniffName(): string
 	{
 		return preg_replace(
@@ -138,17 +149,6 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 			],
 			self::getSniffClassName()
 		);
-	}
-
-	/**
-	 * @return class-string
-	 */
-	private static function getSniffClassName(): string
-	{
-		/** @var class-string $sniffClassName */
-		$sniffClassName = substr(static::class, 0, -strlen('Test'));
-
-		return $sniffClassName;
 	}
 
 	private static function getSniffClassReflection(): ReflectionClass


### PR DESCRIPTION
Me and the company i work for have made an internal coding standard that uses slevomat/coding-standard. We were trying to override getSniffClassName. We found out that we weren't able to do that because it was a private method. In order for people to have the ability to override getSniffClassName i made the following changes.

Changed access modifier for the method getSniffClassName from private to protected to make overriding this method possible

Changed the way getSniffClassName method is called from self to static so that when the method is overridden it uses the overridden method