### PR TITLE
`SlevomatCodingStandard.Classes.ClassStructure`: Group for __invoke method

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Classes/ClassStructureSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/ClassStructureSniff.php
@@ -60,6 +60,7 @@ class ClassStructureSniff implements Sniff
 	private const GROUP_CONSTRUCTOR = 'constructor';
 	private const GROUP_STATIC_CONSTRUCTORS = 'static constructors';
 	private const GROUP_DESTRUCTOR = 'destructor';
+	private const GROUP_INVOKE_METHOD = 'invoke method';
 	private const GROUP_MAGIC_METHODS = 'magic methods';
 	private const GROUP_PUBLIC_METHODS = 'public methods';
 	private const GROUP_PUBLIC_ABSTRACT_METHODS = 'public abstract methods';
@@ -153,6 +154,7 @@ class ClassStructureSniff implements Sniff
 			self::GROUP_SHORTCUT_STATIC_METHODS,
 			self::GROUP_CONSTRUCTOR,
 			self::GROUP_DESTRUCTOR,
+			self::GROUP_INVOKE_METHOD,
 			self::GROUP_PUBLIC_METHODS,
 			self::GROUP_PROTECTED_METHODS,
 			self::GROUP_PRIVATE_METHODS,
@@ -174,7 +176,7 @@ class ClassStructureSniff implements Sniff
 		'__serialize' => self::GROUP_MAGIC_METHODS,
 		'__unserialize' => self::GROUP_MAGIC_METHODS,
 		'__tostring' => self::GROUP_MAGIC_METHODS,
-		'__invoke' => self::GROUP_MAGIC_METHODS,
+		'__invoke' => self::GROUP_INVOKE_METHOD,
 		'__set_state' => self::GROUP_MAGIC_METHODS,
 		'__clone' => self::GROUP_MAGIC_METHODS,
 		'__debuginfo' => self::GROUP_MAGIC_METHODS,
@@ -576,6 +578,7 @@ class ClassStructureSniff implements Sniff
 				self::GROUP_CONSTRUCTOR,
 				self::GROUP_STATIC_CONSTRUCTORS,
 				self::GROUP_DESTRUCTOR,
+				self::GROUP_INVOKE_METHOD,
 				self::GROUP_PUBLIC_METHODS,
 				self::GROUP_PUBLIC_STATIC_METHODS,
 				self::GROUP_PROTECTED_METHODS,


### PR DESCRIPTION
As mentioned in issue #1471, we need to give special treatment to __invoke methods. In some applications, __invoke methods are as important as __construct methods, such as in EventHandler, CommandHandler, and invokable controllers.

Adding this specific “invoke” case might be much easier than handling individual method names, as discussed in issue #1098.