### PR TITLE
Arrays/DisallowImplicitArrayCreation: bug fix - recognize `global` statements

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Arrays/DisallowImplicitArrayCreationSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Arrays/DisallowImplicitArrayCreationSniff.php
@@ -12,9 +12,11 @@ use function count;
 use function in_array;
 use const T_CLOSE_PARENTHESIS;
 use const T_CLOSURE;
+use const T_COMMA;
 use const T_DOUBLE_COLON;
 use const T_EQUAL;
 use const T_FOREACH;
+use const T_GLOBAL;
 use const T_LIST;
 use const T_OBJECT_OPERATOR;
 use const T_OPEN_PARENTHESIS;
@@ -203,6 +205,10 @@ class DisallowImplicitArrayCreationSniff implements Sniff
 			if ($this->isCreatedByReferencedParameterInFunctionCall($phpcsFile, $i, $scopeOpenerPointer)) {
 				return true;
 			}
+
+			if ($this->isImportedUsingGlobalStatement($phpcsFile, $i)) {
+				return true;
+			}
 		}
 
 		return false;
@@ -260,6 +266,15 @@ class DisallowImplicitArrayCreationSniff implements Sniff
 
 		$pointerBeforeParenthesisOpener = TokenHelper::findPreviousEffective($phpcsFile, $parenthesisOpenerPointer - 1);
 		return $tokens[$pointerBeforeParenthesisOpener]['code'] === T_STRING;
+	}
+
+	private function isImportedUsingGlobalStatement(File $phpcsFile, int $variablePointer): bool
+	{
+		$tokens = $phpcsFile->getTokens();
+
+		$startOfStatement = $phpcsFile->findStartOfStatement($variablePointer, T_COMMA);
+
+		return $tokens[$startOfStatement]['code'] === T_GLOBAL;
 	}
 
 }

--- a/tests/Sniffs/Arrays/DisallowImplicitArrayCreationSniffTest.php
+++ b/tests/Sniffs/Arrays/DisallowImplicitArrayCreationSniffTest.php
@@ -17,7 +17,7 @@ class DisallowImplicitArrayCreationSniffTest extends TestCase
 	{
 		$report = self::checkFile(__DIR__ . '/data/disallowImplicitArrayCreationErrors.php');
 
-		self::assertSame(8, $report->getErrorCount());
+		self::assertSame(9, $report->getErrorCount());
 
 		self::assertSniffError($report, 3, DisallowImplicitArrayCreationSniff::CODE_IMPLICIT_ARRAY_CREATION_USED);
 		self::assertSniffError($report, 7, DisallowImplicitArrayCreationSniff::CODE_IMPLICIT_ARRAY_CREATION_USED);
@@ -27,6 +27,7 @@ class DisallowImplicitArrayCreationSniffTest extends TestCase
 		self::assertSniffError($report, 36, DisallowImplicitArrayCreationSniff::CODE_IMPLICIT_ARRAY_CREATION_USED);
 		self::assertSniffError($report, 41, DisallowImplicitArrayCreationSniff::CODE_IMPLICIT_ARRAY_CREATION_USED);
 		self::assertSniffError($report, 48, DisallowImplicitArrayCreationSniff::CODE_IMPLICIT_ARRAY_CREATION_USED);
+		self::assertSniffError($report, 54, DisallowImplicitArrayCreationSniff::CODE_IMPLICIT_ARRAY_CREATION_USED);
 	}
 
 }

--- a/tests/Sniffs/Arrays/data/disallowImplicitArrayCreationErrors.php
+++ b/tests/Sniffs/Arrays/data/disallowImplicitArrayCreationErrors.php
@@ -47,3 +47,9 @@ function undefinedVariable()
 	$b = $a ? true : false;
 	$a[] = 2;
 }
+
+function notImportedViaGlobalStatement()
+{
+	static $something, $value, $somethingElse;
+	$value[] = 'a';
+}

--- a/tests/Sniffs/Arrays/data/disallowImplicitArrayCreationNoErrors.php
+++ b/tests/Sniffs/Arrays/data/disallowImplicitArrayCreationNoErrors.php
@@ -90,3 +90,9 @@ function staticVariable()
 	static $value;
 	$value[] = true;
 }
+
+function importedViaGlobalStatement()
+{
+	global $something, $value, $somethingElse;
+	$value[] = 'a';
+}


### PR DESCRIPTION
While it may be unclear whether the variable imported via the `global` statement is an array, the variable does exist, so this is not implicit array creation.

Includes tests.