### PR TITLE
Utilize TokenHelper::$arrayTokenCodes and ArrayHelper utils in array sniffs

### DIFF
--- a/SlevomatCodingStandard/Helpers/ArrayHelper.php
+++ b/SlevomatCodingStandard/Helpers/ArrayHelper.php
@@ -164,11 +164,22 @@ class ArrayHelper
 		$tokenOpener = $tokens[$pointerOpener];
 		$tokenCloser = $tokens[$pointerCloser];
 
+		return $tokenOpener['line'] !== $tokenCloser['line'];
+	}
+
+	/**
+	 * Test if effective tokens between open & closing tokens
+	 */
+	public static function isNotEmpty(File $phpcsFile, int $pointer): bool
+	{
+		$tokens = $phpcsFile->getTokens();
+		$token = $tokens[$pointer];
+		[$pointerOpener, $pointerCloser] = self::openClosePointers($token);
+
 		/** @var int $pointerPreviousToClose */
 		$pointerPreviousToClose = TokenHelper::findPreviousEffective($phpcsFile, $pointerCloser - 1);
 
-		return $tokenOpener['line'] !== $tokenCloser['line']
-			&& $pointerPreviousToClose !== $pointerOpener;
+		return $pointerPreviousToClose !== $pointerOpener;
 	}
 
 	/**
@@ -189,7 +200,7 @@ class ArrayHelper
 
 	/**
 	 * @param array<string, array<int, int|string>|int|string> $token
-	 * @return int[]
+	 * @return array{0: int, 1: int}
 	 */
 	public static function openClosePointers(array $token): array
 	{

--- a/tests/Helpers/ArrayHelperTest.php
+++ b/tests/Helpers/ArrayHelperTest.php
@@ -150,8 +150,22 @@ class ArrayHelperTest extends TestCase
 			self::expectNotToPerformAssertions();
 			return;
 		}
-		$isKeyed = ArrayHelper::isMultiLine($phpcsFile, $pointer);
-		self::assertSame(in_array('multi', $expect['flags'], true), $isKeyed);
+		$isMultiLine = ArrayHelper::isMultiLine($phpcsFile, $pointer);
+		self::assertSame(in_array('multi', $expect['flags'], true), $isMultiLine);
+	}
+
+	/**
+	 * @dataProvider dataProvider
+	 * @param array<string, mixed> $expect flags and various expected values for the given array
+	 */
+	public function testIsNotEmpty(File $phpcsFile, int $pointer, array $expect): void
+	{
+		if (array_key_exists('flags', $expect) === false) {
+			self::expectNotToPerformAssertions();
+			return;
+		}
+		$isNotEmpty = ArrayHelper::isNotEmpty($phpcsFile, $pointer);
+		self::assertSame(in_array('notEmpty', $expect['flags'], true), $isNotEmpty);
 	}
 
 	/**
@@ -243,74 +257,92 @@ class ArrayHelperTest extends TestCase
 	protected function files(): array
 	{
 		return [
-			__DIR__ . '/data/array/multiline1Keyed1Sorted1.php' => [
+			__DIR__ . '/data/array/isNotEmpty.php' => [
 				[
-					'flags' => ['keyed', 'keyedAll', 'multi', 'sorted'],
+					'flags' => ['multi'],
 					'indentation' => "\t",
 				],
 				[
-					'flags' => ['keyed', 'keyedAll', 'multi', 'sorted', 'short'],
+					'flags' => ['multi', 'short'],
+					'indentation' => "\t",
+				],
+				[
+					'flags' => ['multi', 'notEmpty'],
+					'indentation' => "\t",
+				],
+				[
+					'flags' => ['multi', 'notEmpty', 'short'],
+					'indentation' => "\t",
+				],
+			],
+			__DIR__ . '/data/array/multiline1Keyed1Sorted1.php' => [
+				[
+					'flags' => ['keyed', 'keyedAll', 'multi', 'notEmpty', 'sorted'],
+					'indentation' => "\t",
+				],
+				[
+					'flags' => ['keyed', 'keyedAll', 'multi', 'notEmpty', 'sorted', 'short'],
 					'indentation' => "\t\t",
 				],
 				[
-					'flags' => ['keyed', 'keyedAll', 'multi', 'sorted', 'short'],
+					'flags' => ['keyed', 'keyedAll', 'multi', 'notEmpty', 'sorted', 'short'],
 					'indentation' => "\t",
 				],
 				[
-					'flags' => ['keyed', 'keyedAll', 'multi', 'sorted'],
+					'flags' => ['keyed', 'keyedAll', 'multi', 'notEmpty', 'sorted'],
 					'indentation' => "\t\t",
 				],
 			],
 			__DIR__ . '/data/array/multiline1Keyed1Sorted0.php' => [
 				[
-					'flags' => ['keyed', 'keyedAll', 'multi'],
+					'flags' => ['keyed', 'keyedAll', 'multi', 'notEmpty'],
 					'indentation' => "\t",
 				],
 				[
-					'flags' => ['keyed', 'keyedAll', 'multi', 'short'],
+					'flags' => ['keyed', 'keyedAll', 'multi', 'notEmpty', 'short'],
 					'indentation' => "\t\t",
 				],
 				[
-					'flags' => ['keyed', 'keyedAll', 'multi', 'short'],
+					'flags' => ['keyed', 'keyedAll', 'multi', 'notEmpty', 'short'],
 					'indentation' => "\t",
 				],
 				[
-					'flags' => ['keyed', 'keyedAll', 'multi'],
+					'flags' => ['keyed', 'keyedAll', 'multi', 'notEmpty'],
 					'indentation' => "\t\t",
 				],
 			],
 			__DIR__ . '/data/array/multiline0Keyed1Sorted1.php' => [
 				[
-					'flags' => ['keyed', 'keyedAll', 'sorted'],
+					'flags' => ['keyed', 'keyedAll', 'notEmpty', 'sorted'],
 					'indentation' => null,
 				],
 				[
-					'flags' => ['keyed', 'keyedAll', 'sorted', 'short'],
+					'flags' => ['keyed', 'keyedAll', 'notEmpty', 'sorted', 'short'],
 					'indentation' => null,
 				],
 			],
 			__DIR__ . '/data/array/multiline1Keyed0.php' => [
 				[
-					'flags' => ['multi'],
+					'flags' => ['multi', 'notEmpty'],
 					'indentation' => "\t",
 				],
 				[
-					'flags' => ['multi', 'short'],
+					'flags' => ['multi', 'notEmpty', 'short'],
 					'indentation' => "\t\t",
 				],
 				[
-					'flags' => ['multi', 'short'],
+					'flags' => ['multi', 'notEmpty', 'short'],
 					'indentation' => "\t",
 				],
 				[
-					'flags' => ['multi'],
+					'flags' => ['multi', 'notEmpty'],
 					'indentation' => "\t\t",
 				],
 			],
 			__DIR__ . '/data/array/multiline1Keyed1Comments.php' => [
 				[
 					'count' => 8,
-					'flags' => ['multi', 'keyed', 'short'],
+					'flags' => ['keyed', 'multi', 'notEmpty', 'short'],
 					'indentation' => "\t",
 					'keyValues' => [
 						[
@@ -380,7 +412,7 @@ class ArrayHelperTest extends TestCase
 				[
 					// the array inside the closure
 					'count' => 2,
-					'flags' => ['short'],
+					'flags' => ['notEmpty', 'short'],
 					'indentation' => null,
 					'keyValues' => [
 						[
@@ -402,7 +434,7 @@ class ArrayHelperTest extends TestCase
 				[
 					// the nested array
 					'count' => 2,
-					'flags' => ['multi', 'keyed', 'keyedAll'],
+					'flags' => ['keyed', 'keyedAll', 'multi', 'notEmpty'],
 					'indentation' => "\t\t",
 					'keyValues' => [
 						[

--- a/tests/Helpers/data/array/isNotEmpty.php
+++ b/tests/Helpers/data/array/isNotEmpty.php
@@ -1,0 +1,17 @@
+<?php
+
+array(
+	// empty array
+);
+
+[
+	// empty array
+];
+
+array(
+	'not empty',
+);
+
+[
+	'not empty',
+];

--- a/tests/Sniffs/Arrays/MultiLineArrayEndBracketPlacementSniffTest.php
+++ b/tests/Sniffs/Arrays/MultiLineArrayEndBracketPlacementSniffTest.php
@@ -17,13 +17,16 @@ class MultiLineArrayEndBracketPlacementSniffTest extends TestCase
 	{
 		$report = self::checkFile(__DIR__ . '/data/multiLineArrayEndBracketPlacementErrors.php');
 
-		self::assertSame(5, $report->getErrorCount());
+		self::assertSame(8, $report->getErrorCount());
 
 		self::assertSniffError($report, 3, MultiLineArrayEndBracketPlacementSniff::CODE_ARRAY_END_WRONG_PLACEMENT);
 		self::assertSniffError($report, 5, MultiLineArrayEndBracketPlacementSniff::CODE_ARRAY_END_WRONG_PLACEMENT);
 		self::assertSniffError($report, 13, MultiLineArrayEndBracketPlacementSniff::CODE_ARRAY_END_WRONG_PLACEMENT);
 		self::assertSniffError($report, 19, MultiLineArrayEndBracketPlacementSniff::CODE_ARRAY_END_WRONG_PLACEMENT);
 		self::assertSniffError($report, 33, MultiLineArrayEndBracketPlacementSniff::CODE_ARRAY_END_WRONG_PLACEMENT);
+		self::assertSniffError($report, 42, MultiLineArrayEndBracketPlacementSniff::CODE_ARRAY_END_WRONG_PLACEMENT);
+		self::assertSniffError($report, 44, MultiLineArrayEndBracketPlacementSniff::CODE_ARRAY_END_WRONG_PLACEMENT);
+		self::assertSniffError($report, 55, MultiLineArrayEndBracketPlacementSniff::CODE_ARRAY_END_WRONG_PLACEMENT);
 
 		self::assertAllFixedInFile($report);
 	}

--- a/tests/Sniffs/Arrays/SingleLineArrayWhitespaceSniffTest.php
+++ b/tests/Sniffs/Arrays/SingleLineArrayWhitespaceSniffTest.php
@@ -48,11 +48,15 @@ class SingleLineArrayWhitespaceSniffTest extends TestCase
 			'enableEmptyArrayCheck' => true,
 		]);
 
-		self::assertSame(5, $report->getErrorCount());
+		self::assertSame(10, $report->getErrorCount());
 
 		self::assertSniffError($report, 3, SingleLineArrayWhitespaceSniff::CODE_SPACE_AFTER_ARRAY_OPEN, '0 found');
 		self::assertSniffError($report, 3, SingleLineArrayWhitespaceSniff::CODE_SPACE_BEFORE_ARRAY_CLOSE, '0 found');
 		self::assertSniffError($report, 3, SingleLineArrayWhitespaceSniff::CODE_SPACE_IN_EMPTY_ARRAY);
+
+		self::assertSniffError($report, 5, SingleLineArrayWhitespaceSniff::CODE_SPACE_AFTER_ARRAY_OPEN, '0 found');
+		self::assertSniffError($report, 5, SingleLineArrayWhitespaceSniff::CODE_SPACE_BEFORE_ARRAY_CLOSE, '0 found');
+		self::assertSniffError($report, 5, SingleLineArrayWhitespaceSniff::CODE_SPACE_IN_EMPTY_ARRAY);
 
 		self::assertAllFixedInFile($report);
 	}

--- a/tests/Sniffs/Arrays/data/multiLineArrayEndBracketPlacementErrors.fixed.php
+++ b/tests/Sniffs/Arrays/data/multiLineArrayEndBracketPlacementErrors.fixed.php
@@ -44,3 +44,28 @@ $array = [
 		],
 	],
 ];
+$array = array(
+array(1 => 2),
+);
+$array = array(
+array(
+	1 => 2,
+	3 => 4,
+),
+);
+$array = array(
+	array(
+		array(1 => 2),
+		array(array(1 => 2, 2 => 3)),
+		array(
+			static function () {
+				return array(
+array(
+					1 => 2,
+					2 => 3,
+				),
+				);
+			},
+		),
+	),
+);

--- a/tests/Sniffs/Arrays/data/multiLineArrayEndBracketPlacementErrors.php
+++ b/tests/Sniffs/Arrays/data/multiLineArrayEndBracketPlacementErrors.php
@@ -39,3 +39,25 @@ $array = [
 		],
 	],
 ];
+$array = array(array(1 => 2),
+);
+$array = array(array(
+	1 => 2,
+	3 => 4,
+),
+);
+$array = array(
+	array(
+		array(1 => 2),
+		array(array(1 => 2, 2 => 3)),
+		array(
+			static function () {
+				return array(array(
+					1 => 2,
+					2 => 3,
+				),
+				);
+			},
+		),
+	),
+);

--- a/tests/Sniffs/Arrays/data/multiLineArrayEndBracketPlacementNoErrors.php
+++ b/tests/Sniffs/Arrays/data/multiLineArrayEndBracketPlacementNoErrors.php
@@ -32,3 +32,23 @@ $array = [
 		],
 	],
 ];
+$array = array(array(
+	1 => 2,
+	3 => 4,
+));
+$array = array(
+	array(
+		array(1 => 2),
+		array(array(1 => 2)),
+		array(
+			static function () {
+				return array(
+					array(
+						1 => 2,
+						2 => 3,
+					),
+				);
+			},
+		),
+	),
+);

--- a/tests/Sniffs/Arrays/data/singleLineArrayWhitespaceNoErrors.php
+++ b/tests/Sniffs/Arrays/data/singleLineArrayWhitespaceNoErrors.php
@@ -24,3 +24,26 @@ $array = [1, run([1, 2], 3, [])];
 $array = [1,];
 
 [$a, , $c] = $array;
+
+$singleLine = array('a', 'b', 1, 'c', array('d' => '1', 2 => 3, 'e'));
+
+$multiLine = array(
+	'a',
+	'b',
+	1,
+	'c',
+	array(
+		'd' => '1',
+		2 => 3,
+		'e',
+	),
+);
+
+$array = array(1 => 2);
+$array = array(array(1 => 2));
+$array = array(
+	array(1 => 2),
+);
+
+$array = array(1, run(array(1, 2), 3, array()));
+$array = array(1,);

--- a/tests/Sniffs/Arrays/data/singleLineArrayWhitespaceRequireSpacesErrors.fixed.php
+++ b/tests/Sniffs/Arrays/data/singleLineArrayWhitespaceRequireSpacesErrors.fixed.php
@@ -1,3 +1,5 @@
 <?php
 
 $singleLine = [ 1, run(1, [ 2, 3 ], 4), 5, [], [] ];
+
+$singleLine = array( 1, run(1, array( 2, 3 ), 4), 5, array(), array() );

--- a/tests/Sniffs/Arrays/data/singleLineArrayWhitespaceRequireSpacesErrors.php
+++ b/tests/Sniffs/Arrays/data/singleLineArrayWhitespaceRequireSpacesErrors.php
@@ -1,3 +1,5 @@
 <?php
 
 $singleLine = [1, run(1, [2, 3], 4), 5, [], [ ]];
+
+$singleLine = array(1, run(1, array(2, 3), 4), 5, array(), array( ));


### PR DESCRIPTION
Take advantage of TokenHelper::$arrayTokenCodes & ArrayHelper class

**ArrayHelper**
  * new `isNotEmpty` method   (separated from `ArrayHelper::isMultiLine()`)

**MultiLIneArrayEndBracketPlacementSniff**:
  * apply sniff to `TokenHelper::$arrayTokenCodes` vs  just `T_OPEN_SHORT_ARRAY`
  * normalize var names - $pointerOpener & $pointerCloser vs $arrayStart & $arrayEnd 
 
**SingleLineArrayWhitespaceSniff**:
  * apply sniff to `TokenHelper::$arrayTokenCodes` vs  just `T_OPEN_SHORT_ARRAY`
  * normalize var names - $pointerOpener & $pointerCloser vs $arrayStart & $arrayEnd 
  
**TrailingArrayCommaSniff**:
  * `TokenHelper::$arrayTokenCodes` vs  `[T_OPEN_SHORT_ARRAY, T_ARRAY]`
  * utilize ArrayHelper::OpenClosePointers()