### PR TITLE
TypeHints/DisallowMixedTypeHint: fix logic error

### DIFF
--- a/SlevomatCodingStandard/Sniffs/TypeHints/DisallowMixedTypeHintSniff.php
+++ b/SlevomatCodingStandard/Sniffs/TypeHints/DisallowMixedTypeHintSniff.php
@@ -83,7 +83,7 @@ class DisallowMixedTypeHintSniff implements Sniff
 		$tokens = $phpcsFile->getTokens();
 		$nextPointer = TokenHelper::findNextEffective($phpcsFile, $docCommentOpenPointer + 1);
 
-		if ($tokens[$nextPointer]['code'] !== T_ATTRIBUTE) {
+		if ($nextPointer === null || $tokens[$nextPointer]['code'] !== T_ATTRIBUTE) {
 			return false;
 		}
 

--- a/tests/Sniffs/TypeHints/data/disallowMixedTypeHintNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/disallowMixedTypeHintNoErrors.php
@@ -47,3 +47,8 @@ class WhateverOverridden extends Whatever
 	}
 
 }
+
+/**
+ * This MUST be the last docblock in the test file and there must not be any code
+ * after this line for the test to be valid.
+ */


### PR DESCRIPTION
If a file only contains a placeholder docblock (typically an empty `index.php` file in a OS project which doesn't have control over server configuration), it is possible for the `TokenHelper::findNextEffective()` method to return `null`.

As the code didn't take this into account, this led to the following error:
```
 1 | ERROR | [ ] An error occurred during processing; checking has been aborted. The error message was: Undefined array
   |       |     key "" in
   |       |     path/to/SlevomatCodingStandard/Sniffs/TypeHints/DisallowMixedTypeHintSniff.php on
   |       |     line 86
   |       |     The error originated in the SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint sniff on line 86.
   |       |     (Internal.Exception)
```