### PR TITLE
ControlStructures/AssignmentInCondition: prevent fatal error during live coding

### DIFF
--- a/SlevomatCodingStandard/Sniffs/ControlStructures/AssignmentInConditionSniff.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/AssignmentInConditionSniff.php
@@ -42,6 +42,7 @@ class AssignmentInConditionSniff implements Sniff
 	{
 		$tokens = $phpcsFile->getTokens();
 		$token = $tokens[$conditionStartPointer];
+
 		if ($token['code'] === T_DO) {
 			$whilePointer = TokenHelper::findNext($phpcsFile, T_WHILE, $token['scope_closer'] + 1);
 			$whileToken = $tokens[$whilePointer];
@@ -53,6 +54,14 @@ class AssignmentInConditionSniff implements Sniff
 			$parenthesisCloser = $token['parenthesis_closer'];
 			$type = $token['code'] === T_IF ? 'if' : 'elseif';
 		}
+
+		if (
+			$parenthesisOpener === null
+			|| $parenthesisCloser === null
+		) {
+			return;
+		}
+
 		$this->processCondition($phpcsFile, $parenthesisOpener, $parenthesisCloser, $type);
 	}
 

--- a/tests/Sniffs/ControlStructures/AssignmentInConditionSniffTest.php
+++ b/tests/Sniffs/ControlStructures/AssignmentInConditionSniffTest.php
@@ -49,4 +49,10 @@ class AssignmentInConditionSniffTest extends TestCase
 		}
 	}
 
+	public function testLiveCoding(): void
+	{
+		$resultFile = self::checkFile(__DIR__ . '/data/assignmentsInConditionsLiveCoding.php');
+		self::assertNoSniffErrorInFile($resultFile);
+	}
+
 }

--- a/tests/Sniffs/ControlStructures/data/assignmentsInConditionsLiveCoding.php
+++ b/tests/Sniffs/ControlStructures/data/assignmentsInConditionsLiveCoding.php
@@ -1,0 +1,5 @@
+<?php // lint >= 99.00
+
+// Live coding/parse error.
+// This must be the last test in the file.
+if ($a = 1


### PR DESCRIPTION
Fixes:

```
Fatal error: Uncaught TypeError: SlevomatCodingStandard\Sniffs\ControlStructures\AssignmentInConditionSniff::processCondition(): Argument #3 ($parenthesisCloser) must be of type int, null given, called in path\to\SlevomatCodingStandard\Sniffs\ControlStructures\AssignmentInConditionSniff.php on line 56 and defined in path\to\SlevomatCodingStandard\Sniffs\ControlStructures\AssignmentInConditionSniff.php:59
Stack trace:
#0 path\to\SlevomatCodingStandard\Sniffs\ControlStructures\AssignmentInConditionSniff.php(56): SlevomatCodingStandard\Sniffs\ControlStructures\AssignmentInConditionSniff->processCondition(Object(PHP_CodeSniffer\Files\LocalFile), 100, NULL, 'if')
#1 D:\000_GitHub\PHPCS\PHP_CodeSniffer\src\Files\File.php(509): SlevomatCodingStandard\Sniffs\ControlStructures\AssignmentInConditionSniff->process(Object(PHP_CodeSniffer\Files\LocalFile), 99)
#2 D:\000_GitHub\PHPCS\PHP_CodeSniffer\src\Files\LocalFile.php(92): PHP_CodeSniffer\Files\File->process()
#3 D:\000_GitHub\PHPCS\PHP_CodeSniffer\src\Runner.php(632): PHP_CodeSniffer\Files\LocalFile->process()
#4 D:\000_GitHub\PHPCS\PHP_CodeSniffer\src\Runner.php(438): PHP_CodeSniffer\Runner->processFile(Object(PHP_CodeSniffer\Files\LocalFile))
#5 D:\000_GitHub\PHPCS\PHP_CodeSniffer\src\Runner.php(116): PHP_CodeSniffer\Runner->run()
#6 D:\000_GitHub\PHPCS\PHP_CodeSniffer\bin\phpcs(18): PHP_CodeSniffer\Runner->runPHPCS()
#7 {main}
  thrown in path\to\SlevomatCodingStandard\Sniffs\ControlStructures\AssignmentInConditionSniff.php on line 59
```