### PR TITLE
ClassHelper::isFinal() - param 2 must be an int... null passed

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Classes/ModernClassNameReferenceSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/ModernClassNameReferenceSniff.php
@@ -142,7 +142,7 @@ class ModernClassNameReferenceSniff implements Sniff
 					return;
 				}
 
-				/** @var int $classPointer */
+				/** @var int|null $classPointer */
 				$classPointer = FunctionHelper::findClassPointer($phpcsFile, $functionPointer);
 				if (!ClassHelper::isFinal($phpcsFile, (int) $classPointer)) {
 					return;

--- a/SlevomatCodingStandard/Sniffs/Classes/ModernClassNameReferenceSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/ModernClassNameReferenceSniff.php
@@ -144,7 +144,7 @@ class ModernClassNameReferenceSniff implements Sniff
 
 				/** @var int $classPointer */
 				$classPointer = FunctionHelper::findClassPointer($phpcsFile, $functionPointer);
-				if (!ClassHelper::isFinal($phpcsFile, $classPointer)) {
+				if (!ClassHelper::isFinal($phpcsFile, (int) $classPointer)) {
 					return;
 				}
 			}

--- a/SlevomatCodingStandard/Sniffs/Classes/UselessLateStaticBindingSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/UselessLateStaticBindingSniff.php
@@ -51,7 +51,7 @@ class UselessLateStaticBindingSniff implements Sniff
 			break;
 		}
 
-		if (!ClassHelper::isFinal($phpcsFile, $classPointer)) {
+		if (!ClassHelper::isFinal($phpcsFile, (int) $classPointer)) {
 			return;
 		}
 


### PR DESCRIPTION
Got an error regarding ClassHelper::isFinal requiring an int, `null` passed

quick and easy fix... sorry, no unit tests
