### PR TITLE
InlineDocCommentDeclarationSniff: fix error when no code is found after @var

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Commenting/InlineDocCommentDeclarationSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Commenting/InlineDocCommentDeclarationSniff.php
@@ -120,7 +120,7 @@ class InlineDocCommentDeclarationSniff implements Sniff
 
 		if ($this->allowDocCommentAboveReturn) {
 			$pointerAfterCommentClosePointer = TokenHelper::findNextEffective($phpcsFile, $commentClosePointer + 1);
-			if ($tokens[$pointerAfterCommentClosePointer]['code'] === T_RETURN) {
+			if ($pointerAfterCommentClosePointer === null || $tokens[$pointerAfterCommentClosePointer]['code'] === T_RETURN) {
 				return;
 			}
 		}

--- a/tests/Sniffs/Commenting/data/inlineDocDocommentDeclarationWithDocCommentAboveReturnAllowedNoErrors.php
+++ b/tests/Sniffs/Commenting/data/inlineDocDocommentDeclarationWithDocCommentAboveReturnAllowedNoErrors.php
@@ -4,3 +4,7 @@ function ($a) {
 	/** @var string */
 	return $a;
 };
+
+/**
+ * @var string $foo
+ */


### PR DESCRIPTION
Currently, with `allowDocCommentAboveReturn` set to `true`, the sniff errors with `Undefined array key "" in InlineDocCommentDeclarationSniff.php on line 123` when a `@var` annotation is not followed by any other code, because `$pointerAfterCommentClosePointer` ends up being `null` in that case.
