### PR TITLE
Do not remove true/false phpdoc if type hint is bool

### DIFF
--- a/SlevomatCodingStandard/Helpers/AnnotationHelper.php
+++ b/SlevomatCodingStandard/Helpers/AnnotationHelper.php
@@ -286,7 +286,7 @@ class AnnotationHelper
 				['true', 'false', 'null'],
 				true,
 			)) {
-				return $enableStandaloneNullTrueFalseTypeHints;
+				return $typeHint->getTypeHint() === strtolower($annotationType->name) ? $enableStandaloneNullTrueFalseTypeHints : false;
 			}
 
 			if (TypeHintHelper::isSimpleUnofficialTypeHints(

--- a/SlevomatCodingStandard/Sniffs/TypeHints/ReturnTypeHintSniff.php
+++ b/SlevomatCodingStandard/Sniffs/TypeHints/ReturnTypeHintSniff.php
@@ -179,6 +179,31 @@ class ReturnTypeHintSniff implements Sniff
 				}
 			}
 
+			if (
+				$this->enableStandaloneNullTrueFalseTypeHints
+				&& $returnTypeHint->getTypeHint() === 'bool'
+				&& $returnTypeNode instanceof IdentifierTypeNode
+				&& in_array(strtolower($returnTypeNode->name), ['true', 'false'], true)
+			) {
+				$fix = $phpcsFile->addFixableError(
+					sprintf(
+						'%s %s() has return type hint "bool" but it should be possible to use "%s" based on @return annotation "%s".',
+						FunctionHelper::getTypeLabel($phpcsFile, $functionPointer),
+						FunctionHelper::getFullyQualifiedName($phpcsFile, $functionPointer),
+						strtolower($returnTypeNode->name),
+						AnnotationTypeHelper::print($returnTypeNode),
+					),
+					$functionPointer,
+					self::CODE_LESS_SPECIFIC_NATIVE_TYPE_HINT,
+				);
+
+				if ($fix) {
+					$phpcsFile->fixer->beginChangeset();
+					FixerHelper::replace($phpcsFile, $returnTypeHint->getStartPointer(), strtolower($returnTypeNode->name));
+					$phpcsFile->fixer->endChangeset();
+				}
+			}
+
 			return;
 		}
 

--- a/tests/Sniffs/TypeHints/ReturnTypeHintSniffTest.php
+++ b/tests/Sniffs/TypeHints/ReturnTypeHintSniffTest.php
@@ -228,7 +228,7 @@ class ReturnTypeHintSniffTest extends TestCase
 			'enableStandaloneNullTrueFalseTypeHints' => true,
 		]);
 
-		self::assertSame(6, $report->getErrorCount());
+		self::assertSame(7, $report->getErrorCount());
 
 		self::assertSniffError($report, 7, ReturnTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
 		self::assertSniffError($report, 13, ReturnTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
@@ -236,6 +236,7 @@ class ReturnTypeHintSniffTest extends TestCase
 		self::assertSniffError($report, 22, ReturnTypeHintSniff::CODE_USELESS_ANNOTATION);
 		self::assertSniffError($report, 27, ReturnTypeHintSniff::CODE_USELESS_ANNOTATION);
 		self::assertSniffError($report, 33, ReturnTypeHintSniff::CODE_USELESS_ANNOTATION);
+		self::assertSniffError($report, 41, ReturnTypeHintSniff::CODE_LESS_SPECIFIC_NATIVE_TYPE_HINT);
 
 		self::assertAllFixedInFile($report);
 	}

--- a/tests/Sniffs/TypeHints/data/parameterTypeHintNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/parameterTypeHintNoErrors.php
@@ -297,6 +297,11 @@ class Whatever extends ParentClass
 	{
 	}
 
+	/**
+	 * @param true $a
+	 */
+	function trueStandaloneNotEqualBool(bool $a): bool
+	{}
 
 }
 

--- a/tests/Sniffs/TypeHints/data/parameterTypeHintWithNullTrueFalseErrors.fixed.php
+++ b/tests/Sniffs/TypeHints/data/parameterTypeHintWithNullTrueFalseErrors.fixed.php
@@ -31,4 +31,10 @@ class Whatever
 	public function parameterFalseWithUselessAnnotation(false $a)
 	{}
 
+	/**
+	 * @param true $a
+	 */
+	function trueStandaloneNotEqualBool(bool $a): bool
+	{}
+
 }

--- a/tests/Sniffs/TypeHints/data/parameterTypeHintWithNullTrueFalseErrors.php
+++ b/tests/Sniffs/TypeHints/data/parameterTypeHintWithNullTrueFalseErrors.php
@@ -35,4 +35,10 @@ class Whatever
 	public function parameterFalseWithUselessAnnotation(false $a)
 	{}
 
+	/**
+	 * @param true $a
+	 */
+	function trueStandaloneNotEqualBool(bool $a): bool
+	{}
+
 }

--- a/tests/Sniffs/TypeHints/data/returnTypeHintNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/returnTypeHintNoErrors.php
@@ -296,6 +296,12 @@ abstract class Whatever
 
 	}
 
+	/**
+	 * @return true
+	 */
+	function returnsTrueFromBool(): bool
+	{}
+
 }
 
 /**

--- a/tests/Sniffs/TypeHints/data/returnTypeHintWithNullTrueFalseErrors.fixed.php
+++ b/tests/Sniffs/TypeHints/data/returnTypeHintWithNullTrueFalseErrors.fixed.php
@@ -31,4 +31,9 @@ class Whatever
 	public function returnsFalseWithUselessAnnotation(): false
 	{}
 
+	/**
+	 */
+	function returnsTrueFromBool(): true
+	{}
+
 }

--- a/tests/Sniffs/TypeHints/data/returnTypeHintWithNullTrueFalseErrors.php
+++ b/tests/Sniffs/TypeHints/data/returnTypeHintWithNullTrueFalseErrors.php
@@ -35,4 +35,10 @@ class Whatever
 	public function returnsFalseWithUselessAnnotation(): false
 	{}
 
+	/**
+	 * @return true
+	 */
+	function returnsTrueFromBool(): bool
+	{}
+
 }


### PR DESCRIPTION
Fix https://github.com/slevomat/coding-standard/issues/1777

No tests added yet, bc adding them would cause conflicts with the other one of my PRs. Feel free to just copy the test case provided in the issue as a unit test yourself or I'll do it once the other PR is merged (and I can rebase this one)