### PR TITLE
Custom method groups order

### DIFF
--- a/doc/classes.md
+++ b/doc/classes.md
@@ -45,6 +45,7 @@ Checks that class/trait/interface members are in the correct order.
 Sniff provides the following settings:
 
 * `groups`: order of groups. Use multiple groups in one `<element value="">` to not differentiate among them. You can use specific groups or shortcuts.
+* `methodGroups`: custom method groups. Define a custom group for special methods based on their name, annotation, or attribute.
 
 **List of supported groups**:
 uses,
@@ -63,6 +64,10 @@ constants, properties, static properties, methods, all public methods, all prote
 ```xml
 <rule ref="SlevomatCodingStandard.Classes.ClassStructure">
 	<properties>
+		<property name="methodGroups" type="array">
+			<element key="phpunit before" value="setUp, @before, #PHPUnit\Framework\Attributes\Before"/>
+		</property>
+
 		<property name="groups" type="array">
 			<element value="uses"/>
 
@@ -77,6 +82,9 @@ constants, properties, static properties, methods, all public methods, all prote
 
 			<!-- Constructor is first, then all public methods, then protected/private methods and magic methods are last -->
 			<element value="constructor"/>
+
+			<!-- PHPUnit's before hooks are placed before all other public methods using a custom method group regardless their visibility -->
+			<element value="phpunit before"/>
 			<element value="all public methods"/>
 			<element value="methods"/>
 			<element value="magic methods"/>

--- a/tests/Sniffs/Classes/ClassStructureSniffTest.php
+++ b/tests/Sniffs/Classes/ClassStructureSniffTest.php
@@ -26,6 +26,45 @@ class ClassStructureSniffTest extends TestCase
 		'protected static final methods',
 	];
 
+	private const METHOD_GROUPS = [
+		'phpunit before class' => 'setUpBeforeClass, @beforeClass, #PHPUnit\Framework\Attributes\BeforeClass',
+		'phpunit after class' => 'tearDownAfterClass, @afterClass, #PHPUnit\Framework\Attributes\AfterClass',
+		'phpunit before' => 'setUp, @before, #PHPUnit\Framework\Attributes\Before',
+		'phpunit after' => 'tearDown, @after, #PHPUnit\Framework\Attributes\After',
+	];
+
+	private const METHOD_GROUP_RULES = [
+		'uses',
+		'public constants',
+		'protected constants',
+		'private constants',
+		'enum cases',
+		'public static properties',
+		'protected static properties',
+		'private static properties',
+		'public properties',
+		'protected properties',
+		'private properties',
+		'constructor',
+		'static constructors',
+		'destructor',
+		'phpunit before class',
+		'phpunit after class',
+		'phpunit before',
+		'phpunit after',
+		'public methods, public final methods',
+		'public abstract methods',
+		'public static methods, public static final methods',
+		'public static abstract methods',
+		'magic methods',
+		'protected methods, protected final methods',
+		'protected abstract methods',
+		'protected static methods, protected static final methods',
+		'protected static abstract methods',
+		'private methods',
+		'private static methods',
+	];
+
 	public function testNoErrors(): void
 	{
 		$report = self::checkFile(__DIR__ . '/data/classStructureSniffNoErrors.php');
@@ -144,6 +183,38 @@ class ClassStructureSniffTest extends TestCase
 		);
 
 		self::assertSame(10, $report->getErrorCount());
+		self::assertAllFixedInFile($report);
+	}
+
+	public function testNoErrorsWithMethodGroupRules(): void
+	{
+		$report = self::checkFile(
+			__DIR__ . '/data/classStructureSniffNoErrorsWithMethodGroupRules.php',
+			[
+				'methodGroups' => self::METHOD_GROUPS,
+				'groups' => self::METHOD_GROUP_RULES,
+			],
+		);
+
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testErrorsWithMethodGroupRules(): void
+	{
+		$report = self::checkFile(
+			__DIR__ . '/data/classStructureSniffErrorsWithMethodGroupRules.php',
+			[
+				'methodGroups' => self::METHOD_GROUPS,
+				'groups' => self::METHOD_GROUP_RULES,
+			],
+		);
+
+		self::assertSame(5, $report->getErrorCount());
+		self::assertSniffError($report, 22, ClassStructureSniff::CODE_INCORRECT_GROUP_ORDER);
+		self::assertSniffError($report, 33, ClassStructureSniff::CODE_INCORRECT_GROUP_ORDER);
+		self::assertSniffError($report, 44, ClassStructureSniff::CODE_INCORRECT_GROUP_ORDER);
+		self::assertSniffError($report, 48, ClassStructureSniff::CODE_INCORRECT_GROUP_ORDER);
+		self::assertSniffError($report, 67, ClassStructureSniff::CODE_INCORRECT_GROUP_ORDER);
 		self::assertAllFixedInFile($report);
 	}
 

--- a/tests/Sniffs/Classes/data/classStructureSniffErrorsWithMethodGroupRules.fixed.php
+++ b/tests/Sniffs/Classes/data/classStructureSniffErrorsWithMethodGroupRules.fixed.php
@@ -1,0 +1,70 @@
+<?php
+
+class ClassStructureSniffErrorsWithMethodGroupRulesData
+{
+	public function __construct()
+	{
+	}
+
+	public function __destruct()
+	{
+	}
+
+	public static function setUpBeforeClass()
+	{
+	}
+
+	#[PHPUnit\Framework\Attributes\BeforeClass]
+	public static function beforeClassUsingAttribute()
+	{
+	}
+
+	/**
+	 * @beforeClass
+	 */
+	public static function beforeClassUsingAnnotation()
+	{
+	}
+
+	#[PHPUnit\Framework\Attributes\Before]
+	protected function beforeUsingAttribute()
+	{
+	}
+
+	protected function setUp()
+	{
+	}
+
+	/**
+	 * @before
+	 */
+	protected function beforeUsingAnnotation()
+	{
+	}
+
+	#[PHPUnit\Framework\Attributes\After]
+	#[ReturnTypeWillChange]
+	protected function afterUsingAttribute()
+	{
+	}
+
+	/**
+	 * @after
+	 */
+	#[ReturnTypeWillChange]
+	protected function afterUsingAnnotation()
+	{
+	}
+
+	public function lorem()
+	{
+	}
+
+	protected function ipsum()
+	{
+	}
+
+	private function dolor()
+	{
+	}
+}

--- a/tests/Sniffs/Classes/data/classStructureSniffErrorsWithMethodGroupRules.php
+++ b/tests/Sniffs/Classes/data/classStructureSniffErrorsWithMethodGroupRules.php
@@ -1,0 +1,70 @@
+<?php
+
+class ClassStructureSniffErrorsWithMethodGroupRulesData
+{
+	public function __construct()
+	{
+	}
+
+	public function __destruct()
+	{
+	}
+
+	#[PHPUnit\Framework\Attributes\Before]
+	protected function beforeUsingAttribute()
+	{
+	}
+
+	public function lorem()
+	{
+	}
+
+	public static function setUpBeforeClass()
+	{
+	}
+
+	#[PHPUnit\Framework\Attributes\BeforeClass]
+	public static function beforeClassUsingAttribute()
+	{
+	}
+
+	#[PHPUnit\Framework\Attributes\After]
+	#[ReturnTypeWillChange]
+	protected function afterUsingAttribute()
+	{
+	}
+
+	protected function ipsum()
+	{
+	}
+
+	/**
+	 * @beforeClass
+	 */
+	public static function beforeClassUsingAnnotation()
+	{
+	}
+
+	protected function setUp()
+	{
+	}
+
+	/**
+	 * @before
+	 */
+	protected function beforeUsingAnnotation()
+	{
+	}
+
+	private function dolor()
+	{
+	}
+
+	/**
+	 * @after
+	 */
+	#[ReturnTypeWillChange]
+	protected function afterUsingAnnotation()
+	{
+	}
+}

--- a/tests/Sniffs/Classes/data/classStructureSniffNoErrorsWithMethodGroupRules.php
+++ b/tests/Sniffs/Classes/data/classStructureSniffNoErrorsWithMethodGroupRules.php
@@ -1,0 +1,70 @@
+<?php
+
+class ClassStructureSniffNoErrorsWithMethodGroupRulesData
+{
+	public function __construct()
+	{
+	}
+
+	public function __destruct()
+	{
+	}
+
+	public static function setUpBeforeClass()
+	{
+	}
+
+	#[PHPUnit\Framework\Attributes\BeforeClass]
+	public static function beforeClassUsingAttribute()
+	{
+	}
+
+	/**
+	 * @beforeClass
+	 */
+	public static function beforeClassUsingAnnotation()
+	{
+	}
+
+	protected function setUp()
+	{
+	}
+
+	#[PHPUnit\Framework\Attributes\Before]
+	protected function beforeUsingAttribute()
+	{
+	}
+
+	/**
+	 * @before
+	 */
+	protected function beforeUsingAnnotation()
+	{
+	}
+
+	#[PHPUnit\Framework\Attributes\After]
+	#[ReturnTypeWillChange]
+	protected function afterUsingAttribute()
+	{
+	}
+
+	/**
+	 * @after
+	 */
+	#[ReturnTypeWillChange]
+	protected function afterUsingAnnotation()
+	{
+	}
+
+	public function lorem()
+	{
+	}
+
+	protected function ipsum()
+	{
+	}
+
+	private function dolor()
+	{
+	}
+}


### PR DESCRIPTION
Define custom groups for ClassStructureSniff based on method name, annotation, or attribute.
It bothered me I cannot place static `#[BeforeClass]` before public test methods.
see https://github.com/slevomat/coding-standard/pull/1679/files#diff-15e77f559a2e54d8f075cefd9d6b4cb5ad5efc4d1e753ab60d41f05aa46fd380 for usage
resolves #1098
resolves #1422