### PR TITLE
Add ruleset validation in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
           dependency-versions: "highest"
 
       - name: "Validate ruleset"
-        uses: "szepeviktor/phpcs-ruleset-validator@v0.1.0"
+        uses: "szepeviktor/phpcs-ruleset-validator@v0.2.0"
         with:
           xmllint_indent: "	"
           xml_ruleset: "SlevomatCodingStandard/ruleset.xml"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,7 @@ jobs:
       - name: "Validate ruleset"
         uses: "szepeviktor/phpcs-ruleset-validator@v0.1.0"
         with:
+          xmllint_indent: "	"
           xml_ruleset: "SlevomatCodingStandard/ruleset.xml"
           xml_ruleset2: "build/phpcs.xml"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,32 @@ jobs:
       - name: "Lint"
         run: "bin/phing lint"
 
+  validate-rulesets:
+    name: "Validate PHPCS rulesets"
+
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v3"
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "8.2"
+
+      - name: "Install dependencies"
+        uses: "ramsey/composer-install@v2"
+        with:
+          dependency-versions: "highest"
+
+      - name: "Validate ruleset"
+        uses: "szepeviktor/phpcs-ruleset-validator@v0.1.0"
+        with:
+          xml_ruleset: "SlevomatCodingStandard/ruleset.xml"
+          xml_ruleset2: "build/phpcs.xml"
+
   coding-standards:
     name: "Coding standards"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
           dependency-versions: "highest"
 
       - name: "Validate ruleset"
-        uses: "szepeviktor/phpcs-ruleset-validator@v0.2.0"
+        uses: "szepeviktor/phpcs-ruleset-validator@v0.3.0"
         with:
           xmllint_indent: "\t"
           xml_ruleset: "SlevomatCodingStandard/ruleset.xml"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
       - name: "Validate ruleset"
         uses: "szepeviktor/phpcs-ruleset-validator@v0.2.0"
         with:
-          xmllint_indent: "	"
+          xmllint_indent: "\t"
           xml_ruleset: "SlevomatCodingStandard/ruleset.xml"
           xml_ruleset2: "build/phpcs.xml"
 

--- a/SlevomatCodingStandard/ruleset.xml
+++ b/SlevomatCodingStandard/ruleset.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Slevomat Coding Standard" xsi:noNamespaceSchemaLocation="../vendor/squizlabs/php_codesniffer/phpcs.xsd">
-    <autoload>./../autoload-bootstrap.php</autoload>
+	<autoload>./../autoload-bootstrap.php</autoload>
 </ruleset>

--- a/SlevomatCodingStandard/ruleset.xml
+++ b/SlevomatCodingStandard/ruleset.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Slevomat Coding Standard" xsi:noNamespaceSchemaLocation="../vendor/squizlabs/php_codesniffer/phpcs.xsd">
-	<autoload>./../autoload-bootstrap.php</autoload>
+    <autoload>./../autoload-bootstrap.php</autoload>
 </ruleset>


### PR DESCRIPTION
I hope you benefit from it.
```yaml
          xml_ruleset: "SlevomatCodingStandard/ruleset.xml"
          xml_ruleset2: "build/phpcs.xml"
```
It simply runs the `xmllint` command.