### PR TITLE
RequireMultiLineMethodSignatureSniff: allow setting minimal param count

### DIFF
--- a/doc/classes.md
+++ b/doc/classes.md
@@ -213,6 +213,7 @@ Enforces method signature to be split to more lines so each parameter is on its 
 Sniff provides the following settings:
 
 * `minLineLength`: specifies min line length to enforce signature to be split. Use 0 value to enforce for all methods, regardless of length.
+* `minParametersCount`: specifies min parameters count to enforce signature to be split.
 
 * `includedMethodPatterns`: allows to configure which methods are included in sniff detection. This is an array of regular expressions (PCRE) with delimiters. You should not use this with `excludedMethodPatterns`, as it will not work properly.
 

--- a/tests/Sniffs/Classes/RequireMultiLineMethodSignatureSniffTest.php
+++ b/tests/Sniffs/Classes/RequireMultiLineMethodSignatureSniffTest.php
@@ -23,6 +23,16 @@ final class RequireMultiLineMethodSignatureSniffTest extends TestCase
 		);
 	}
 
+	public function testThrowExceptionOnInvalidSetup(): void
+	{
+		$this->expectException(Throwable::class);
+
+		self::checkFile(
+			__DIR__ . '/data/requireMultiLineMethodSignatureNoErrors.php',
+			['minLineLength' => 100, 'minParametersCount' => 2]
+		);
+	}
+
 	public function testNoErrors(): void
 	{
 		$report = self::checkFile(__DIR__ . '/data/requireMultiLineMethodSignatureNoErrors.php');
@@ -38,6 +48,22 @@ final class RequireMultiLineMethodSignatureSniffTest extends TestCase
 		self::assertSniffError($report, 8, RequireMultiLineMethodSignatureSniff::CODE_REQUIRED_MULTI_LINE_SIGNATURE);
 		self::assertSniffError($report, 14, RequireMultiLineMethodSignatureSniff::CODE_REQUIRED_MULTI_LINE_SIGNATURE);
 		self::assertSniffError($report, 16, RequireMultiLineMethodSignatureSniff::CODE_REQUIRED_MULTI_LINE_SIGNATURE);
+
+		self::assertAllFixedInFile($report);
+	}
+
+	public function testErrorsBasedOnParamCount(): void
+	{
+		$report = self::checkFile(
+			__DIR__ . '/data/requireMultiLineMethodSignatureBasedOnParamCountErrors.php',
+			[
+				'minParametersCount' => 2,
+			]
+		);
+		self::assertSame(2, $report->getErrorCount());
+
+		self::assertSniffError($report, 8, RequireMultiLineMethodSignatureSniff::CODE_REQUIRED_MULTI_LINE_SIGNATURE);
+		self::assertSniffError($report, 14, RequireMultiLineMethodSignatureSniff::CODE_REQUIRED_MULTI_LINE_SIGNATURE);
 
 		self::assertAllFixedInFile($report);
 	}

--- a/tests/Sniffs/Classes/data/requireMultiLineMethodSignatureBasedOnParamCountErrors.fixed.php
+++ b/tests/Sniffs/Classes/data/requireMultiLineMethodSignatureBasedOnParamCountErrors.fixed.php
@@ -1,0 +1,24 @@
+<?php // lint >= 8.0
+
+class A
+{
+	public function __construct(public int $single) {
+	}
+
+	public function tooManyParams(
+		int $one,
+		string $two
+	) {
+	}
+}
+
+interface B
+{
+	public function tooManyParams(
+		int $one,
+		string $two,
+		string $three
+	) : void;
+
+	public function noParam();
+}

--- a/tests/Sniffs/Classes/data/requireMultiLineMethodSignatureBasedOnParamCountErrors.php
+++ b/tests/Sniffs/Classes/data/requireMultiLineMethodSignatureBasedOnParamCountErrors.php
@@ -1,0 +1,17 @@
+<?php // lint >= 8.0
+
+class A
+{
+	public function __construct(public int $single) {
+	}
+
+	public function tooManyParams(int $one, string $two) {
+	}
+}
+
+interface B
+{
+	public function tooManyParams(int $one, string $two, string $three) : void;
+
+	public function noParam();
+}


### PR DESCRIPTION
~This is a draft.~ Would you accept such feature if I add proper tests? Default value might be adjusted / removed.

We want to force multi-line signatures for 2+ parameters.