### PR TITLE
Bail out earlier on #[Override]

### DIFF
--- a/SlevomatCodingStandard/Sniffs/TypeHints/PropertyTypeHintSniff.php
+++ b/SlevomatCodingStandard/Sniffs/TypeHints/PropertyTypeHintSniff.php
@@ -184,6 +184,8 @@ class PropertyTypeHintSniff implements Sniff
 		array $prefixedPropertyAnnotations
 	): void
 	{
+		$isInherited = AttributeHelper::hasAttribute($phpcsFile, $propertyPointer, '\Override');
+
 		$suppressNameAnyTypeHint = $this->getSniffName(self::CODE_MISSING_ANY_TYPE_HINT);
 		$isSuppressedAnyTypeHint = SuppressHelper::isSniffSuppressed($phpcsFile, $propertyPointer, $suppressNameAnyTypeHint);
 
@@ -204,7 +206,7 @@ class PropertyTypeHintSniff implements Sniff
 
 			if (
 				!$isSuppressedAnyTypeHint
-				&& !AttributeHelper::hasAttribute($phpcsFile, $propertyPointer, '\Override')
+				&& !$isInherited
 			) {
 				$phpcsFile->addError(
 					sprintf(
@@ -222,10 +224,6 @@ class PropertyTypeHintSniff implements Sniff
 		}
 
 		if (!$this->enableNativeTypeHint) {
-			return;
-		}
-
-		if (AttributeHelper::hasAttribute($phpcsFile, $propertyPointer, '\Override')) {
 			return;
 		}
 
@@ -365,7 +363,7 @@ class PropertyTypeHintSniff implements Sniff
 			$nullableTypeHint = true;
 		}
 
-		if ($isSuppressedNativeTypeHint) {
+		if ($isSuppressedNativeTypeHint || $isInherited) {
 			return;
 		}
 
@@ -429,6 +427,8 @@ class PropertyTypeHintSniff implements Sniff
 		array $prefixedPropertyAnnotations
 	): void
 	{
+		$isInherited = AttributeHelper::hasAttribute($phpcsFile, $propertyPointer, '\Override');
+
 		$suppressName = $this->getSniffName(self::CODE_MISSING_TRAVERSABLE_TYPE_HINT_SPECIFICATION);
 		$isSuppressed = SuppressHelper::isSniffSuppressed($phpcsFile, $propertyPointer, $suppressName);
 
@@ -444,7 +444,7 @@ class PropertyTypeHintSniff implements Sniff
 
 				if (
 					!$isSuppressed
-					&& !AttributeHelper::hasAttribute($phpcsFile, $propertyPointer, '\Override')
+					&& !$isInherited
 				) {
 					$phpcsFile->addError(
 						sprintf(

--- a/tests/Sniffs/TypeHints/data/parameterTypeHintNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/parameterTypeHintNoErrors.php
@@ -8,8 +8,9 @@ class ParentClass
 
 	/**
 	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint
+	 * @param array{} $b
 	 */
-	public function overrideAttribute($a): void
+	public function overrideAttribute($a, array $b): void
 	{
 	}
 
@@ -293,7 +294,7 @@ class Whatever extends ParentClass
 	 * @param bool $a
 	 */
 	#[Override]
-	public function overrideAttribute($a): void
+	public function overrideAttribute($a, array $b): void
 	{
 	}
 

--- a/tests/Sniffs/TypeHints/data/propertyTypeHintEnabledNativeNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/propertyTypeHintEnabledNativeNoErrors.php
@@ -200,9 +200,6 @@ class Whatever extends ParentClass
 	 */
 	public WeakMap $objectShapeInItems;
 
-	/**
-	 * @var string[]
-	 */
 	#[Override]
 	public $arrayTypeHint = ['hello'];
 


### PR DESCRIPTION
- `SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification`: do not report missing native type hint when method has `#[Override]` attribute.

- `SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint`: do not report missing native type hint when method has `#[Override]` attribute.

This time I took a more holistic approach and search for occurrences of `DocCommentHelper::hasInheritdocAnnotation`, and checked if there was a similar check for the override attribute.