### PR TITLE
Fix TypeError via JumpStatementsSpacingSniff when return is on the first line of the file

### DIFF
--- a/SlevomatCodingStandard/Sniffs/ControlStructures/AbstractControlStructureSpacing.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/AbstractControlStructureSpacing.php
@@ -217,7 +217,9 @@ abstract class AbstractControlStructureSpacing implements Sniff
 			$phpcsFile->fixer->replaceToken($pointerBefore, '<?php');
 		}
 
-		FixerHelper::removeBetweenIncluding($phpcsFile, $pointerBefore + 1, $endOfLineBeforePointer);
+		if ($endOfLineBeforePointer !== null) {
+			FixerHelper::removeBetweenIncluding($phpcsFile, $pointerBefore + 1, $endOfLineBeforePointer);
+		}
 
 		$linesToAdd = $hasCommentWithLineEndBefore ? $requiredLinesCountBefore - 1 : $requiredLinesCountBefore;
 		for ($i = 0; $i <= $linesToAdd; $i++) {

--- a/tests/Sniffs/ControlStructures/JumpStatementsSpacingSniffTest.php
+++ b/tests/Sniffs/ControlStructures/JumpStatementsSpacingSniffTest.php
@@ -292,6 +292,22 @@ class JumpStatementsSpacingSniffTest extends TestCase
 		self::assertAllFixedInFile($report);
 	}
 
+	public function testAtTheBeginnningOfFile(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/jumpStatementsSpacingAtTheBeginningOfFile.php');
+
+		self::assertSame(1, $report->getErrorCount());
+
+		self::assertSniffError(
+			$report,
+			1,
+			JumpStatementsSpacingSniff::CODE_INCORRECT_LINES_COUNT_BEFORE_CONTROL_STRUCTURE,
+			'Expected 1 line before "return", found -1.'
+		);
+
+		self::assertAllFixedInFile($report);
+	}
+
 	public function testAtTheEndOfFile(): void
 	{
 		$report = self::checkFile(__DIR__ . '/data/jumpStatementsSpacingAtTheEndOfFile.php');

--- a/tests/Sniffs/ControlStructures/data/jumpStatementsSpacingAtTheBeginningOfFile.fixed.php
+++ b/tests/Sniffs/ControlStructures/data/jumpStatementsSpacingAtTheBeginningOfFile.fixed.php
@@ -1,0 +1,3 @@
+<?php
+
+return true;

--- a/tests/Sniffs/ControlStructures/data/jumpStatementsSpacingAtTheBeginningOfFile.php
+++ b/tests/Sniffs/ControlStructures/data/jumpStatementsSpacingAtTheBeginningOfFile.php
@@ -1,0 +1,1 @@
+<?php return true;


### PR DESCRIPTION
This fixes
```
TypeError: SlevomatCodingStandard\Helpers\FixerHelper::removeBetweenIncluding(): Argument #3 ($endPointer) must be of type int, null given, called in <redacted>/coding-standard/SlevomatCodingStandard/Sniffs/ControlStructures/AbstractControlStructureSpacing.php on line 221
```

`$endOfLineBeforePointer` can be `null`, but `FixerHelper::removeBetweenIncluding()` expects `int`.