### PR TITLE
ReturnTypeHint: report missing type hint in abstract methods

### DIFF
--- a/SlevomatCodingStandard/Sniffs/TypeHints/ReturnTypeHintSniff.php
+++ b/SlevomatCodingStandard/Sniffs/TypeHints/ReturnTypeHintSniff.php
@@ -205,7 +205,7 @@ class ReturnTypeHintSniff implements Sniff
 			? ($hasReturnAnnotation && !$isAnnotationReturnTypeVoidOrNever)
 			: FunctionHelper::returnsValue($phpcsFile, $functionPointer);
 
-		if ($returnsValue && !$hasReturnAnnotation) {
+		if (($returnsValue || $isAbstract) && !$hasReturnAnnotation) {
 			if (count($prefixedReturnAnnotations) !== 0) {
 				$this->reportUselessSuppress($phpcsFile, $functionPointer, $isSuppressedAnyTypeHint, $suppressNameAnyTypeHint);
 				return;

--- a/tests/Sniffs/TypeHints/ReturnTypeHintSniffTest.php
+++ b/tests/Sniffs/TypeHints/ReturnTypeHintSniffTest.php
@@ -33,7 +33,7 @@ class ReturnTypeHintSniffTest extends TestCase
 			'traversableTypeHints' => ['Traversable', '\ArrayIterator'],
 		]);
 
-		self::assertSame(65, $report->getErrorCount());
+		self::assertSame(67, $report->getErrorCount());
 
 		self::assertSniffError($report, 6, ReturnTypeHintSniff::CODE_MISSING_ANY_TYPE_HINT);
 		self::assertSniffError($report, 14, ReturnTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
@@ -107,6 +107,9 @@ class ReturnTypeHintSniffTest extends TestCase
 		self::assertSniffError($report, 378, ReturnTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
 		self::assertSniffError($report, 383, ReturnTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
 		self::assertSniffError($report, 388, ReturnTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
+
+		self::assertSniffError($report, 392, ReturnTypeHintSniff::CODE_MISSING_ANY_TYPE_HINT);
+		self::assertSniffError($report, 397, ReturnTypeHintSniff::CODE_MISSING_ANY_TYPE_HINT);
 
 		self::assertAllFixedInFile($report);
 	}

--- a/tests/Sniffs/TypeHints/data/returnTypeHintErrors.fixed.php
+++ b/tests/Sniffs/TypeHints/data/returnTypeHintErrors.fixed.php
@@ -376,4 +376,10 @@ abstract class Whatever
 	{
 	}
 
+	abstract public function returnWhoKnows();
+
+}
+
+interface Whateverable {
+	function returnWhoKnows();
 }

--- a/tests/Sniffs/TypeHints/data/returnTypeHintErrors.php
+++ b/tests/Sniffs/TypeHints/data/returnTypeHintErrors.php
@@ -389,4 +389,10 @@ abstract class Whatever
 	{
 	}
 
+	abstract public function returnWhoKnows();
+
+}
+
+interface Whateverable {
+	function returnWhoKnows();
 }


### PR DESCRIPTION
Abstract methods now report fixable error _Method … does not have void return type hint_ which is wrong.