### PR TITLE
Helper/TokenHelper: remove use of T_ARRAY_HINT

### DIFF
--- a/SlevomatCodingStandard/Helpers/TokenHelper.php
+++ b/SlevomatCodingStandard/Helpers/TokenHelper.php
@@ -8,7 +8,6 @@ use function array_merge;
 use function count;
 use const T_ANON_CLASS;
 use const T_ARRAY;
-use const T_ARRAY_HINT;
 use const T_BREAK;
 use const T_CALLABLE;
 use const T_CLASS;
@@ -502,7 +501,6 @@ class TokenHelper
 				[
 					T_SELF,
 					T_PARENT,
-					T_ARRAY_HINT,
 					T_CALLABLE,
 					T_FALSE,
 					T_TRUE,


### PR DESCRIPTION
This token was deprecated in PHPCS 3.3.0 and has been unused in PHPCS since, so no need to look for it as the minimum PHPCS version for this standard is PHPCS 3.9.0.