### PR TITLE
Composer: tidy up version constraints Composer PHPCS plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	},
 	"require": {
 		"php": "^7.4 || ^8.0",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.2.0",
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.2.0",
 		"phpstan/phpdoc-parser": "^2.3.0",
 		"squizlabs/php_codesniffer": "^4.0.1"
 	},


### PR DESCRIPTION
The `dealerdirect/phpcodesniffer-composer-installer` package did not allow for PHPCS 4.x until version 0.7.