### PR TITLE
Bail out on `#[Override]`

### DIFF
--- a/SlevomatCodingStandard/Sniffs/TypeHints/ReturnTypeHintSniff.php
+++ b/SlevomatCodingStandard/Sniffs/TypeHints/ReturnTypeHintSniff.php
@@ -19,6 +19,7 @@ use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
 use SlevomatCodingStandard\Helpers\Annotation;
 use SlevomatCodingStandard\Helpers\AnnotationHelper;
 use SlevomatCodingStandard\Helpers\AnnotationTypeHelper;
+use SlevomatCodingStandard\Helpers\AttributeHelper;
 use SlevomatCodingStandard\Helpers\DocCommentHelper;
 use SlevomatCodingStandard\Helpers\FixerHelper;
 use SlevomatCodingStandard\Helpers\FunctionHelper;
@@ -106,6 +107,10 @@ class ReturnTypeHintSniff implements Sniff
 		);
 
 		if (SuppressHelper::isSniffSuppressed($phpcsFile, $pointer, self::NAME)) {
+			return;
+		}
+
+		if (AttributeHelper::hasAttribute($phpcsFile, $pointer, '\Override')) {
 			return;
 		}
 

--- a/tests/Sniffs/TypeHints/data/returnTypeHintNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/returnTypeHintNoErrors.php
@@ -1,8 +1,15 @@
 <?php // lint >= 8.0
 
-abstract class Whatever
-{
+use Override;
 
+interface FloatsYourBoat
+{
+	/** @return array{} */
+	public function overrideAttribute(): array;
+}
+
+abstract class Whatever implements FloatsYourBoat
+{
 	public function __construct()
 	{
 	}
@@ -85,6 +92,12 @@ abstract class Whatever
 	private function noTraversableType(): int
 	{
 		return 0;
+	}
+
+	#[Override]
+	public function overrideAttribute(): array
+	{
+		return [];
 	}
 
 	/**


### PR DESCRIPTION
`SlevomatCodingStandard.TypeHints.ReturnTypeHint`: do not report missing native type hint when method has `#[Override]` attribute.

Same as cda88e64329f1ad722a44357b1bb8b9173361187 but for return type declarations.

Closes #1824