### PR TITLE
Fix typo for new RequireNullCoalesceEqualOperator flag

### DIFF
--- a/doc/control-structures.md
+++ b/doc/control-structures.md
@@ -194,7 +194,7 @@ Requires use of null coalesce equal operator when possible.
 This sniff provides the following setting:
 
 * `enable`: either to enable or not this sniff. By default, it is enabled for PHP versions 7.4 or higher.
-* `checkIfCondition` (default: `false`): will check `if` conditions too.
+* `checkIfConditions` (default: `false`): will check `if` conditions too.
 
 #### SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator 🔧
 


### PR DESCRIPTION
See also https://github.com/slevomat/coding-standard/commit/203137338491a97d68da31d53f96617e9938a919#diff-4febc264375453662d26cc68746517deab6a1140267dce334766fd0fc755cf1e