### PR TITLE
Allow targeting multiline elements in AbstractPropertyConstantAndEnumCaseSpacing

### DIFF
--- a/doc/classes.md
+++ b/doc/classes.md
@@ -113,6 +113,8 @@ Sniff provides the following settings:
 * `maxLinesCountBeforeWithComment`: maximum number of lines before constant with a documentation comment or attribute
 * `minLinesCountBeforeWithoutComment`: minimum number of lines before constant without a documentation comment or attribute
 * `maxLinesCountBeforeWithoutComment`: maximum number of lines before constant without a documentation comment or attribute
+* `minLinesCountBeforeMultiline` (default: `null`): minimum number of lines before multiline constant
+* `maxLinesCountBeforeMultiline` (default: `null`): maximum number of lines before multiline constant
 
 #### SlevomatCodingStandard.Classes.DisallowConstructorPropertyPromotion
 
@@ -216,6 +218,8 @@ Sniff provides the following settings:
 * `maxLinesCountBeforeWithComment`: maximum number of lines before property with a documentation comment or attribute
 * `minLinesCountBeforeWithoutComment`: minimum number of lines before property without a documentation comment or attribute
 * `maxLinesCountBeforeWithoutComment`: maximum number of lines before property without a documentation comment or attribute
+* `minLinesCountBeforeMultiline` (default: `null`): minimum number of lines before multiline property
+* `maxLinesCountBeforeMultiline` (default: `null`): maximum number of lines before multiline property
 
 #### SlevomatCodingStandard.Classes.RequireAbstractOrFinal 🔧
 

--- a/tests/Sniffs/Classes/ConstantSpacingSniffTest.php
+++ b/tests/Sniffs/Classes/ConstantSpacingSniffTest.php
@@ -44,6 +44,22 @@ class ConstantSpacingSniffTest extends TestCase
 		self::assertSniffError($report, 26, ConstantSpacingSniff::CODE_INCORRECT_COUNT_OF_BLANK_LINES_AFTER_CONSTANT);
 	}
 
+	public function testErrorsBasedOnMultiline(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/constantSpacingMultilineErrors.php', [
+			'minLinesCountBeforeMultiline' => 1,
+			'minLinesCountBeforeWithComment' => 2,
+			'maxLinesCountBeforeWithComment' => 2,
+		]);
+
+		self::assertSame(2, $report->getErrorCount());
+
+		self::assertSniffError($report, 4, ConstantSpacingSniff::CODE_INCORRECT_COUNT_OF_BLANK_LINES_AFTER_CONSTANT);
+		self::assertSniffError($report, 9, ConstantSpacingSniff::CODE_INCORRECT_COUNT_OF_BLANK_LINES_AFTER_CONSTANT);
+
+		self::assertAllFixedInFile($report);
+	}
+
 	public function testInGlobalNamespaceNoErrors(): void
 	{
 		$report = self::checkFile(__DIR__ . '/data/constantSpacingInGlobalNamespaceNoErrors.php');

--- a/tests/Sniffs/Classes/data/constantSpacingMultilineErrors.fixed.php
+++ b/tests/Sniffs/Classes/data/constantSpacingMultilineErrors.fixed.php
@@ -1,0 +1,23 @@
+<?php // lint >= 8.2
+
+abstract class Foo {
+	const ItemsA = [
+		'A',
+		'B',
+		'C',
+	];
+
+	const ItemsB = [
+		'A',
+		'B',
+		'C',
+	];
+
+
+	/** @var array<string> */
+	const ItemsC = [
+		'A',
+		'B',
+		'C',
+	];
+}

--- a/tests/Sniffs/Classes/data/constantSpacingMultilineErrors.php
+++ b/tests/Sniffs/Classes/data/constantSpacingMultilineErrors.php
@@ -1,0 +1,20 @@
+<?php // lint >= 8.2
+
+abstract class Foo {
+	const ItemsA = [
+		'A',
+		'B',
+		'C',
+	];
+	const ItemsB = [
+		'A',
+		'B',
+		'C',
+	];
+	/** @var array<string> */
+	const ItemsC = [
+		'A',
+		'B',
+		'C',
+	];
+}


### PR DESCRIPTION
Hi, feel free to reject this if you don't like this. I love the nice spacing I can define with the various Spacing sniffs. I use 1 empty line above phpDoc and 0 lines otherwise. To me it's about visually putting apart more complex elements (with phpDoc a property basically becomes multiline even if it's just single-line on its own). But I noticed that multiline `const` are still crammed together. The reason is that they don't really need phpDoc (eg. PHPStan can read them precisely just fine without phpDoc).

I've tried to implement these 2 extra options `minLinesCountBeforeMultiline` & `maxLinesCountBeforeMultiline` as optional. By default they are off (value `-1`). They also still respect other rules, so most _demanding_ value always wins.

The `max` call on line 105 I'm not sure about. I noticed weird behavior when the min is higher than max, so this ensures max is always same or higher than min.