### PR TITLE
NamespaceHelper::getAllNamespacesPointers(): bug fix - allow for namespace tokens used as operator

### DIFF
--- a/SlevomatCodingStandard/Helpers/NamespaceHelper.php
+++ b/SlevomatCodingStandard/Helpers/NamespaceHelper.php
@@ -3,8 +3,10 @@
 namespace SlevomatCodingStandard\Helpers;
 
 use PHP_CodeSniffer\Files\File;
+use function array_filter;
 use function array_reverse;
 use function array_slice;
+use function array_values;
 use function count;
 use function defined;
 use function explode;
@@ -35,8 +37,18 @@ class NamespaceHelper
 	 */
 	public static function getAllNamespacesPointers(File $phpcsFile): array
 	{
-		$lazyValue = static function () use ($phpcsFile): array {
-			return TokenHelper::findNextAll($phpcsFile, T_NAMESPACE, 0);
+		$tokens = $phpcsFile->getTokens();
+		$lazyValue = static function () use ($phpcsFile, $tokens): array {
+			$all = TokenHelper::findNextAll($phpcsFile, T_NAMESPACE, 0);
+			$all = array_filter(
+				$all,
+				static function ($pointer) use ($phpcsFile, $tokens) {
+					$next = TokenHelper::findNextEffective($phpcsFile, $pointer + 1);
+					return $next === null || $tokens[$next]['code'] !== T_NS_SEPARATOR;
+				}
+			);
+
+			return array_values($all);
 		};
 
 		return SniffLocalCache::getAndSetIfNotCached($phpcsFile, 'namespacePointers', $lazyValue);

--- a/tests/Helpers/data/multipleNamespaces.php
+++ b/tests/Helpers/data/multipleNamespaces.php
@@ -7,3 +7,6 @@ new Baz();
 namespace Lorem\Ipsum;
 
 new Dolor();
+
+namespace\functionCallNotADeclaration();
+namespace\CONSTANT_ACCES_NOT_A_DECLARATION;

--- a/tests/Sniffs/Namespaces/UnusedUsesSniffTest.php
+++ b/tests/Sniffs/Namespaces/UnusedUsesSniffTest.php
@@ -294,4 +294,10 @@ class UnusedUsesSniffTest extends TestCase
 		self::assertNoSniffErrorInFile($report);
 	}
 
+	public function testUnusedUseNamespaceOperatorNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/unusedUsesNamespaceOperatorNoErrors.php');
+		self::assertNoSniffErrorInFile($report);
+	}
+
 }

--- a/tests/Sniffs/Namespaces/data/unusedUsesNamespaceOperatorNoErrors.php
+++ b/tests/Sniffs/Namespaces/data/unusedUsesNamespaceOperatorNoErrors.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Foo;
+
+use Bar;
+
+class MyClass {
+	function foobar() {
+		namespace\callMe();
+		if (method_exists( Bar::class, 'method')) {}
+	}
+}


### PR DESCRIPTION
The `namespace` keyword can be used to declare namespaces, but is also allowed as an operator which resolves to the current namespace: `namespace\callMe();`.

This was not taken into account correctly when gathering all namespace declaration pointers.

Discovered via a false positive received from the `Namespaces/UnusedUses` sniff.

Includes tests for both the `NamespaceHelper` method as well as the `Namespaces/UnusedUses` sniff.