### PR TITLE
`SlevomatCodingStandard.Commenting.AnnotationName`: New sniff to check incorrect annotation names

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Slevomat Coding Standard for [PHP_CodeSniffer](https://github.com/squizlabs/PHP_
  - [SlevomatCodingStandard.Classes.TraitUseDeclaration](doc/classes.md#slevomatcodingstandardclassestraitusedeclaration-) 🔧
  - [SlevomatCodingStandard.Classes.TraitUseSpacing](doc/classes.md#slevomatcodingstandardclassestraitusespacing-) 🔧
  - [SlevomatCodingStandard.Classes.UselessLateStaticBinding](doc/classes.md#slevomatcodingstandardclassesuselesslatestaticbinding-) 🔧
+ - [SlevomatCodingStandard.Commenting.AnnotationName](doc/commenting.md#slevomatcodingstandardcommentingannotationname-)
  - [SlevomatCodingStandard.Commenting.DeprecatedAnnotationDeclaration](doc/commenting.md#slevomatcodingstandardcommentingdeprecatedannotationdeclaration)
  - [SlevomatCodingStandard.Commenting.DisallowCommentAfterCode](doc/commenting.md#slevomatcodingstandardcommentingdisallowcommentaftercode-) 🔧
  - [SlevomatCodingStandard.Commenting.DisallowOneLinePropertyDocComment](doc/commenting.md#slevomatcodingstandardcommentingdisallowonelinepropertydoccomment-) 🔧

--- a/SlevomatCodingStandard/Sniffs/Commenting/AnnotationNameSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Commenting/AnnotationNameSniff.php
@@ -1,0 +1,283 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use SlevomatCodingStandard\Helpers\AnnotationHelper;
+use SlevomatCodingStandard\Helpers\FixerHelper;
+use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
+use SlevomatCodingStandard\Helpers\TokenHelper;
+use function array_combine;
+use function array_key_exists;
+use function array_map;
+use function array_merge;
+use function array_unique;
+use function ltrim;
+use function preg_match_all;
+use function sprintf;
+use function strlen;
+use function strpos;
+use function strtolower;
+use function substr;
+use const PREG_OFFSET_CAPTURE;
+use const T_DOC_COMMENT_OPEN_TAG;
+
+class AnnotationNameSniff implements Sniff
+{
+
+	public const CODE_ANNOTATION_NAME_INCORRECT = 'AnnotationNameIncorrect';
+
+	private const STANDARD_ANNOTATIONS = [
+		'api',
+		'author',
+		'category',
+		'copyright',
+		'deprecated',
+		'example',
+		'filesource',
+		'global',
+		'ignore',
+		'inheritDoc',
+		'internal',
+		'license',
+		'link',
+		'method',
+		'package',
+		'param',
+		'property',
+		'property-read',
+		'property-write',
+		'return',
+		'see',
+		'since',
+		'source',
+		'subpackage',
+		'throws',
+		'todo',
+		'uses',
+		'used-by',
+		'var',
+		'version',
+	];
+
+	private const STATIC_ANALYSIS_ANNOTATIONS = [
+		'api',
+		'allow-private-mutation',
+		'assert',
+		'assert-if-true',
+		'assert-if-false',
+		'consistent-constructor',
+		'consistent-templates',
+		'extends',
+		'external-mutation-free',
+		'implements',
+		'mixin',
+		'ignore-falsable-return',
+		'ignore-nullable-return',
+		'ignore-var',
+		'ignore-variable-method',
+		'ignore-variable-property',
+		'immutable',
+		'import-type',
+		'internal',
+		'method',
+		'mutation-free',
+		'no-named-arguments',
+		'param',
+		'param-out',
+		'property',
+		'property-read',
+		'property-write',
+		'psalm-check-type',
+		'psalm-check-type-exact',
+		'psalm-suppress',
+		'psalm-trace',
+		'pure',
+		'readonly',
+		'readonly-allow-private-mutation',
+		'require-extends',
+		'require-implements',
+		'return',
+		'seal-properties',
+		'self-out',
+		'template',
+		'template-covariant',
+		'template-extends',
+		'template-implements',
+		'template-use',
+		'this-out',
+		'type',
+		'var',
+		'yield',
+	];
+
+	private const PHPUNIT_ANNOTATIONS = [
+		'author',
+		'after',
+		'afterClass',
+		'backupGlobals',
+		'backupStaticAttributes',
+		'before',
+		'beforeClass',
+		'codeCoverageIgnore',
+		'codeCoverageIgnoreStart',
+		'codeCoverageIgnoreEnd',
+		'covers',
+		'coversDefaultClass',
+		'coversNothing',
+		'dataProvider',
+		'depends',
+		'doesNotPerformAssertions',
+		'group',
+		'large',
+		'medium',
+		'preserveGlobalState',
+		'requires',
+		'runTestsInSeparateProcesses',
+		'runInSeparateProcess',
+		'small',
+		'test',
+		'testdox',
+		'testWith',
+		'ticket',
+		'uses',
+	];
+
+	/** @var list<string>|null */
+	public $annotations;
+
+	/** @var array<string, string>|null */
+	private $normalizedAnnotations;
+
+	/**
+	 * @return array<int, (int|string)>
+	 */
+	public function register(): array
+	{
+		return [
+			T_DOC_COMMENT_OPEN_TAG,
+		];
+	}
+
+	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+	 * @param int $docCommentOpenPointer
+	 */
+	public function process(File $phpcsFile, $docCommentOpenPointer): void
+	{
+		$annotations = AnnotationHelper::getAnnotations($phpcsFile, $docCommentOpenPointer);
+		$correctAnnotationNames = $this->getNormalizedAnnotationNames();
+
+		foreach ($annotations as $annotationName => $annotationsByName) {
+			$lowerCasedAnnotationName = strtolower($annotationName);
+
+			if (!array_key_exists($lowerCasedAnnotationName, $correctAnnotationNames)) {
+				continue;
+			}
+
+			$correctAnnotationName = $correctAnnotationNames[$lowerCasedAnnotationName];
+
+			if ($correctAnnotationName === $annotationName) {
+				continue;
+			}
+
+			foreach ($annotationsByName as $annotation) {
+				$fix = $phpcsFile->addFixableError(
+					sprintf('Annotation name is incorrect. Expected %s, found %s.', $correctAnnotationName, $annotationName),
+					$annotation->getStartPointer(),
+					self::CODE_ANNOTATION_NAME_INCORRECT
+				);
+				if (!$fix) {
+					continue;
+				}
+
+				$phpcsFile->fixer->beginChangeset();
+
+				$phpcsFile->fixer->replaceToken($annotation->getStartPointer(), $correctAnnotationName);
+
+				$phpcsFile->fixer->endChangeset();
+			}
+		}
+
+		$tokens = $phpcsFile->getTokens();
+
+		$docCommentContent = TokenHelper::getContent($phpcsFile, $docCommentOpenPointer, $tokens[$docCommentOpenPointer]['comment_closer']);
+
+		foreach ($correctAnnotationNames as $correctAnnotationName) {
+			if (preg_match_all('~\{(' . $correctAnnotationName . ')\}~i', $docCommentContent, $matches, PREG_OFFSET_CAPTURE) === 0) {
+				continue;
+			}
+
+			foreach ($matches[1] as $match) {
+				if ($match[0] === $correctAnnotationName) {
+					continue;
+				}
+
+				$fix = $phpcsFile->addFixableError(
+					sprintf('Annotation name is incorrect. Expected %s, found %s.', $correctAnnotationName, $match[0]),
+					$docCommentOpenPointer,
+					self::CODE_ANNOTATION_NAME_INCORRECT
+				);
+				if (!$fix) {
+					continue;
+				}
+
+				$phpcsFile->fixer->beginChangeset();
+
+				$fixedDocCommentContent = substr($docCommentContent, 0, $match[1]) . $correctAnnotationName . substr(
+					$docCommentContent,
+					$match[1] + strlen($match[0])
+				);
+
+				$phpcsFile->fixer->replaceToken($docCommentOpenPointer, $fixedDocCommentContent);
+				FixerHelper::removeBetweenIncluding(
+					$phpcsFile,
+					$docCommentOpenPointer + 1,
+					$tokens[$docCommentOpenPointer]['comment_closer']
+				);
+
+				$phpcsFile->fixer->endChangeset();
+			}
+		}
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	private function getNormalizedAnnotationNames(): array
+	{
+		if ($this->normalizedAnnotations !== null) {
+			return $this->normalizedAnnotations;
+		}
+
+		if ($this->annotations !== null) {
+			$annotationNames = array_map(static function (string $annotationName): string {
+				return ltrim($annotationName, '@');
+			}, SniffSettingsHelper::normalizeArray($this->annotations));
+		} else {
+			$annotationNames = array_merge(self::STANDARD_ANNOTATIONS, self::PHPUNIT_ANNOTATIONS, self::STATIC_ANALYSIS_ANNOTATIONS);
+
+			foreach (self::STATIC_ANALYSIS_ANNOTATIONS as $annotationName) {
+				if (strpos($annotationName, 'psalm') === 0) {
+					continue;
+				}
+
+				foreach (AnnotationHelper::STATIC_ANALYSIS_PREFIXES as $prefix) {
+					$annotationNames[] = sprintf('%s-%s', $prefix, $annotationName);
+				}
+			}
+		}
+
+		$annotationNames = array_map(static function (string $annotationName): string {
+			return '@' . $annotationName;
+		}, array_unique($annotationNames));
+
+		$this->normalizedAnnotations = array_combine(array_map(static function (string $annotationName): string {
+			return strtolower($annotationName);
+		}, $annotationNames), $annotationNames);
+
+		return $this->normalizedAnnotations;
+	}
+
+}

--- a/doc/commenting.md
+++ b/doc/commenting.md
@@ -1,5 +1,14 @@
 ## Commenting
 
+#### SlevomatCodingStandard.Commenting.AnnotationName 🔧
+
+Reports incorrect annotation name. It reports standard annotation names used by phpDocumentor, PHPUnit, PHPStan and Psalm by default.
+Unknown annotation names are ignored.
+
+Sniff provides the following settings:
+
+* `annotations`: allows to configure which annotations are checked and how.
+
 #### SlevomatCodingStandard.Commenting.DeprecatedAnnotationDeclaration
 
 Reports `@deprecated` annotations without description.

--- a/tests/Sniffs/Commenting/AnnotationNameSniffTest.php
+++ b/tests/Sniffs/Commenting/AnnotationNameSniffTest.php
@@ -1,0 +1,118 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Commenting;
+
+use SlevomatCodingStandard\Sniffs\TestCase;
+
+class AnnotationNameSniffTest extends TestCase
+{
+
+	public function testNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/annotationNameNoErrors.php');
+
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/annotationNameErrors.php');
+
+		self::assertSame(6, $report->getErrorCount());
+
+		self::assertSniffError(
+			$report,
+			4,
+			AnnotationNameSniff::CODE_ANNOTATION_NAME_INCORRECT,
+			'Annotation name is incorrect. Expected @deprecated, found @Deprecated.'
+		);
+		self::assertSniffError(
+			$report,
+			10,
+			AnnotationNameSniff::CODE_ANNOTATION_NAME_INCORRECT,
+			'Annotation name is incorrect. Expected @param, found @pArAm.'
+		);
+		self::assertSniffError(
+			$report,
+			11,
+			AnnotationNameSniff::CODE_ANNOTATION_NAME_INCORRECT,
+			'Annotation name is incorrect. Expected @phpstan-return, found @PHPSTAN-return.'
+		);
+		self::assertSniffError(
+			$report,
+			18,
+			AnnotationNameSniff::CODE_ANNOTATION_NAME_INCORRECT,
+			'Annotation name is incorrect. Expected @inheritDoc, found @inheritdoc.'
+		);
+		self::assertSniffError(
+			$report,
+			17,
+			AnnotationNameSniff::CODE_ANNOTATION_NAME_INCORRECT,
+			'Annotation name is incorrect. Expected @inheritDoc, found @inheritdoc.'
+		);
+		self::assertSniffError(
+			$report,
+			17,
+			AnnotationNameSniff::CODE_ANNOTATION_NAME_INCORRECT,
+			'Annotation name is incorrect. Expected @inheritDoc, found @INHERITDOC.'
+		);
+
+		self::assertAllFixedInFile($report);
+	}
+
+	public function testWithModifiedSettingsNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/annotationNameWithModifiedSettingsNoErrors.php', [
+			'annotations' => [
+				'Deprecated',
+				'PARAM',
+				'PHPSTAN-RETURN',
+				'inheritdoc',
+			],
+		]);
+
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testWithModifiedSettingsErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/annotationNameWithModifiedSettingsErrors.php', [
+			'annotations' => [
+				'@Deprecated',
+				'@PARAM',
+				'@PHPSTAN-RETURN',
+				'@inheritdoc',
+			],
+		]);
+
+		self::assertSame(4, $report->getErrorCount());
+
+		self::assertSniffError(
+			$report,
+			4,
+			AnnotationNameSniff::CODE_ANNOTATION_NAME_INCORRECT,
+			'Annotation name is incorrect. Expected @Deprecated, found @deprecated.'
+		);
+		self::assertSniffError(
+			$report,
+			10,
+			AnnotationNameSniff::CODE_ANNOTATION_NAME_INCORRECT,
+			'Annotation name is incorrect. Expected @PARAM, found @param.'
+		);
+		self::assertSniffError(
+			$report,
+			11,
+			AnnotationNameSniff::CODE_ANNOTATION_NAME_INCORRECT,
+			'Annotation name is incorrect. Expected @PHPSTAN-RETURN, found @phpstan-return.'
+		);
+		self::assertSniffError(
+			$report,
+			18,
+			AnnotationNameSniff::CODE_ANNOTATION_NAME_INCORRECT,
+			'Annotation name is incorrect. Expected @inheritdoc, found @inheritDoc.'
+		);
+
+		self::assertAllFixedInFile($report);
+	}
+
+}

--- a/tests/Sniffs/Commenting/data/annotationNameErrors.fixed.php
+++ b/tests/Sniffs/Commenting/data/annotationNameErrors.fixed.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @deprecated Yes, it's deprecated
+ */
+class Whatever
+{
+
+	/**
+	 * @param string $a Some comment
+	 * @phpstan-return array{0: string, 1: int}
+	 */
+	public function method($a)
+	{
+	}
+
+	/**
+	 * @inheritDoc
+	 *
+	 * And some text with {@inheritDoc} and {@inheritDoc} annotation.
+	 */
+	public function inherit()
+	{
+	}
+
+}

--- a/tests/Sniffs/Commenting/data/annotationNameErrors.php
+++ b/tests/Sniffs/Commenting/data/annotationNameErrors.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @Deprecated Yes, it's deprecated
+ */
+class Whatever
+{
+
+	/**
+	 * @pArAm string $a Some comment
+	 * @PHPSTAN-return array{0: string, 1: int}
+	 */
+	public function method($a)
+	{
+	}
+
+	/**
+	 * @inheritdoc
+	 *
+	 * And some text with {@inheritdoc} and {@INHERITDOC} annotation.
+	 */
+	public function inherit()
+	{
+	}
+
+}

--- a/tests/Sniffs/Commenting/data/annotationNameNoErrors.php
+++ b/tests/Sniffs/Commenting/data/annotationNameNoErrors.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @deprecated
+ *
+ * @unknown-annotation
+ */
+class Whatever
+{
+
+	/**
+	 * @param string $a
+	 * @phpstan-return array{0: string, 1: int}
+	 */
+	public function method($a)
+	{
+	}
+
+	/**
+	 * @inheritDoc
+	 *
+	 * And some text with {@inheritDoc} annotation.
+	 */
+	public function inherit()
+	{
+	}
+
+}

--- a/tests/Sniffs/Commenting/data/annotationNameWithModifiedSettingsErrors.fixed.php
+++ b/tests/Sniffs/Commenting/data/annotationNameWithModifiedSettingsErrors.fixed.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @Deprecated
+ */
+class Whatever
+{
+
+	/**
+	 * @PARAM string $a
+	 * @PHPSTAN-RETURN array{0: string, 1: int}
+	 */
+	public function method($a)
+	{
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function inherit()
+	{
+	}
+
+}

--- a/tests/Sniffs/Commenting/data/annotationNameWithModifiedSettingsErrors.php
+++ b/tests/Sniffs/Commenting/data/annotationNameWithModifiedSettingsErrors.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @deprecated
+ */
+class Whatever
+{
+
+	/**
+	 * @param string $a
+	 * @phpstan-return array{0: string, 1: int}
+	 */
+	public function method($a)
+	{
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function inherit()
+	{
+	}
+
+}

--- a/tests/Sniffs/Commenting/data/annotationNameWithModifiedSettingsNoErrors.php
+++ b/tests/Sniffs/Commenting/data/annotationNameWithModifiedSettingsNoErrors.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @Deprecated
+ *
+ * @unknown-annotation
+ */
+class Whatever
+{
+
+	/**
+	 * @PARAM string $a
+	 * @PHPSTAN-RETURN array{0: string, 1: int}
+	 */
+	public function method($a)
+	{
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function inherit()
+	{
+	}
+
+}


### PR DESCRIPTION
Fixes #1556