### PR TITLE
Fix https://github.com/slevomat/coding-standard/issues/1768 non-empty-lowercase-string, non-empty-array

### DIFF
--- a/SlevomatCodingStandard/Helpers/AnnotationHelper.php
+++ b/SlevomatCodingStandard/Helpers/AnnotationHelper.php
@@ -293,11 +293,10 @@ class AnnotationHelper
 				return $enableStandaloneNullTrueFalseTypeHints;
 			}
 
-			if (in_array(
+			if (TypeHintHelper::isSimpleUnofficialTypeHints(
 				strtolower($annotationType->name),
-				['class-string', 'trait-string', 'callable-string', 'numeric-string', 'non-empty-string', 'non-falsy-string', 'literal-string', 'positive-int', 'negative-int'],
-				true,
-			)) {
+			) && !in_array($annotationType->name, ['object', 'mixed'], true)
+			) {
 				return false;
 			}
 		}

--- a/SlevomatCodingStandard/Helpers/AnnotationTypeHelper.php
+++ b/SlevomatCodingStandard/Helpers/AnnotationTypeHelper.php
@@ -22,6 +22,7 @@ use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
 use function count;
 use function in_array;
+use function preg_match;
 use function strtolower;
 
 /**
@@ -303,16 +304,33 @@ class AnnotationTypeHelper
 				return $enableUnionTypeHint || $enableStandaloneNullTrueFalseTypeHints ? 'false' : 'bool';
 			}
 
-			if (in_array(strtolower($typeNode->name), ['positive-int', 'negative-int'], true)) {
+			if (in_array(
+				strtolower($typeNode->name),
+				['positive-int', 'non-positive-int', 'negative-int', 'non-negative-int', 'literal-int', 'int-mask'],
+				true,
+			)) {
 				return 'int';
 			}
 
 			if (in_array(
 				strtolower($typeNode->name),
-				['class-string', 'trait-string', 'callable-string', 'numeric-string', 'non-empty-string', 'non-falsy-string', 'literal-string'],
+				['callable-array', 'callable-string'],
 				true,
 			)) {
+				return 'callable';
+			}
+
+			// See https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#class-string-interface-string
+			if (preg_match('~-string$~i', $typeNode->name) === 1) {
 				return 'string';
+			}
+
+			if (in_array(
+				strtolower($typeNode->name),
+				['non-empty-array', 'list', 'non-empty-list'],
+				true,
+			)) {
+				return 'array';
 			}
 
 			return $typeNode->name;

--- a/SlevomatCodingStandard/Helpers/TypeHintHelper.php
+++ b/SlevomatCodingStandard/Helpers/TypeHintHelper.php
@@ -13,6 +13,7 @@ use function array_unique;
 use function count;
 use function implode;
 use function in_array;
+use function preg_match;
 use function preg_split;
 use function sort;
 use function sprintf;
@@ -79,7 +80,7 @@ class TypeHintHelper
 
 	public static function isUnofficialUnionTypeHint(string $typeHint): bool
 	{
-		return in_array($typeHint, ['scalar', 'numeric'], true);
+		return in_array($typeHint, ['scalar', 'numeric', 'array-key'], true);
 	}
 
 	public static function isVoidTypeHint(string $typeHint): bool
@@ -99,7 +100,8 @@ class TypeHintHelper
 	{
 		$conversion = [
 			'scalar' => ['string', 'int', 'float', 'bool'],
-			'numeric' => ['int', 'float'],
+			'numeric' => ['int', 'float', 'string'],
+			'array-key' => ['int', 'string'],
 		];
 
 		return $conversion[$typeHint];
@@ -167,37 +169,37 @@ class TypeHintHelper
 
 	public static function isSimpleUnofficialTypeHints(string $typeHint): bool
 	{
-		static $simpleUnofficialTypeHints;
+		static $simpleUnofficialTypeHints = null;
 
-		if ($simpleUnofficialTypeHints === null) {
-			$simpleUnofficialTypeHints = [
-				'null',
-				'mixed',
-				'scalar',
-				'numeric',
-				'true',
-				'object',
-				'resource',
-				'static',
-				'$this',
-				'class-string',
-				'trait-string',
-				'callable-string',
-				'numeric-string',
-				'non-empty-string',
-				'non-falsy-string',
-				'literal-string',
-				'array-key',
-				'list',
-				'empty',
-				'positive-int',
-				'negative-int',
-				'min',
-				'max',
-			];
-		}
+		// See https://psalm.dev/docs/annotating_code/type_syntax/atomic_types/
+		$simpleUnofficialTypeHints ??= [
+			'null',
+			'mixed',
+			'scalar',
+			'numeric',
+			'true',
+			'object',
+			'resource',
+			'static',
+			'$this',
+			'array-key',
+			'list',
+			'non-empty-array',
+			'non-empty-list',
+			'empty',
+			'positive-int',
+			'non-positive-int',
+			'negative-int',
+			'non-negative-int',
+			'literal-int',
+			'int-mask',
+			'min',
+			'max',
+			'callable-array',
+			'callable-string',
+		];
 
-		return in_array($typeHint, $simpleUnofficialTypeHints, true);
+		return in_array($typeHint, $simpleUnofficialTypeHints, true) || preg_match('~-string$~i', $typeHint) === 1;
 	}
 
 	/**

--- a/SlevomatCodingStandard/Sniffs/TestCase.php
+++ b/SlevomatCodingStandard/Sniffs/TestCase.php
@@ -84,13 +84,35 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 	protected static function assertNoSniffErrorInFile(File $phpcsFile): void
 	{
 		$errors = $phpcsFile->getErrors();
-		self::assertEmpty($errors, sprintf('No errors expected, but %d errors found.', count($errors)));
+		$text = sprintf('No errors expected, but %d errors found:', count($errors));
+		foreach ($errors as $line => $error) {
+			$text .= sprintf(
+				'%sLine %d:%s%s',
+				PHP_EOL,
+				$line,
+				PHP_EOL,
+				self::getFormattedErrors($error),
+			);
+		}
+
+		self::assertEmpty($errors, $text);
 	}
 
 	protected static function assertNoSniffWarningInFile(File $phpcsFile): void
 	{
 		$warnings = $phpcsFile->getWarnings();
-		self::assertEmpty($warnings, sprintf('No warnings expected, but %d warnings found.', count($warnings)));
+		$text = sprintf('No warnings expected, but %d warnings found:', count($warnings));
+		foreach ($warnings as $line => $warning) {
+			$text .= sprintf(
+				'%sLine %d:%s%s',
+				PHP_EOL,
+				$line,
+				PHP_EOL,
+				self::getFormattedErrors($warning),
+			);
+		}
+
+		self::assertEmpty($warnings, $text);
 	}
 
 	protected static function assertSniffError(File $phpcsFile, int $line, string $code, ?string $message = null): void

--- a/tests/Helpers/TypeHintHelperTest.php
+++ b/tests/Helpers/TypeHintHelperTest.php
@@ -81,6 +81,19 @@ class TypeHintHelperTest extends TestCase
 			['resource', true],
 			['static', true],
 			['$this', true],
+			['array-key', true],
+			['list', true],
+			['non-empty-array', true],
+			['non-empty-list', true],
+			['empty', true],
+			['positive-int', true],
+			['non-positive-int', true],
+			['negative-int', true],
+			['non-negative-int', true],
+			['literal-int', true],
+			['int-mask', true],
+			['callable-array', true],
+			['callable-string', true],
 
 			['\Traversable', false],
 			['int', false],
@@ -379,6 +392,8 @@ class TypeHintHelperTest extends TestCase
 		return [
 			['scalar', true],
 			['unionIsNotIntersection', false],
+			['fooFunctionWithReturnAnnotationComplexString', false],
+			['fooFunctionWithReturnAnnotationSimpleHyphenedIterable', false],
 		];
 	}
 

--- a/tests/Helpers/data/typeHintEqualsAnnotation.php
+++ b/tests/Helpers/data/typeHintEqualsAnnotation.php
@@ -14,3 +14,19 @@ function scalar(): int|bool|float|string
 function unionIsNotIntersection(): Foo|Bar
 {
 }
+
+/**
+ * @return non-empty-lowercase-string
+ */
+function fooFunctionWithReturnAnnotationComplexString(): string
+{
+
+}
+
+/**
+ * @return non-empty-array|null
+ */
+function fooFunctionWithReturnAnnotationSimpleHyphenedIterable(): ?array
+{
+
+}

--- a/tests/Sniffs/PHP/RequireExplicitAssertionSniffTest.php
+++ b/tests/Sniffs/PHP/RequireExplicitAssertionSniffTest.php
@@ -76,7 +76,7 @@ class RequireExplicitAssertionSniffTest extends TestCase
 			'enableAdvancedStringTypes' => false,
 		]);
 
-		self::assertSame(10, $report->getErrorCount());
+		self::assertSame(11, $report->getErrorCount());
 
 		self::assertSniffError($report, 3, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
 		self::assertSniffError($report, 6, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
@@ -88,6 +88,7 @@ class RequireExplicitAssertionSniffTest extends TestCase
 		self::assertSniffError($report, 24, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
 		self::assertSniffError($report, 27, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
 		self::assertSniffError($report, 30, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
+		self::assertSniffError($report, 33, RequireExplicitAssertionSniff::CODE_REQUIRED_EXPLICIT_ASSERTION);
 
 		self::assertAllFixedInFile($report);
 	}

--- a/tests/Sniffs/PHP/data/requireExplicitAssertionErrors.fixed.php
+++ b/tests/Sniffs/PHP/data/requireExplicitAssertionErrors.fixed.php
@@ -42,7 +42,7 @@ $i = new \stdClass();
 \assert(\is_object($i));
 
 $j = 0;
-\assert(\is_int($j) || \is_float($j));
+\assert(\is_int($j) || \is_numeric($j));
 
 $k = 'string';
 \assert(\is_int($k) || \is_float($k) || \is_bool($k) || \is_string($k));
@@ -51,7 +51,7 @@ $l = new \stdClass();
 \assert($l instanceof \stdClass);
 
 foreach ([] as $m) {
-	\assert(\is_int($m) || \is_float($m) || \is_bool($m));
+	\assert(\is_numeric($m) || \is_bool($m));
 }
 
 while ($n = next($array)) {
@@ -77,7 +77,7 @@ $u = new ArrayObject();
 \assert($u instanceof \Traversable && $u instanceof \Countable);
 
 foreach ([] as $v) {
-	\assert(\is_int($v) || \is_float($v) || \is_bool($v));
+	\assert(\is_numeric($v) || \is_bool($v));
 }
 
 while ($w = next($array)) {

--- a/tests/Sniffs/PHP/data/requireExplicitAssertionIntegerRangesErrors.fixed.php
+++ b/tests/Sniffs/PHP/data/requireExplicitAssertionIntegerRangesErrors.fixed.php
@@ -29,3 +29,6 @@ $e = 0;
 
 $ee = null;
 \assert((\is_int($ee) && $ee >= 50) || $ee === null);
+
+$f = 100;
+\assert(\is_int($f));

--- a/tests/Sniffs/PHP/data/requireExplicitAssertionIntegerRangesErrors.php
+++ b/tests/Sniffs/PHP/data/requireExplicitAssertionIntegerRangesErrors.php
@@ -29,3 +29,6 @@ $e = 0;
 
 /** @var int<50, max>|null $ee */
 $ee = null;
+
+/** @var literal-int $f */
+$f = 100;

--- a/tests/Sniffs/TypeHints/ReturnTypeHintSniffTest.php
+++ b/tests/Sniffs/TypeHints/ReturnTypeHintSniffTest.php
@@ -33,7 +33,7 @@ class ReturnTypeHintSniffTest extends TestCase
 			'traversableTypeHints' => ['Traversable', '\ArrayIterator'],
 		]);
 
-		self::assertSame(62, $report->getErrorCount());
+		self::assertSame(65, $report->getErrorCount());
 
 		self::assertSniffError($report, 6, ReturnTypeHintSniff::CODE_MISSING_ANY_TYPE_HINT);
 		self::assertSniffError($report, 14, ReturnTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
@@ -104,6 +104,9 @@ class ReturnTypeHintSniffTest extends TestCase
 		self::assertSniffError($report, 368, ReturnTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
 
 		self::assertSniffError($report, 373, ReturnTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
+		self::assertSniffError($report, 378, ReturnTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
+		self::assertSniffError($report, 383, ReturnTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
+		self::assertSniffError($report, 388, ReturnTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
 
 		self::assertAllFixedInFile($report);
 	}
@@ -134,7 +137,7 @@ class ReturnTypeHintSniffTest extends TestCase
 			'traversableTypeHints' => ['Traversable', '\ArrayIterator'],
 		]);
 
-		self::assertSame(16, $report->getErrorCount());
+		self::assertSame(17, $report->getErrorCount());
 
 		self::assertSniffError($report, 7, ReturnTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
 		self::assertSniffError($report, 11, ReturnTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
@@ -153,6 +156,7 @@ class ReturnTypeHintSniffTest extends TestCase
 		self::assertSniffError($report, 59, ReturnTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
 		self::assertSniffError($report, 63, ReturnTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
 		self::assertSniffError($report, 67, ReturnTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
+		self::assertSniffError($report, 71, ReturnTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
 
 		self::assertAllFixedInFile($report);
 	}

--- a/tests/Sniffs/TypeHints/data/parameterTypeHintWithUnionErrors.fixed.php
+++ b/tests/Sniffs/TypeHints/data/parameterTypeHintWithUnionErrors.fixed.php
@@ -48,11 +48,11 @@ class Whatever
 	{}
 
 	/** */
-	private function numeric(int|float $a)
+	private function numeric(int|float|string $a)
 	{}
 
 	/** */
-	private function numericNullable(int|float|null $a)
+	private function numericNullable(int|float|string|null $a)
 	{}
 
 	/** */

--- a/tests/Sniffs/TypeHints/data/propertyTypeHintEnabledNativeWithUnionErrors.fixed.php
+++ b/tests/Sniffs/TypeHints/data/propertyTypeHintEnabledNativeWithUnionErrors.fixed.php
@@ -27,9 +27,9 @@ class Whatever
 
 	private string|int|float|bool|null $scalarNullable = null;
 
-	private int|float $numeric;
+	private int|float|string $numeric;
 
-	private int|float|null $numericNullable = null;
+	private int|float|string|null $numericNullable = null;
 
 	private string|int|float|bool|null $scalarAndnumericNullable = null;
 

--- a/tests/Sniffs/TypeHints/data/returnTypeHintErrors.fixed.php
+++ b/tests/Sniffs/TypeHints/data/returnTypeHintErrors.fixed.php
@@ -361,4 +361,19 @@ abstract class Whatever
 	{
 	}
 
+	/** @return non-empty-lowercase-string */
+	public function returnComplexString(): string
+	{
+	}
+
+	/** @return callable-array */
+	public function returnCallableArray(): callable
+	{
+	}
+
+	/** @return non-empty-array */
+	public function returnNonEmptyArray(): array
+	{
+	}
+
 }

--- a/tests/Sniffs/TypeHints/data/returnTypeHintErrors.php
+++ b/tests/Sniffs/TypeHints/data/returnTypeHintErrors.php
@@ -374,4 +374,19 @@ abstract class Whatever
 	{
 	}
 
+	/** @return non-empty-lowercase-string */
+	public function returnComplexString()
+	{
+	}
+
+	/** @return callable-array */
+	public function returnCallableArray()
+	{
+	}
+
+	/** @return non-empty-array */
+	public function returnNonEmptyArray()
+	{
+	}
+
 }

--- a/tests/Sniffs/TypeHints/data/returnTypeHintNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/returnTypeHintNoErrors.php
@@ -397,4 +397,14 @@ class Aliases
 	{
 	}
 
+	/** @return non-empty-lowercase-string */
+	public function returnComplexString(): string
+	{
+	}
+
+	/** @return callable-array */
+	public function returnCallableArray(): callable
+	{
+	}
+
 }

--- a/tests/Sniffs/TypeHints/data/returnTypeHintWithUnionErrors.fixed.php
+++ b/tests/Sniffs/TypeHints/data/returnTypeHintWithUnionErrors.fixed.php
@@ -48,11 +48,11 @@ class Whatever
 	{}
 
 	/** */
-	private function numeric(): int|float
+	private function numeric(): int|float|string
 	{}
 
 	/** */
-	private function numericNullable(): int|float|null
+	private function numericNullable(): int|float|string|null
 	{}
 
 	/** */
@@ -65,6 +65,10 @@ class Whatever
 
 	/** */
 	private function mixedAndVoid(): mixed
+	{}
+
+	/** @return non-empty-array|null */
+	public function returnNonEmptyArray(): ?array
 	{}
 
 }

--- a/tests/Sniffs/TypeHints/data/returnTypeHintWithUnionErrors.php
+++ b/tests/Sniffs/TypeHints/data/returnTypeHintWithUnionErrors.php
@@ -67,4 +67,8 @@ class Whatever
 	private function mixedAndVoid()
 	{}
 
+	/** @return non-empty-array|null */
+	public function returnNonEmptyArray()
+	{}
+
 }

--- a/tests/Sniffs/TypeHints/data/returnTypeHintWithUnionNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/returnTypeHintWithUnionNoErrors.php
@@ -33,4 +33,14 @@ class Whatever
 	{
 	}
 
+	/** @return non-empty-lowercase-string|null */
+	public function returnComplexString(): ?string
+	{
+	}
+
+	/** @return callable-array|null */
+	public function returnCallableArray(): ?callable
+	{
+	}
+
 }


### PR DESCRIPTION
Fix: https://github.com/slevomat/coding-standard/issues/1768
Fix https://github.com/slevomat/coding-standard/issues/1771

* correctly handle all current and future string types
* correctly handle additional int types
* fix non-empty-array not correctly set as native type but set with hyphens
* fix numeric also contains string (numeric-string specifically)