### PR TITLE
PHPUnit tweaks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
+          ini-values: error_reporting=-1, display_errors=On, zend.assertions=1
 
       - name: "Reset composer platform"
         if: matrix.php-version == '7.2' || matrix.php-version == '7.3' || matrix.php-version == '7.4'
@@ -77,6 +78,7 @@ jobs:
         with:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
+          ini-values: error_reporting=-1, display_errors=On, zend.assertions=1
 
       - name: "Install dependencies"
         uses: "ramsey/composer-install@v2"
@@ -152,6 +154,7 @@ jobs:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
           extensions: mbstring
+          ini-values: error_reporting=-1, display_errors=On, zend.assertions=1
 
       - name: "Reset composer platform"
         if: matrix.php-version == '7.2' || matrix.php-version == '7.3' || matrix.php-version == '7.4' || matrix.php-version == '8.0'
@@ -188,6 +191,7 @@ jobs:
         with:
           coverage: "pcov"
           php-version: "${{ matrix.php-version }}"
+          ini-values: error_reporting=-1, display_errors=On, zend.assertions=1
 
       - name: "Install dependencies"
         uses: "ramsey/composer-install@v2"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /phpunit.xml
 /temp
 /vendor
+/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 		"phpstan/phpstan-deprecation-rules": "1.1.4",
 		"phpstan/phpstan-phpunit": "1.3.14",
 		"phpstan/phpstan-strict-rules": "1.5.1",
-		"phpunit/phpunit": "7.5.20|8.5.21|9.6.8|10.3.5"
+		"phpunit/phpunit": "8.5.21|9.6.8|10.3.5"
 	},
 	"autoload": {
 		"psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <phpunit
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd"
 	bootstrap="tests/bootstrap.php"
 	colors="true"
 	backupGlobals="false"
@@ -26,10 +26,12 @@
 			<directory suffix="Test.php">./tests/</directory>
 		</testsuite>
 	</testsuites>
-	<coverage>
+	<source>
 		<include>
 			<directory suffix=".php">SlevomatCodingStandard</directory>
 		</include>
+	</source>
+	<coverage>
 		<report>
 			<clover outputFile="temp/coverage.xml"/>
 			<html outputDirectory="temp/coverage"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,6 +13,13 @@
 	stopOnDefect="true"
 	executionOrder="defects"
 	cacheDirectory="temp/phpunit-cache"
+	displayDetailsOnTestsThatTriggerErrors="true"
+	displayDetailsOnTestsThatTriggerWarnings="true"
+	displayDetailsOnTestsThatTriggerNotices="true"
+	displayDetailsOnTestsThatTriggerDeprecations="true"
+	failOnWarning="true"
+	failOnNotice="true"
+	failOnDeprecation="true"
 >
 	<testsuites>
 		<testsuite name="Slevomat Coding Standard">


### PR DESCRIPTION
### .gitignore: ignore PHPUnit cache file

### PHPUnit config: display errors/warnings/notices etc

The config as it was, was hiding 6 `Undefined array key`/`Trying to access array offset on null` notices.

As any notice caused by a sniff will stop a PHPCS scan of a file dead, these should be discovered when running the tests and then fixed.
Better yet: the tests should fail on them. This change in the configuration makes it so.

Note: this does mean you now have a bug to fix.

Also see: squizlabs/PHP_CodeSniffer#3844


### PHPUnit config: upgrade to 10.3 schema

This upgrades the XML configuration to one accepted by PHPUnit 10.3 and higher, which is in line with the PHPUnit requirements in the `composer.json` file.

Note: the configuration will not validate for PHPUnit < 10.3 and will throw warnings, but as code coverage in CI is only run with PHPUnit 10 and the warnings are about that part of the configuration, this is nothing to worry about. Moreover, on PHPUnit 8.x/9.x, those warnings won't fail the build and the tests will still be run.

### GH Actions: turn error reporting on

The default ini file used by the SetupPHP action is the production one, which turns error_reporting/display off.

For the purposes of CI, I'd recommend running with `error_reporting=-1` and `display_errors=On` to ensure **all** PHP notices are shown.

Also see: shivammathur/setup-php#469

### Composer: no need to allow PHPUnit 7.x

PHPUnit 8.x has a minimum supported version of PHP 7.2, so there is no need to include PHPUnit 7.x in the allowed versions.

