### PR TITLE
SlevomatCodingStandard.Classes.ClassMemberSpacing: Prevent deleting code

### DIFF
--- a/tests/Sniffs/Classes/ClassMemberSpacingSniffTest.php
+++ b/tests/Sniffs/Classes/ClassMemberSpacingSniffTest.php
@@ -17,7 +17,7 @@ class ClassMemberSpacingSniffTest extends TestCase
 	{
 		$report = self::checkFile(__DIR__ . '/data/classMemberSpacingErrors.php');
 
-		self::assertSame(9, $report->getErrorCount());
+		self::assertSame(10, $report->getErrorCount());
 
 		self::assertSniffError($report, 15, ClassMemberSpacingSniff::CODE_INCORRECT_COUNT_OF_BLANK_LINES_BETWEEN_MEMBERS);
 		self::assertSniffError($report, 21, ClassMemberSpacingSniff::CODE_INCORRECT_COUNT_OF_BLANK_LINES_BETWEEN_MEMBERS);
@@ -26,8 +26,9 @@ class ClassMemberSpacingSniffTest extends TestCase
 		self::assertSniffError($report, 44, ClassMemberSpacingSniff::CODE_INCORRECT_COUNT_OF_BLANK_LINES_BETWEEN_MEMBERS);
 		self::assertSniffError($report, 47, ClassMemberSpacingSniff::CODE_INCORRECT_COUNT_OF_BLANK_LINES_BETWEEN_MEMBERS);
 		self::assertSniffError($report, 50, ClassMemberSpacingSniff::CODE_INCORRECT_COUNT_OF_BLANK_LINES_BETWEEN_MEMBERS);
-		self::assertSniffError($report, 60, ClassMemberSpacingSniff::CODE_INCORRECT_COUNT_OF_BLANK_LINES_BETWEEN_MEMBERS);
-		self::assertSniffError($report, 69, ClassMemberSpacingSniff::CODE_INCORRECT_COUNT_OF_BLANK_LINES_BETWEEN_MEMBERS);
+		self::assertSniffError($report, 58, ClassMemberSpacingSniff::CODE_INCORRECT_COUNT_OF_BLANK_LINES_BETWEEN_MEMBERS);
+		self::assertSniffError($report, 70, ClassMemberSpacingSniff::CODE_INCORRECT_COUNT_OF_BLANK_LINES_BETWEEN_MEMBERS);
+		self::assertSniffError($report, 79, ClassMemberSpacingSniff::CODE_INCORRECT_COUNT_OF_BLANK_LINES_BETWEEN_MEMBERS);
 
 		self::assertAllFixedInFile($report);
 	}
@@ -38,10 +39,21 @@ class ClassMemberSpacingSniffTest extends TestCase
 			'linesCountBetweenMembers' => 2,
 		]);
 
-		self::assertSame(2, $report->getErrorCount());
+		self::assertSame(3, $report->getErrorCount());
 
 		self::assertSniffError($report, 21, ClassMemberSpacingSniff::CODE_INCORRECT_COUNT_OF_BLANK_LINES_BETWEEN_MEMBERS);
-		self::assertSniffError($report, 69, ClassMemberSpacingSniff::CODE_INCORRECT_COUNT_OF_BLANK_LINES_BETWEEN_MEMBERS);
+		self::assertSniffError($report, 58, ClassMemberSpacingSniff::CODE_INCORRECT_COUNT_OF_BLANK_LINES_BETWEEN_MEMBERS);
+		self::assertSniffError($report, 79, ClassMemberSpacingSniff::CODE_INCORRECT_COUNT_OF_BLANK_LINES_BETWEEN_MEMBERS);
+	}
+
+	public function testErrorsDuringLiveCoding(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/classMemberSpacingLiveCodingErrors.php');
+
+		self::assertSame(1, $report->getErrorCount());
+		self::assertSame(0, $report->getFixableCount());
+
+		self::assertSniffError($report, 11, ClassMemberSpacingSniff::CODE_INCORRECT_COUNT_OF_BLANK_LINES_BETWEEN_MEMBERS);
 	}
 
 }

--- a/tests/Sniffs/Classes/data/classMemberSpacingErrors.fixed.php
+++ b/tests/Sniffs/Classes/data/classMemberSpacingErrors.fixed.php
@@ -42,7 +42,15 @@ class Whatever
 
 	final const THIRD = 'third';
 
-	readonly int $forth;
+	readonly int $fourth;
+
+	/**
+	 * @return void
+	 */
+
+	public function fifth()
+	{
+	}
 
 }
 

--- a/tests/Sniffs/Classes/data/classMemberSpacingErrors.php
+++ b/tests/Sniffs/Classes/data/classMemberSpacingErrors.php
@@ -47,7 +47,17 @@ class Whatever
 	final const THIRD = 'third';
 
 
-	readonly int $forth;
+	readonly int $fourth;
+
+
+
+	/**
+	 * @return void
+	 */
+
+	public function fifth()
+	{
+	}
 
 }
 

--- a/tests/Sniffs/Classes/data/classMemberSpacingLiveCodingErrors.php
+++ b/tests/Sniffs/Classes/data/classMemberSpacingLiveCodingErrors.php
@@ -1,0 +1,13 @@
+<?php // lint >= 99.0
+
+class Test
+{
+
+	public const FOO = 'foo';
+
+	// Live coding/parse error.
+	pub
+
+	public $bar;
+
+}

--- a/tests/Sniffs/Classes/data/classMemberSpacingNoErrors.php
+++ b/tests/Sniffs/Classes/data/classMemberSpacingNoErrors.php
@@ -94,7 +94,7 @@ abstract class WithoutErrors
 	 *
 	 * @var string
 	 */
-	protected $forth;
+	protected $fourth;
 	// @codingStandardsIgnoreEnd
 
 	#[SomeAttribute]
@@ -124,6 +124,11 @@ abstract class WithoutErrors
 		};
 	}
 
+	/**
+	 * @var string
+	 */
+
+	protected $fifth;
 }
 
 enum Gender: string


### PR DESCRIPTION
Given this code
```php
private int $property;


/**
 * Description
 */

public function method(): void
{
}
```

The sniff deleted the docblock entirely because there is (quite unexpected, still a valid docblock though) newline after it.

Also, there could be some extra comments like this:

```php
private int $property;

// Extra comment

/**
 * Description
 */
public function method(): void
{
}
```

I'm not sure what the ideal solution would be here. I changed it so that the extra comment is considered part of the method.

But there could even be some unexpected code (it would be probably invalid though) which should not get deleted either. In such case, i disabled the fix and just report it as an error.