### PR TITLE
RequireMultiLineCall: Fix when multiline call exactly fits into the line length limit

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Functions/RequireMultiLineCallSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Functions/RequireMultiLineCallSniff.php
@@ -107,7 +107,7 @@ class RequireMultiLineCallSniff extends AbstractLineCall
 			$lineEnd = $this->getLineEnd($phpcsFile, $parenthesisCloserPointer);
 			$lineLength = strlen($lineStart . $call . $lineEnd);
 		} else {
-			$lineEnd = $this->getLineEnd($phpcsFile, $parenthesisOpenerPointer);
+			$lineEnd = $this->getLineEnd($phpcsFile, $parenthesisOpenerPointer + 1);
 			$lineLength = strlen($lineStart . $lineEnd);
 		}
 

--- a/tests/Sniffs/Functions/data/requireMultiLineCallNoErrors.php
+++ b/tests/Sniffs/Functions/data/requireMultiLineCallNoErrors.php
@@ -34,3 +34,7 @@ printf(
 $array = array_merge([], array_map(function (): string {
 	return 'very looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong value';
 }, []));
+
+$array = array_map(['a loooooooooooooooooong value that exactly fits into the line length limit'], function (): string {
+	return 'foo';
+});


### PR DESCRIPTION
Fixing reporting error for a multiline call that exactly fits into the line length limit.


```php
$array = array_map(['a loooooooooooooooooong value that exactly fits into the line length limit'], function (): string {
    return 'foo';
});
```

Here, `$lineStart` would be `        $array = array_map(`.
Previously, `$lineEnd` was `(['a loooooooooooooooooong value that exactly fits into the line length limit'], function (): string {`.
It was including the opening parenthesis `(` again, so `$lineLength` of this line was `121` instead of `120`.