### PR TITLE
SlevomatCodingStandard.Classes.PropertyDeclaration: Prevent confusion when type hint is missing

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Classes/PropertyDeclarationSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/PropertyDeclarationSniff.php
@@ -23,6 +23,7 @@ use function sprintf;
 use function strtolower;
 use const T_ABSTRACT;
 use const T_AS;
+use const T_CLASS;
 use const T_CONST;
 use const T_DOUBLE_COLON;
 use const T_FINAL;
@@ -117,7 +118,7 @@ class PropertyDeclarationSniff implements Sniff
 			}
 		}
 
-		$propertyPointer = TokenHelper::findNext($phpcsFile, [T_FUNCTION, T_CONST, T_VARIABLE], $modifierPointer + 1);
+		$propertyPointer = TokenHelper::findNext($phpcsFile, [T_CLASS, T_FUNCTION, T_CONST, T_VARIABLE], $modifierPointer + 1);
 
 		if ($propertyPointer === null || $tokens[$propertyPointer]['code'] !== T_VARIABLE) {
 			return;


### PR DESCRIPTION
I've noticed that when property doesn't have native type hint, `PropertyDeclaration` gets confused if the class also has property-like modifiers (eg. `final`). It led to unintended screw up when auto-fixing.

For example this class https://github.com/vojtech-dobes/php-graphql-server/blob/7f0587879ed4ce58d866bbeee2c301d98aca0c03/src/GraphQL/Deferred.php#L11-L15 got auto-fixed to:

```php
final class Deferred {

	/** @var callable(): TValue */
	private $callback;
```

I don't know exactly how to create test for this.