### PR TITLE
SlevomatCodingStandard.TypeHints.ClassConstantTypeHint: fixing only private constants

### DIFF
--- a/doc/type-hints.md
+++ b/doc/type-hints.md
@@ -8,6 +8,7 @@
 Sniff provides the following settings:
 
 * `enableNativeTypeHint`: enforces native typehint. It's on by default if you're on PHP 8.3+
+* `fixableNativeTypeHint`: (default: `yes`) allows fixing native type hints. Use `no` to disable fixing, or `private` to fix only private constants (safer for inheritance/interface compatibility).
 
 #### SlevomatCodingStandard.TypeHints.DeclareStrictTypes 🔧
 

--- a/tests/Sniffs/TypeHints/ClassConstantTypeHintSniffTest.php
+++ b/tests/Sniffs/TypeHints/ClassConstantTypeHintSniffTest.php
@@ -43,6 +43,22 @@ class ClassConstantTypeHintSniffTest extends TestCase
 		self::assertAllFixedInFile($report);
 	}
 
+	public function testNativeTypeHintPrivateErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/classConstantTypeHintNativePrivateErrors.php', [
+			'enableNativeTypeHint' => true,
+			'fixableNativeTypeHint' => 'private',
+		]);
+
+		self::assertSame(4, $report->getErrorCount());
+
+		foreach (range(6, 9) as $line) {
+			self::assertSniffError($report, $line, ClassConstantTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
+		}
+
+		self::assertAllFixedInFile($report);
+	}
+
 	public function testUselessDocCommentNoErrors(): void
 	{
 		$report = self::checkFile(__DIR__ . '/data/classConstantTypeHintUselessDocCommentNoErrors.php', [

--- a/tests/Sniffs/TypeHints/data/classConstantTypeHintNativePrivateErrors.fixed.php
+++ b/tests/Sniffs/TypeHints/data/classConstantTypeHintNativePrivateErrors.fixed.php
@@ -1,0 +1,11 @@
+<?php // lint >= 8.3
+
+class Whatever
+{
+
+	const C_IMPLICIT_PUBLIC = 'implicit_public';
+	public const C_EXPLICIT_PUBLIC = 'explicit_public';
+	protected const C_PROTECTED = 'protected';
+	private const string C_PRIVATE = 'private';
+
+}

--- a/tests/Sniffs/TypeHints/data/classConstantTypeHintNativePrivateErrors.php
+++ b/tests/Sniffs/TypeHints/data/classConstantTypeHintNativePrivateErrors.php
@@ -1,0 +1,11 @@
+<?php // lint >= 8.3
+
+class Whatever
+{
+
+	const C_IMPLICIT_PUBLIC = 'implicit_public';
+	public const C_EXPLICIT_PUBLIC = 'explicit_public';
+	protected const C_PROTECTED = 'protected';
+	private const C_PRIVATE = 'private';
+
+}


### PR DESCRIPTION
It is dangerous to automatically add typehints for other than private constants as the type might not be compatible with constants in the inheritance chain or implemented interfaces.

Or if you prefered this to be configurable, I could make it configurable.