### PR TITLE
RequireConstructorPropertyPromotion: Properly autofixing arguments with attribute

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Classes/RequireConstructorPropertyPromotionSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/RequireConstructorPropertyPromotionSniff.php
@@ -201,7 +201,11 @@ class RequireConstructorPropertyPromotionSniff implements Sniff
 					TokenHelper::findNextNonWhitespace($phpcsFile, $propertyEndPointer + 1),
 				);
 
-				$pointerBeforeParameterStart = TokenHelper::findPrevious($phpcsFile, [T_COMMA, T_OPEN_PARENTHESIS], $parameterPointer - 1);
+				$pointerBeforeParameterStart = TokenHelper::findPrevious(
+					$phpcsFile,
+					[T_COMMA, T_OPEN_PARENTHESIS, T_ATTRIBUTE_END],
+					$parameterPointer - 1,
+				);
 				$parameterStartPointer = TokenHelper::findNextEffective($phpcsFile, $pointerBeforeParameterStart + 1);
 
 				$parameterEqualPointer = TokenHelper::findNextEffective($phpcsFile, $parameterPointer + 1);

--- a/tests/Sniffs/Classes/RequireConstructorPropertyPromotionSniffTest.php
+++ b/tests/Sniffs/Classes/RequireConstructorPropertyPromotionSniffTest.php
@@ -21,7 +21,7 @@ class RequireConstructorPropertyPromotionSniffTest extends TestCase
 			'enable' => true,
 		]);
 
-		self::assertSame(7, $report->getErrorCount());
+		self::assertSame(9, $report->getErrorCount());
 
 		self::assertSniffError(
 			$report,
@@ -64,6 +64,18 @@ class RequireConstructorPropertyPromotionSniffTest extends TestCase
 			44,
 			RequireConstructorPropertyPromotionSniff::CODE_REQUIRED_CONSTRUCTOR_PROPERTY_PROMOTION,
 			'Required promotion of property $from.',
+		);
+		self::assertSniffError(
+			$report,
+			60,
+			RequireConstructorPropertyPromotionSniff::CODE_REQUIRED_CONSTRUCTOR_PROPERTY_PROMOTION,
+			'Required promotion of property $login.',
+		);
+		self::assertSniffError(
+			$report,
+			61,
+			RequireConstructorPropertyPromotionSniff::CODE_REQUIRED_CONSTRUCTOR_PROPERTY_PROMOTION,
+			'Required promotion of property $password.',
 		);
 
 		self::assertAllFixedInFile($report);

--- a/tests/Sniffs/Classes/data/requireConstructorPropertyPromotionErrors.fixed.php
+++ b/tests/Sniffs/Classes/data/requireConstructorPropertyPromotionErrors.fixed.php
@@ -28,3 +28,16 @@ class DontKnow
 	}
 
 }
+
+class Credentials
+{
+
+	public function __construct(
+		#[\SensitiveParameter]
+		private string $login,
+		#[\SensitiveParameter]
+		private string $password
+	) {
+	}
+
+}

--- a/tests/Sniffs/Classes/data/requireConstructorPropertyPromotionErrors.php
+++ b/tests/Sniffs/Classes/data/requireConstructorPropertyPromotionErrors.php
@@ -53,3 +53,21 @@ class DontKnow
 	}
 
 }
+
+class Credentials
+{
+
+	private string $login;
+	private string $password;
+
+	public function __construct(
+		#[\SensitiveParameter]
+		string $login,
+		#[\SensitiveParameter]
+		string $password
+	) {
+		$this->login = $login;
+		$this->password = $password;
+	}
+
+}


### PR DESCRIPTION
It was incorrectly fixing to the following:

```diff
public function __construct(
-    #[\SensitiveParameter]
-    private string $login,
-    #[\SensitiveParameter]
-    private string $password
+    private #[\SensitiveParameter]
+    string $login,
+    private #[\SensitiveParameter]
+    string $password
) {
```