### PR TITLE
SlevomatCodingStandard.PHP.UselessParentheses: Checks useless parentheses around (new class())->f().

### DIFF
--- a/SlevomatCodingStandard/Sniffs/PHP/UselessParenthesesSniff.php
+++ b/SlevomatCodingStandard/Sniffs/PHP/UselessParenthesesSniff.php
@@ -54,7 +54,9 @@ use const T_MINUS;
 use const T_MODULUS;
 use const T_MULTIPLY;
 use const T_NEW;
+use const T_NULLSAFE_OBJECT_OPERATOR;
 use const T_OBJECT_CAST;
+use const T_OBJECT_OPERATOR;
 use const T_OPEN_PARENTHESIS;
 use const T_PARENT;
 use const T_PLUS;
@@ -102,6 +104,8 @@ class UselessParenthesesSniff implements Sniff
 	];
 
 	public bool $ignoreComplexTernaryConditions = false;
+
+	public bool $enableCheckAroundNew = false;
 
 	/**
 	 * @return array<int, (int|string)>
@@ -611,7 +615,19 @@ class UselessParenthesesSniff implements Sniff
 			$tokens[$parenthesisOpenerPointer]['parenthesis_closer'] + 1,
 		);
 		if (!in_array($tokens[$pointerAfterParenthesisCloser]['code'], [T_COMMA, T_SEMICOLON, T_CLOSE_SHORT_ARRAY], true)) {
-			return;
+			if (!in_array($tokens[$pointerAfterParenthesisCloser]['code'], [T_OBJECT_OPERATOR, T_NULLSAFE_OBJECT_OPERATOR], true)) {
+				return;
+			}
+			if (!$this->enableCheckAroundNew) {
+				return;
+			}
+			$pointerBeforeParenthesisCloser = TokenHelper::findPreviousEffective(
+				$phpcsFile,
+				$tokens[$parenthesisOpenerPointer]['parenthesis_closer'] - 1,
+			);
+			if ($tokens[$pointerBeforeParenthesisCloser]['type'] !== 'T_CLOSE_PARENTHESIS') {
+				return;
+			}
 		}
 
 		$fix = $phpcsFile->addFixableError('Useless parentheses.', $parenthesisOpenerPointer, self::CODE_USELESS_PARENTHESES);

--- a/doc/php.md
+++ b/doc/php.md
@@ -74,6 +74,8 @@ Looks for useless parentheses.
 Sniff provides the following settings:
 
 * `ignoreComplexTernaryConditions` (default: `false`): ignores complex ternary conditions - condition must contain `&&`, `||` etc. or end of line.
+* `enableCheckAroundNew` (default: `false`): enables check of useless parentheses around `(new class())->call()`.
+
 
 #### SlevomatCodingStandard.PHP.UselessSemicolon 🔧
 

--- a/tests/Sniffs/PHP/UselessParenthesesSniffTest.php
+++ b/tests/Sniffs/PHP/UselessParenthesesSniffTest.php
@@ -26,6 +26,30 @@ class UselessParenthesesSniffTest extends TestCase
 		self::assertAllFixedInFile($report);
 	}
 
+	public function testCheckAroundNewDisabled(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/uselessParenthesesCheckAroundNewErrors.php', [
+			'enableCheckAroundNew' => false,
+		]);
+
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testCheckAroundNewEnabled(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/uselessParenthesesCheckAroundNewErrors.php', [
+			'enableCheckAroundNew' => true,
+		]);
+
+		self::assertSame(2, $report->getErrorCount());
+
+		foreach ([3, 5] as $line) {
+			self::assertSniffError($report, $line, UselessParenthesesSniff::CODE_USELESS_PARENTHESES);
+		}
+
+		self::assertAllFixedInFile($report);
+	}
+
 	public function testNoErrorsWithIgnoredComplexTernaryConditions(): void
 	{
 		$report = self::checkFile(__DIR__ . '/data/uselessParenthesesNoErrorsWithIgnoredComplexTernaryConditions.php', [

--- a/tests/Sniffs/PHP/data/uselessParenthesesCheckAroundNewErrors.fixed.php
+++ b/tests/Sniffs/PHP/data/uselessParenthesesCheckAroundNewErrors.fixed.php
@@ -1,0 +1,5 @@
+<?php // lint >= 8.4
+
+$response = new Response()->withStatus(200);
+$response = (new Response)->withStatus(200);
+$ip = new RemoteAddress()?->getIpAddress();

--- a/tests/Sniffs/PHP/data/uselessParenthesesCheckAroundNewErrors.php
+++ b/tests/Sniffs/PHP/data/uselessParenthesesCheckAroundNewErrors.php
@@ -1,0 +1,5 @@
+<?php // lint >= 8.4
+
+$response = (new Response())->withStatus(200);
+$response = (new Response)->withStatus(200);
+$ip = (new RemoteAddress())?->getIpAddress();

--- a/tests/Sniffs/PHP/data/uselessParenthesesNoErrors.php
+++ b/tests/Sniffs/PHP/data/uselessParenthesesNoErrors.php
@@ -177,8 +177,7 @@ $anotherObject = new ($object->getClassName());
 
 echo 'Hello' . ($foo ? ' There' : $fn());
 
-$response = (new Response())->withStatus(200);
-$ip = (new RemoteAddress())?->getIpAddress();
+doSomething((new Response()));
 
 echo ~(1 - 1);
 


### PR DESCRIPTION
I haven't found changing behavior based on PHP version in other sniffs or tests, only enabling or disabling them.