### PR TITLE
UnusedUses ignores uses in annotations with multi lines string arguments

### DIFF
--- a/tests/Sniffs/Namespaces/UnusedUsesSniffTest.php
+++ b/tests/Sniffs/Namespaces/UnusedUsesSniffTest.php
@@ -68,6 +68,8 @@ class UnusedUsesSniffTest extends TestCase
 		self::assertNoSniffError($report, 29);
 
 		self::assertNoSniffError($report, 30);
+
+		self::assertNoSniffError($report, 91);
 	}
 
 	public function testUnusedUseWithMultipleNamespaces(): void
@@ -96,7 +98,7 @@ class UnusedUsesSniffTest extends TestCase
 			'searchAnnotations' => false,
 		]);
 
-		self::assertSame(85, $report->getErrorCount());
+		self::assertSame(86, $report->getErrorCount());
 
 		self::assertSniffError($report, 5, UnusedUsesSniff::CODE_UNUSED_USE, 'Type Assert is not used in this file.');
 		self::assertSniffError(

--- a/tests/Sniffs/Namespaces/data/unusedUsesInAnnotation.php
+++ b/tests/Sniffs/Namespaces/data/unusedUsesInAnnotation.php
@@ -88,6 +88,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
+use OpenApi\Annotations as OA;
 
 /**
  * @ORM\Entity()
@@ -344,4 +345,11 @@ class DDC1514EntityB
 	 * @GeneratedValue
 	 */
 	public $id;
+}
+
+/**
+ * @OA\Tag(name="
+ * ")
+ */
+class AnnotationWithMultiLinesStringArguments {
 }


### PR DESCRIPTION
Reproduce issue with the Namespaces.UnusedUses sniff that don't detect usages in annotations when the annotation has multiline string arguments

Work in progress: I didn't try running the test locally yet