### PR TITLE
Fix ConstantSpacingSniff & EnumCaseSpacingSniff warnings

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Classes/ConstantSpacingSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/ConstantSpacingSniff.php
@@ -59,7 +59,7 @@ class ConstantSpacingSniff extends AbstractPropertyConstantAndEnumCaseSpacing
 
 		$nextPointer = TokenHelper::findNext($phpcsFile, [T_FUNCTION, T_ENUM_CASE, T_CONST, T_VARIABLE, T_USE], $pointer + 1);
 
-		return $tokens[$nextPointer]['code'] === T_CONST;
+		return $nextPointer !== null && $tokens[$nextPointer]['code'] === T_CONST;
 	}
 
 	protected function addError(File $phpcsFile, int $pointer, int $minExpectedLines, int $maxExpectedLines, int $found): bool

--- a/SlevomatCodingStandard/Sniffs/Classes/EnumCaseSpacingSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/EnumCaseSpacingSniff.php
@@ -34,7 +34,7 @@ class EnumCaseSpacingSniff extends AbstractPropertyConstantAndEnumCaseSpacing
 
 		$nextPointer = TokenHelper::findNext($phpcsFile, [T_FUNCTION, T_CONST, T_VARIABLE, T_USE, T_ENUM_CASE], $pointer + 1);
 
-		return $tokens[$nextPointer]['code'] === T_ENUM_CASE;
+		return $nextPointer !== null && $tokens[$nextPointer]['code'] === T_ENUM_CASE;
 	}
 
 	protected function addError(File $phpcsFile, int $pointer, int $minExpectedLines, int $maxExpectedLines, int $found): bool

--- a/tests/Sniffs/Classes/data/constantSpacingNoErrors.php
+++ b/tests/Sniffs/Classes/data/constantSpacingNoErrors.php
@@ -54,6 +54,13 @@ class TestClass
 	private const CONSTANT_2 = 'bar';
 }
 
+class TestClass1
+{
+	public const CONSTANT_1 = 'foo';
+
+	use TestTrait;
+}
+
 enum A: string
 {
 	public const X = [];
@@ -61,4 +68,11 @@ enum A: string
 	case A = 'a';
 
 	case B = 'b';
+}
+
+enum B: string
+{
+	public const X = [];
+
+	case A = 'a';
 }

--- a/tests/Sniffs/Classes/data/enumCaseSpacingNoErrors.php
+++ b/tests/Sniffs/Classes/data/enumCaseSpacingNoErrors.php
@@ -44,3 +44,10 @@ enum TestClass
 
 	case BAR;
 }
+
+enum TestClass1
+{
+	case FOO;
+
+	use TestTrait;
+}


### PR DESCRIPTION
In some cases ConstantSpacingSniff and EnumCaseSpacingSniff produce warnings, see latest [comment](https://github.com/slevomat/coding-standard/issues/1620#issuecomment-1758006718) on issue [ConstantSpacingSniff warning](https://github.com/slevomat/coding-standard/issues/1620)