### PR TITLE
SlevomatCodingStandard.Complexity.Cognitive: ability to raise a warning vs error

### DIFF
--- a/SlevomatCodingStandard/Sniffs/TestCase.php
+++ b/SlevomatCodingStandard/Sniffs/TestCase.php
@@ -76,6 +76,12 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 		self::assertEmpty($errors, sprintf('No errors expected, but %d errors found.', count($errors)));
 	}
 
+	protected static function assertNoSniffWarningInFile(File $phpcsFile): void
+	{
+		$warnings = $phpcsFile->getWarnings();
+		self::assertEmpty($warnings, sprintf('No warnings expected, but %d warnings found.', count($warnings)));
+	}
+
 	protected static function assertSniffError(File $phpcsFile, int $line, string $code, ?string $message = null): void
 	{
 		$errors = $phpcsFile->getErrors();
@@ -87,6 +93,31 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 			self::hasError($errors[$line], $sniffCode, $message),
 			sprintf(
 				'Expected error %s%s, but none found on line %d.%sErrors found on line %d:%s%s%s',
+				$sniffCode,
+				$message !== null
+					? sprintf(' with message "%s"', $message)
+					: '',
+				$line,
+				PHP_EOL . PHP_EOL,
+				$line,
+				PHP_EOL,
+				self::getFormattedErrors($errors[$line]),
+				PHP_EOL
+			)
+		);
+	}
+
+	protected static function assertSniffWarning(File $phpcsFile, int $line, string $code, ?string $message = null): void
+	{
+		$errors = $phpcsFile->getWarnings();
+		self::assertTrue(isset($errors[$line]), sprintf('Expected warning on line %s, but none found.', $line));
+
+		$sniffCode = sprintf('%s.%s', self::getSniffName(), $code);
+
+		self::assertTrue(
+			self::hasError($errors[$line], $sniffCode, $message),
+			sprintf(
+				'Expected warning %s%s, but none found on line %d.%sWarnings found on line %d:%s%s%s',
 				$sniffCode,
 				$message !== null
 					? sprintf(' with message "%s"', $message)

--- a/doc/complexity.md
+++ b/doc/complexity.md
@@ -6,4 +6,5 @@ Enforces maximum [cognitive complexity](https://www.sonarsource.com/docs/Cogniti
 
 Sniff provides the following setting:
 
-* `maxComplexity`: defaults to 5
+* `warningThreshold`: defaults to 6
+* `errorThreshold` : defaults to 6

--- a/tests/Sniffs/Complexity/data/cognitive/warnAndError.php
+++ b/tests/Sniffs/Complexity/data/cognitive/warnAndError.php
@@ -1,0 +1,26 @@
+<?php
+
+function warning($var)
+{
+    try {
+        if (true) { // +1
+            for ($i = 0; $i < 10; $i++) { // +2 (nesting=1)
+            }
+        }
+    } catch (\Exception | \Exception $exception) { // +1
+        if (true) { } // +2 (nesting=1)
+    }
+}
+
+function error($var)
+{
+    try {
+        if (true) { // +1
+            for ($i = 0; $i < 10; $i++) { // +2 (nesting=1)
+                while (true) { } // +3 (nesting=2)
+            }
+        }
+    } catch (\Exception | \Exception $exception) { // +1
+        if (true) { } // +2 (nesting=1)
+    }
+}


### PR DESCRIPTION
**no breaking change**

* deprecate 'maxComplexity'  (still works)
* new options : 'warningThreshold' and 'errorThreshold'..    

Both default to 6   (equivalent to the old default maxComplexity value of 5)

----
example
warningThreshold => 6
errorThreshold => 10

will raise a warning if the computed complexity is 6-9 (inclusive)
will raise an error if the computed complexity is >= 10