### PR TITLE
PHP/UselessParentheses: prevent error for parse error

### DIFF
--- a/SlevomatCodingStandard/Sniffs/PHP/UselessParenthesesSniff.php
+++ b/SlevomatCodingStandard/Sniffs/PHP/UselessParenthesesSniff.php
@@ -122,6 +122,10 @@ class UselessParenthesesSniff implements Sniff
 			return;
 		}
 
+		if (!array_key_exists('parenthesis_closer', $tokens[$parenthesisOpenerPointer])) {
+			return;
+		}
+
 		/** @var int $pointerBeforeParenthesisOpener */
 		$pointerBeforeParenthesisOpener = TokenHelper::findPreviousEffective($phpcsFile, $parenthesisOpenerPointer - 1);
 		if (in_array($tokens[$pointerBeforeParenthesisOpener]['code'], array_merge(
@@ -386,7 +390,7 @@ class UselessParenthesesSniff implements Sniff
 			} while (true);
 		} else {
 			$nextPointer = TokenHelper::findNext($phpcsFile, T_OPEN_PARENTHESIS, $notBooleanNotOperatorPointer + 1);
-			if ($nextPointer === null) {
+			if ($nextPointer === null || !isset($tokens[$nextPointer]['parenthesis_closer'])) {
 				return;
 			}
 

--- a/tests/Sniffs/PHP/UselessParenthesesSniffTest.php
+++ b/tests/Sniffs/PHP/UselessParenthesesSniffTest.php
@@ -34,4 +34,10 @@ class UselessParenthesesSniffTest extends TestCase
 		self::assertNoSniffErrorInFile($report);
 	}
 
+	public function testNoErrorsLiveCoding(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/uselessParenthesesLiveCoding.php');
+		self::assertNoSniffErrorInFile($report);
+	}
+
 }

--- a/tests/Sniffs/PHP/data/uselessParenthesesLiveCoding.php
+++ b/tests/Sniffs/PHP/data/uselessParenthesesLiveCoding.php
@@ -1,0 +1,5 @@
+<?php // lint >= 99.0
+
+// Live coding/parse error.
+// This must be the last test in the file.
+if ($a = 1

--- a/tests/Sniffs/PHP/data/uselessParenthesesNoErrors.php
+++ b/tests/Sniffs/PHP/data/uselessParenthesesNoErrors.php
@@ -177,4 +177,3 @@ $anotherObject = new ($object->getClassName());
 return true
 	? 100
 	: (int) ((100 <=> 50) * 100);
-


### PR DESCRIPTION
Fixes:
```
An error occurred during processing; checking has been aborted. The error message was: Undefined array key "parenthesis_closer" in path\to\SlevomatCodingStandard\Sniffs\PHP\UselessParenthesesSniff.php on line 178
```