### PR TITLE
Revert "replace squizlabs/php_codesniffer with phpcsstandards/php_codesniffer"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Code coverage](https://codecov.io/gh/slevomat/coding-standard/branch/master/graph/badge.svg)](https://codecov.io/gh/slevomat/coding-standard)
 ![PHPStan](https://img.shields.io/badge/style-level%207-brightgreen.svg?&label=phpstan)
 
-Slevomat Coding Standard for [PHP_CodeSniffer](https://github.com/phpcsstandards/PHP_CodeSniffer) provides sniffs that fall into three categories:
+Slevomat Coding Standard for [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) provides sniffs that fall into three categories:
 
 * Functional - improving the safety and behaviour of code
 * Cleaning - detecting dead code
@@ -249,7 +249,7 @@ However it is not a recommended way to use Slevomat Coding Standard, because you
 
 ## Fixing errors automatically
 
-Sniffs in this standard marked by the 🔧 symbol support [automatic fixing of coding standard violations](https://github.com/phpcsstandards/PHP_CodeSniffer/wiki/Fixing-Errors-Automatically). To fix your code automatically, run phpcbf instead of phpcs:
+Sniffs in this standard marked by the 🔧 symbol support [automatic fixing of coding standard violations](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Fixing-Errors-Automatically). To fix your code automatically, run phpcbf instead of phpcs:
 
 ```
 vendor/bin/phpcbf --standard=ruleset.xml --extensions=php --tab-width=4 -sp src tests

--- a/SlevomatCodingStandard/Sniffs/TestCase.php
+++ b/SlevomatCodingStandard/Sniffs/TestCase.php
@@ -21,6 +21,7 @@ use function sprintf;
 use function strlen;
 use function strpos;
 use function substr;
+use function version_compare;
 use const PHP_EOL;
 
 /**
@@ -44,6 +45,16 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 		$codeSniffer->init();
 
 		if (count($sniffProperties) > 0) {
+			/** @phpstan-ignore-next-line */
+			if (version_compare(Config::VERSION, '3.8.0', '>=')) {
+				foreach ($sniffProperties as $name => $value) {
+					$sniffProperties[$name] = [
+						'value' => $value,
+						'scope' => 'sniff',
+					];
+				}
+			}
+
 			$codeSniffer->ruleset->ruleset[self::getSniffName()]['properties'] = $sniffProperties;
 		}
 

--- a/build/PHPStan/phpstan.neon
+++ b/build/PHPStan/phpstan.neon
@@ -12,8 +12,8 @@ parameters:
 		- %currentWorkingDirectory%/SlevomatCodingStandard
 
 	bootstrapFiles:
-		- %currentWorkingDirectory%/vendor/phpcsstandards/php_codesniffer/autoload.php
-		- %currentWorkingDirectory%/vendor/phpcsstandards/php_codesniffer/src/Util/Tokens.php
+		- %currentWorkingDirectory%/vendor/squizlabs/php_codesniffer/autoload.php
+		- %currentWorkingDirectory%/vendor/squizlabs/php_codesniffer/src/Util/Tokens.php
 	excludePaths:
 		- %currentWorkingDirectory%/tests/*/data/*
 	ignoreErrors:

--- a/build/phpcs.xml
+++ b/build/phpcs.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Slevomat Coding Standard" xsi:noNamespaceSchemaLocation="../vendor/phpcsstandards/php_codesniffer/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Slevomat Coding Standard" xsi:noNamespaceSchemaLocation="../vendor/squizlabs/php_codesniffer/phpcs.xsd">
 	<config name="php_version" value="70100"/>
 	<arg name="extensions" value="php"/>
 	<arg name="tab-width" value="4"/>

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"php": "^7.2 || ^8.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
 		"phpstan/phpdoc-parser": "^1.23.1",
-		"phpcsstandards/php_codesniffer": "^3.7.1"
+		"squizlabs/php_codesniffer": "^3.7.1"
 	},
 	"require-dev": {
 		"phing/phing": "2.17.4",

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,4 +3,4 @@
 error_reporting(E_ALL);
 
 require __DIR__ . '/../vendor/autoload.php';
-require __DIR__ . '/../vendor/phpcsstandards/php_codesniffer/autoload.php';
+require __DIR__ . '/../vendor/squizlabs/php_codesniffer/autoload.php';


### PR DESCRIPTION
### Revert "replace squizlabs/php_codesniffer with phpcsstandards/php_codesniffer"

This reverts commit 271394724bf57dd77819f766c450d5543d9c9ab3.

See: https://github.com/slevomat/coding-standard/pull/1641#issuecomment-1843958153

Also: https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/tag/3.8.0

### TestCase: update for new Ruleset::$properties format

Related to the handling of the PHP 8.2 dynamic properties deprecation.

Note: this issue will not block end-users, it is only the test suite which is affected.

Refs:
* https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/tag/3.8.0 (2nd bullet in "Changed")
* https://github.com/squizlabs/PHP_CodeSniffer/pull/3629
* https://github.com/squizlabs/PHP_CodeSniffer/issues/3489