### PR TITLE
issue: DocCommentSpacingSniff - same line

### DIFF
--- a/tests/Sniffs/Commenting/DocCommentSpacingSniffTest.php
+++ b/tests/Sniffs/Commenting/DocCommentSpacingSniffTest.php
@@ -159,7 +159,7 @@ class DocCommentSpacingSniffTest extends TestCase
 			DocCommentSpacingSniff::CODE_INCORRECT_ORDER_OF_ANNOTATIONS_IN_GROUP,
 		]);
 
-		self::assertSame(13, $report->getErrorCount());
+		self::assertSame(15, $report->getErrorCount());
 
 		self::assertSniffError($report, 12, DocCommentSpacingSniff::CODE_INCORRECT_ORDER_OF_ANNOTATIONS_GROUPS);
 		self::assertSniffError($report, 23, DocCommentSpacingSniff::CODE_INCORRECT_ANNOTATIONS_GROUP);
@@ -172,8 +172,9 @@ class DocCommentSpacingSniffTest extends TestCase
 		self::assertSniffError($report, 95, DocCommentSpacingSniff::CODE_INCORRECT_ANNOTATIONS_GROUP);
 		self::assertSniffError($report, 105, DocCommentSpacingSniff::CODE_INCORRECT_ANNOTATIONS_GROUP);
 		self::assertSniffError($report, 118, DocCommentSpacingSniff::CODE_INCORRECT_ANNOTATIONS_GROUP);
-		self::assertSniffError($report, 133, DocCommentSpacingSniff::CODE_INCORRECT_ANNOTATIONS_GROUP);
-		self::assertSniffError($report, 164, DocCommentSpacingSniff::CODE_INCORRECT_ANNOTATIONS_GROUP);
+		self::assertSniffError($report, 125, DocCommentSpacingSniff::CODE_INCORRECT_LINES_COUNT_BETWEEN_ANNOTATIONS_GROUPS);
+		self::assertSniffError($report, 138, DocCommentSpacingSniff::CODE_INCORRECT_ANNOTATIONS_GROUP);
+		self::assertSniffError($report, 169, DocCommentSpacingSniff::CODE_INCORRECT_ANNOTATIONS_GROUP);
 
 		self::assertAllFixedInFile($report);
 	}

--- a/tests/Sniffs/Commenting/data/docCommentSpacingAnnotationsGroupsErrors.fixed.php
+++ b/tests/Sniffs/Commenting/data/docCommentSpacingAnnotationsGroupsErrors.fixed.php
@@ -126,6 +126,14 @@ class Whatever
 		return [];
 	}
 
+	/**
+	 * @see self::method()
+	 * @link https://example.com
+	 */
+	public function sameLine()
+	{
+	}
+
 }
 
 class Doctrine

--- a/tests/Sniffs/Commenting/data/docCommentSpacingAnnotationsGroupsErrors.php
+++ b/tests/Sniffs/Commenting/data/docCommentSpacingAnnotationsGroupsErrors.php
@@ -122,6 +122,11 @@ class Whatever
 		return [];
 	}
 
+	/** @see self::method() @link https://example.com */
+	public function sameLine()
+	{
+	}
+
 }
 
 class Doctrine


### PR DESCRIPTION
When we have two PHPDocs in a single line we are getting an error:

```console
| ERROR | [x] Expected 1 line between annotations groups, found -1. (SlevomatCodingStandard.Commenting.DocCommentSpacing.IncorrectLinesCountBetweenAnnotationsGroups)
```

but it is not possible to fix it automatically.

And I am not sure how to fix in in the code atm, so just providing the failing example... Thanks!