### PR TITLE
Add array/DisallowPartiallyKeyedSniff

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Slevomat Coding Standard for [PHP_CodeSniffer](https://github.com/squizlabs/PHP_
 
  - [SlevomatCodingStandard.Arrays.AlphabeticallySortedByKeys](doc/arrays.md#slevomatcodingstandardarrayalphabeticallysortedbykeys) 🔧
  - [SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation](doc/arrays.md#slevomatcodingstandardarraysdisallowimplicitarraycreation)
+ - [SlevomatCodingStandard.Arrays.DisallowPartiallyKeyed](doc/arrays.md#slevomatcodingstandardarraysdisallowpartiallykeyed) 🚧
  - [SlevomatCodingStandard.Arrays.MultiLineArrayEndBracketPlacement](doc/arrays.md#slevomatcodingstandardarraysmultilinearrayendbracketplacement-) 🔧
  - [SlevomatCodingStandard.Arrays.SingleLineArrayWhitespace](doc/arrays.md#slevomatcodingstandardarrayssinglelinearraywhitespace-) 🔧
  - [SlevomatCodingStandard.Arrays.TrailingArrayComma](doc/arrays.md#slevomatcodingstandardarraystrailingarraycomma-) 🔧

--- a/SlevomatCodingStandard/Sniffs/Arrays/DisallowPartiallyKeyedSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Arrays/DisallowPartiallyKeyedSniff.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Arrays;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use SlevomatCodingStandard\Helpers\ArrayHelper;
+use SlevomatCodingStandard\Helpers\TokenHelper;
+
+class DisallowPartiallyKeyedSniff implements Sniff
+{
+
+	public const CODE_DISALLOWED_PARTIALLY_KEYED = 'DisallowedPartiallyKeyed';
+
+	/**
+	 * @return array<int, (int|string)>
+	 */
+	public function register(): array
+	{
+		return TokenHelper::$arrayTokenCodes;
+	}
+
+	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+	 * @param int $stackPointer
+	 */
+	public function process(File $phpcsFile, $stackPointer): void
+	{
+		$keyValues = ArrayHelper::parse($phpcsFile, $stackPointer);
+
+		if (!ArrayHelper::isKeyed($keyValues)) {
+			return;
+		}
+
+		if (ArrayHelper::isKeyedAll($keyValues)) {
+			return;
+		}
+
+		$phpcsFile->addError('Partially keyed array disallowed.', $stackPointer, self::CODE_DISALLOWED_PARTIALLY_KEYED);
+	}
+
+}

--- a/doc/arrays.md
+++ b/doc/arrays.md
@@ -12,6 +12,10 @@ This sniff enforces natural sorting of array definitions by key in multi-line ar
 
 Disallows implicit array creation.
 
+#### SlevomatCodingStandard.Arrays.DisallowPartiallyKeyed 🚧
+
+Array must have keys specified for either all or none of the values.
+
 #### SlevomatCodingStandard.Arrays.MultiLineArrayEndBracketPlacement 🔧
 
 Enforces reasonable end bracket placement for multi-line arrays.

--- a/tests/Sniffs/Arrays/DisallowPartiallyKeyedSniffTest.php
+++ b/tests/Sniffs/Arrays/DisallowPartiallyKeyedSniffTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Arrays;
+
+use SlevomatCodingStandard\Sniffs\TestCase;
+
+class DisallowPartiallyKeyedSniffTest extends TestCase
+{
+
+	public function testNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/disallowPartiallyKeyedNoErrors.php');
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/disallowPartiallyKeyedErrors.php', []);
+
+		self::assertSame(2, $report->getErrorCount());
+
+		self::assertSniffError($report, 3, DisallowPartiallyKeyedSniff::CODE_DISALLOWED_PARTIALLY_KEYED);
+		self::assertSniffError($report, 10, DisallowPartiallyKeyedSniff::CODE_DISALLOWED_PARTIALLY_KEYED);
+	}
+
+}

--- a/tests/Sniffs/Arrays/data/disallowPartiallyKeyedErrors.php
+++ b/tests/Sniffs/Arrays/data/disallowPartiallyKeyedErrors.php
@@ -1,0 +1,15 @@
+<?php
+
+$a = [
+	1 => 'one',
+	'two',
+	4 => 'four',
+	'five',
+];
+
+$a = array(
+	1 => 'one',
+	'two',
+	4 => 'four',
+	'five',
+);

--- a/tests/Sniffs/Arrays/data/disallowPartiallyKeyedNoErrors.php
+++ b/tests/Sniffs/Arrays/data/disallowPartiallyKeyedNoErrors.php
@@ -1,0 +1,23 @@
+<?php
+
+[];
+
+array();
+
+['foo', 'bar', 'baz'];
+
+array('foo', 'bar', 'baz');
+
+[
+	0 => 'zero',
+	'foo' => 'foo',
+	'bar' => 'bar',
+	'baz' => 'baz'
+];
+
+array(
+	0 => 'zero',
+	'foo' => 'foo',
+	'bar' => 'bar',
+	'baz' => 'baz'
+);


### PR DESCRIPTION
Array definitions must have keys specified for either all or none of the values