### PR TITLE
DeclareStrictTypesSniff: Fixing number of empty lines after line comment

### DIFF
--- a/tests/Sniffs/TypeHints/DeclareStrictTypesSniffTest.php
+++ b/tests/Sniffs/TypeHints/DeclareStrictTypesSniffTest.php
@@ -161,6 +161,14 @@ class DeclareStrictTypesSniffTest extends TestCase
 		self::assertNoSniffErrorInFile($report);
 	}
 
+	public function testDeclareStrictWithLineCommentAbove(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/declareStrictTypesWithLineCommentAbove.php', [
+			'linesCountBeforeDeclare' => 1,
+		]);
+		self::assertNoSniffErrorInFile($report);
+	}
+
 	public function testDeclareStrictWithTicks(): void
 	{
 		$report = self::checkFile(__DIR__ . '/data/declareStrictTypesWithTicks.php', [
@@ -228,6 +236,14 @@ class DeclareStrictTypesSniffTest extends TestCase
 	public function testFixableCommentBefore(): void
 	{
 		$report = self::checkFile(__DIR__ . '/data/fixableDeclareStrictTypesCommentBefore.php', [
+			'linesCountBeforeDeclare' => 1,
+		], [DeclareStrictTypesSniff::CODE_INCORRECT_WHITESPACE_BEFORE_DECLARE]);
+		self::assertAllFixedInFile($report);
+	}
+
+	public function testFixableLineCommentBefore(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/fixableDeclareStrictTypesLineCommentBefore.php', [
 			'linesCountBeforeDeclare' => 1,
 		], [DeclareStrictTypesSniff::CODE_INCORRECT_WHITESPACE_BEFORE_DECLARE]);
 		self::assertAllFixedInFile($report);

--- a/tests/Sniffs/TypeHints/data/declareStrictTypesWithLineCommentAbove.php
+++ b/tests/Sniffs/TypeHints/data/declareStrictTypesWithLineCommentAbove.php
@@ -1,0 +1,5 @@
+<?php
+
+// Comment across the entire line, it does not contain any whitespace token.
+
+declare(strict_types = 1);

--- a/tests/Sniffs/TypeHints/data/fixableDeclareStrictTypesLineCommentBefore.fixed.php
+++ b/tests/Sniffs/TypeHints/data/fixableDeclareStrictTypesLineCommentBefore.fixed.php
@@ -1,0 +1,5 @@
+<?php
+
+//
+
+declare(strict_types = 1);

--- a/tests/Sniffs/TypeHints/data/fixableDeclareStrictTypesLineCommentBefore.php
+++ b/tests/Sniffs/TypeHints/data/fixableDeclareStrictTypesLineCommentBefore.php
@@ -1,0 +1,4 @@
+<?php
+
+//
+declare(strict_types = 1);


### PR DESCRIPTION
When the previous effective token before declare statement is line comment (`// ...`/`# ..`), the comment spans across the entire line and there is no newline whitespace token. The number of lines was counter incorrectly in such case.