### PR TITLE
feat(UnusedParameterSniff): support supression via parameter name

### DIFF
--- a/doc/functions.md
+++ b/doc/functions.md
@@ -131,6 +131,10 @@ Looks for unused inherited variables passed to closure via `use`.
 
 Looks for unused parameters.
 
+This sniff provides the following setting:
+
+* `allowedParameterPatterns`: allows to configure which parameters are always allowed, even if unused. This is an array of regular expressions (PCRE) with delimiters, but without the leading `$` from variable names. (For example, use `[/^_/]` to allow parameters that start with an underscore, like `$_unused`.)
+
 #### SlevomatCodingStandard.Functions.UselessParameterDefaultValue 🚧
 
 Looks for useless parameter default value.

--- a/tests/Sniffs/Functions/UnusedParameterSniffTest.php
+++ b/tests/Sniffs/Functions/UnusedParameterSniffTest.php
@@ -3,6 +3,7 @@
 namespace SlevomatCodingStandard\Sniffs\Functions;
 
 use SlevomatCodingStandard\Sniffs\TestCase;
+use Throwable;
 
 class UnusedParameterSniffTest extends TestCase
 {
@@ -37,6 +38,45 @@ class UnusedParameterSniffTest extends TestCase
 			77,
 			UnusedParameterSniff::CODE_USELESS_SUPPRESS,
 			'Useless @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter',
+		);
+	}
+
+	public function testAllowedParameterSetting(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/unusedParameterErrors.php', [
+			'allowedParameterPatterns' => ['~^a$~'],
+		], [UnusedParameterSniff::CODE_UNUSED_PARAMETER]);
+
+		self::assertSame(2, $report->getErrorCount());
+
+		self::assertSniffError($report, 3, UnusedParameterSniff::CODE_UNUSED_PARAMETER, 'Unused parameter $b.');
+		self::assertSniffError($report, 66, UnusedParameterSniff::CODE_UNUSED_PARAMETER, 'Unused parameter $b.');
+
+		$report = self::checkFile(__DIR__ . '/data/unusedParameterErrors.php', [
+			'allowedParameterPatterns' => ['~^b$~'],
+		], [UnusedParameterSniff::CODE_UNUSED_PARAMETER]);
+
+		self::assertSame(10, $report->getErrorCount());
+
+		self::assertSniffError($report, 3, UnusedParameterSniff::CODE_UNUSED_PARAMETER, 'Unused parameter $a.');
+		self::assertSniffError($report, 7, UnusedParameterSniff::CODE_UNUSED_PARAMETER, 'Unused parameter $a.');
+		self::assertSniffError($report, 14, UnusedParameterSniff::CODE_UNUSED_PARAMETER, 'Unused parameter $a.');
+		self::assertSniffError($report, 19, UnusedParameterSniff::CODE_UNUSED_PARAMETER, 'Unused parameter $a.');
+		self::assertSniffError($report, 26, UnusedParameterSniff::CODE_UNUSED_PARAMETER, 'Unused parameter $a.');
+		self::assertSniffError($report, 35, UnusedParameterSniff::CODE_UNUSED_PARAMETER, 'Unused parameter $a.');
+		self::assertSniffError($report, 40, UnusedParameterSniff::CODE_UNUSED_PARAMETER, 'Unused parameter $a.');
+		self::assertSniffError($report, 47, UnusedParameterSniff::CODE_UNUSED_PARAMETER, 'Unused parameter $a.');
+		self::assertSniffError($report, 51, UnusedParameterSniff::CODE_UNUSED_PARAMETER, 'Unused parameter $a.');
+		self::assertSniffError($report, 53, UnusedParameterSniff::CODE_UNUSED_PARAMETER, 'Unused parameter $a.');
+	}
+
+	public function testThrowExceptionForInvalidPattern(): void
+	{
+		$this->expectException(Throwable::class);
+
+		self::checkFile(
+			__DIR__ . '/data/unusedParameterErrors.php',
+			['allowedParameterPatterns' => ['invalidPattern']],
 		);
 	}
 


### PR DESCRIPTION
Hi 👋 

It's common to have unused method params, especially in cases where you're extending and overriding a method from a parent class. Instead of sprinkling `// phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter` thoughout my code, I'd prefer to just rename those variables to `$_variable`. This is similar to how eslint and Rust's `clippy` handle unused params, and I've found those to be convenient and still helpful.

My only TODO is maybe putting this behind a config flag, but I didn't want to get into that until I heard if this change is desired at all. This is my first contribution here, and no AI was used in this. 

This sort of addresses #1074, and it may even close it.