### PR TITLE
ControlStructures/RequireSingleLineCondition: prevent error for parse error

### DIFF
--- a/SlevomatCodingStandard/Sniffs/ControlStructures/AbstractLineCondition.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/AbstractLineCondition.php
@@ -7,6 +7,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 use SlevomatCodingStandard\Helpers\IndentationHelper;
 use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
 use SlevomatCodingStandard\Helpers\TokenHelper;
+use function array_key_exists;
 use function in_array;
 use function preg_replace;
 use function rtrim;
@@ -59,6 +60,15 @@ abstract class AbstractLineCondition implements Sniff
 	protected function shouldBeSkipped(File $phpcsFile, int $controlStructurePointer): bool
 	{
 		$tokens = $phpcsFile->getTokens();
+
+		if (
+			!array_key_exists('parenthesis_opener', $tokens[$controlStructurePointer])
+			|| $tokens[$controlStructurePointer]['parenthesis_opener'] === null
+			|| !array_key_exists('parenthesis_closer', $tokens[$controlStructurePointer])
+			|| $tokens[$controlStructurePointer]['parenthesis_closer'] === null
+		) {
+			return true;
+		}
 
 		if ($tokens[$controlStructurePointer]['code'] === T_WHILE) {
 			$isPartOfDo = $this->isPartOfDo($phpcsFile, $controlStructurePointer);

--- a/build/PHPStan/GetTokenDynamicReturnTypeExtension.php
+++ b/build/PHPStan/GetTokenDynamicReturnTypeExtension.php
@@ -11,6 +11,7 @@ use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\IntegerType;
+use PHPStan\Type\NullType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
@@ -46,6 +47,7 @@ class GetTokenDynamicReturnTypeExtension implements DynamicMethodReturnTypeExten
 			$stringType = new StringType();
 			$integerType = new IntegerType();
 			$stringIntegerUnion = new UnionType([$stringType, $integerType]);
+			$nullableInteger = new UnionType([new NullType(), $integerType]);
 
 			$baseArrayBuilder = ConstantArrayTypeBuilder::createEmpty();
 			$baseArrayBuilder->setOffsetValueType(new ConstantStringType('content'), $stringType);
@@ -65,8 +67,8 @@ class GetTokenDynamicReturnTypeExtension implements DynamicMethodReturnTypeExten
 			$arrayBuilder->setOffsetValueType(new ConstantStringType('length'), $integerType);
 			$arrayBuilder->setOffsetValueType(new ConstantStringType('level'), $integerType);
 			$arrayBuilder->setOffsetValueType(new ConstantStringType('conditions'), new ArrayType($integerType, $stringIntegerUnion));
-			$arrayBuilder->setOffsetValueType(new ConstantStringType('parenthesis_opener'), $integerType);
-			$arrayBuilder->setOffsetValueType(new ConstantStringType('parenthesis_closer'), $integerType);
+			$arrayBuilder->setOffsetValueType(new ConstantStringType('parenthesis_opener'), $nullableInteger);
+			$arrayBuilder->setOffsetValueType(new ConstantStringType('parenthesis_closer'), $nullableInteger);
 			$arrayBuilder->setOffsetValueType(new ConstantStringType('parenthesis_owner'), $integerType);
 			$arrayBuilder->setOffsetValueType(new ConstantStringType('scope_condition'), $integerType);
 			$arrayBuilder->setOffsetValueType(new ConstantStringType('scope_opener'), $integerType);

--- a/tests/Sniffs/ControlStructures/RequireSingleLineConditionSniffTest.php
+++ b/tests/Sniffs/ControlStructures/RequireSingleLineConditionSniffTest.php
@@ -98,4 +98,10 @@ class RequireSingleLineConditionSniffTest extends TestCase
 		self::assertNoSniffErrorInFile($report);
 	}
 
+	public function testNoErrorsLiveCoding(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/requireSingleLineConditionLiveCoding.php');
+		self::assertNoSniffErrorInFile($report);
+	}
+
 }

--- a/tests/Sniffs/ControlStructures/data/requireSingleLineConditionLiveCoding.php
+++ b/tests/Sniffs/ControlStructures/data/requireSingleLineConditionLiveCoding.php
@@ -1,0 +1,5 @@
+<?php // lint >= 99.0
+
+// Live coding/parse error.
+// This must be the last test in the file.
+if ($a = 1


### PR DESCRIPTION
Fixes:

```
An error occurred during processing; checking has been aborted. The error message was: Undefined array key "" in path\to\SlevomatCodingStandard\Sniffs\ControlStructures\RequireSingleLineConditionSniff.php on line 41
```