### PR TITLE
DisallowMixedTypeHintSniff does not report error when attribute #[Ove…

### DIFF
--- a/tests/Sniffs/TypeHints/data/disallowMixedTypeHintNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/disallowMixedTypeHintNoErrors.php
@@ -22,4 +22,28 @@ class Whatever
 	 */
 	private $suppressed;
 
+	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint
+	 * @var array<mixed>
+	 */
+	#[Attribute1]
+	public function foo(array $mixed)
+	{
+		return $mixed === true;
+	}
+
+}
+
+class WhateverOverridden extends Whatever
+{
+
+	/**
+	 * @var array<mixed>
+	 */
+	#[\Override]
+	public function foo(array $mixed)
+	{
+		return $mixed === false;
+	}
+
 }


### PR DESCRIPTION
DisallowMixedTypeHintSniff does not report error when attribute #[Override] is presented.