### PR TITLE
SlevomatCodingStandard.Classes.RequireMultiLineMethodSignature: New option "withPromotedProperties"

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Classes/RequireMultiLineMethodSignatureSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/RequireMultiLineMethodSignatureSniff.php
@@ -26,6 +26,8 @@ class RequireMultiLineMethodSignatureSniff extends AbstractMethodSignature
 
 	public ?int $minParametersCount = null;
 
+	public bool $withPromotedProperties = false;
+
 	/** @var list<string> */
 	public array $includedMethodPatterns = [];
 
@@ -91,12 +93,24 @@ class RequireMultiLineMethodSignatureSniff extends AbstractMethodSignature
 			return;
 		}
 
-		if ($this->minLineLength !== null && $this->minLineLength !== 0 && strlen($signature) < $this->minLineLength) {
-			return;
+		$splitPromotedProperties = false;
+		if ($this->withPromotedProperties) {
+			foreach ($parameters as $parameter) {
+				if (isset($parameter['property_visibility'])) {
+					$splitPromotedProperties = true;
+					break;
+				}
+			}
 		}
 
-		if ($this->minParametersCount !== null && $parametersCount < $this->minParametersCount) {
-			return;
+		if (!$splitPromotedProperties) {
+			if ($this->minLineLength !== null && $this->minLineLength !== 0 && strlen($signature) < $this->minLineLength) {
+				return;
+			}
+
+			if ($this->minParametersCount !== null && $parametersCount < $this->minParametersCount) {
+				return;
+			}
 		}
 
 		$error = sprintf('Signature of method "%s" should be split to more lines so each parameter is on its own line.', $methodName);

--- a/doc/classes.md
+++ b/doc/classes.md
@@ -246,6 +246,8 @@ Sniff provides the following settings:
 
 * `excludedMethodPatterns`: allows to configure which methods are excluded from sniff detection. This is an array of regular expressions (PCRE) with delimiters. You should not use this with `includedMethodPatterns`, as it will not work properly.
 
+* `withPromotedProperties`: always require multiline signatures for methods with promoted properties.
+
 #### SlevomatCodingStandard.Classes.RequireSelfReference 🔧
 
 Requires `self` for local reference.

--- a/tests/Sniffs/Classes/RequireMultiLineMethodSignatureSniffTest.php
+++ b/tests/Sniffs/Classes/RequireMultiLineMethodSignatureSniffTest.php
@@ -68,6 +68,19 @@ final class RequireMultiLineMethodSignatureSniffTest extends TestCase
 		self::assertAllFixedInFile($report);
 	}
 
+	public function testErrorsBasedOnPromotedProperties(): void
+	{
+		$report = self::checkFile(
+			__DIR__ . '/data/requireMultiLineMethodSignatureBasedOnPromotedPropertiesErrors.php',
+			['withPromotedProperties' => true],
+		);
+		self::assertSame(1, $report->getErrorCount());
+
+		self::assertSniffError($report, 5, RequireMultiLineMethodSignatureSniff::CODE_REQUIRED_MULTI_LINE_SIGNATURE);
+
+		self::assertAllFixedInFile($report);
+	}
+
 	public function testForAllMethods(): void
 	{
 		$report = self::checkFile(__DIR__ . '/data/requireMultiLineMethodSignatureAllMethodsErrors.php', ['minLineLength' => 0]);

--- a/tests/Sniffs/Classes/data/requireMultiLineMethodSignatureBasedOnPromotedPropertiesErrors.fixed.php
+++ b/tests/Sniffs/Classes/data/requireMultiLineMethodSignatureBasedOnPromotedPropertiesErrors.fixed.php
@@ -1,0 +1,9 @@
+<?php // lint >= 8.0
+
+class A
+{
+	public function __construct(
+		public int $single
+	) {
+	}
+}

--- a/tests/Sniffs/Classes/data/requireMultiLineMethodSignatureBasedOnPromotedPropertiesErrors.php
+++ b/tests/Sniffs/Classes/data/requireMultiLineMethodSignatureBasedOnPromotedPropertiesErrors.php
@@ -1,0 +1,7 @@
+<?php // lint >= 8.0
+
+class A
+{
+	public function __construct(public int $single) {
+	}
+}


### PR DESCRIPTION
A similar option should be probably in `RequireSingleLineMethodSignature`. However, `minParametersCount` is not there either. I think that the best solution would be to merge these two into one but it seems quite complicated mainly because of BC. If you agree, I'll add `withoutPromotedProperties` to `RequireSingleLineMethodSignature`.