### PR TITLE
GH Actions: allow test runs to succeed on fork

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,6 +195,7 @@ jobs:
         run: bin/phing tests
 
       - name: "Upload to Codecov.io"
+        if: ${{ success() && github.event.repository.fork == false }}
         uses: codecov/codecov-action@v4
         with:
           token: "${{ secrets.CODECOV }}"


### PR DESCRIPTION
As things were, test runs on forks (when the `master` branch in the fork is updated) would always fail on the "upload code coverage reports" step, as forks (justifiably) don't have access to the `CODECOV_TOKEN`.

Fixed now by adding a condition for running that step.