### PR TITLE
Sort import traits inside class

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Slevomat Coding Standard for [PHP_CodeSniffer](https://github.com/PHPCSStandards
  - [SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming](doc/classes.md#slevomatcodingstandardclassessuperfluousinterfacenaming)
  - [SlevomatCodingStandard.Classes.SuperfluousTraitNaming](doc/classes.md#slevomatcodingstandardclassessuperfluoustraitnaming)
  - [SlevomatCodingStandard.Classes.TraitUseDeclaration](doc/classes.md#slevomatcodingstandardclassestraitusedeclaration-) 🔧
+ - [SlevomatCodingStandard.Classes.TraitUseOrder](doc/classes.md#slevomatcodingstandardclassestraituseorder-) 🔧
  - [SlevomatCodingStandard.Classes.TraitUseSpacing](doc/classes.md#slevomatcodingstandardclassestraitusespacing-) 🔧
  - [SlevomatCodingStandard.Classes.UselessLateStaticBinding](doc/classes.md#slevomatcodingstandardclassesuselesslatestaticbinding-) 🔧
  - [SlevomatCodingStandard.Commenting.AnnotationName](doc/commenting.md#slevomatcodingstandardcommentingannotationname-)

--- a/SlevomatCodingStandard/Helpers/NamespaceHelper.php
+++ b/SlevomatCodingStandard/Helpers/NamespaceHelper.php
@@ -12,7 +12,10 @@ use function defined;
 use function explode;
 use function implode;
 use function ltrim;
+use function min;
 use function sprintf;
+use function strcasecmp;
+use function strcmp;
 use function strpos;
 use const T_NAME_FULLY_QUALIFIED;
 use const T_NAMESPACE;
@@ -195,6 +198,33 @@ class NamespaceHelper
 			$name = sprintf('%s%s%s', self::NAMESPACE_SEPARATOR, $namespaceName, $name);
 		}
 		return $name;
+	}
+
+	public static function compareStatements(string $fqnA, string $fqnB, bool $caseSensitive): int
+	{
+		$aNameParts = explode(self::NAMESPACE_SEPARATOR, ltrim($fqnA, self::NAMESPACE_SEPARATOR));
+		$bNameParts = explode(self::NAMESPACE_SEPARATOR, ltrim($fqnB, self::NAMESPACE_SEPARATOR));
+
+		$minPartsCount = min(count($aNameParts), count($bNameParts));
+		for ($i = 0; $i < $minPartsCount; $i++) {
+			$comparison = self::compare($aNameParts[$i], $bNameParts[$i], $caseSensitive);
+			if ($comparison === 0) {
+				continue;
+			}
+
+			return $comparison;
+		}
+
+		return count($aNameParts) <=> count($bNameParts);
+	}
+
+	private static function compare(string $a, string $b, bool $caseSensitive): int
+	{
+		if ($caseSensitive) {
+			return strcmp($a, $b);
+		}
+
+		return strcasecmp($a, $b);
 	}
 
 }

--- a/SlevomatCodingStandard/Sniffs/Classes/TraitUseOrderSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/TraitUseOrderSniff.php
@@ -1,0 +1,177 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use SlevomatCodingStandard\Helpers\ClassHelper;
+use SlevomatCodingStandard\Helpers\FixerHelper;
+use SlevomatCodingStandard\Helpers\NamespaceHelper;
+use SlevomatCodingStandard\Helpers\TokenHelper;
+use function count;
+use function usort;
+use const T_ANON_CLASS;
+use const T_CLASS;
+use const T_ENUM;
+use const T_OPEN_CURLY_BRACKET;
+use const T_SEMICOLON;
+use const T_TRAIT;
+
+class TraitUseOrderSniff implements Sniff
+{
+
+	public const CODE_INCORRECT_ORDER = 'IncorrectOrder';
+
+	public bool $caseSensitive = false;
+
+	/**
+	 * @return array<int, (int|string)>
+	 */
+	public function register(): array
+	{
+		return [
+			T_CLASS,
+			T_ANON_CLASS,
+			T_TRAIT,
+			T_ENUM,
+		];
+	}
+
+	public function process(File $phpcsFile, int $classPointer): void
+	{
+		$usePointers = ClassHelper::getTraitUsePointers($phpcsFile, $classPointer);
+
+		if (count($usePointers) === 0) {
+			return;
+		}
+
+		$tokens = $phpcsFile->getTokens();
+
+		foreach ($usePointers as $usePointer) {
+			$this->processCommaSeparatedUse($phpcsFile, $classPointer, $usePointer);
+		}
+
+		if (count($usePointers) <= 1) {
+			return;
+		}
+
+		$uses = [];
+
+		foreach ($usePointers as $usePointer) {
+			/** @var int $nameStartPointer */
+			$nameStartPointer = TokenHelper::findNext($phpcsFile, TokenHelper::NAME_TOKEN_CODES, $usePointer + 1);
+
+			$name = $tokens[$nameStartPointer]['content'];
+
+			/** @var int $endPointer */
+			$endPointer = TokenHelper::findNextLocal($phpcsFile, [T_SEMICOLON, T_OPEN_CURLY_BRACKET], $usePointer + 1);
+
+			if ($tokens[$endPointer]['code'] === T_OPEN_CURLY_BRACKET) {
+				$endPointer = $tokens[$endPointer]['bracket_closer'];
+			}
+
+			$uses[] = [
+				'name' => $name,
+				'contentStartPointer' => $nameStartPointer,
+				'contentEndPointer' => $endPointer,
+			];
+		}
+
+		$sortedUses = $uses;
+
+		usort($sortedUses, fn (array $a, array $b): int => $this->compare($a['name'], $b['name']));
+
+		$isSorted = true;
+
+		for ($i = 0; $i < count($uses); $i++) {
+			if ($uses[$i]['name'] !== $sortedUses[$i]['name']) {
+				$isSorted = false;
+				break;
+			}
+		}
+
+		if ($isSorted) {
+			return;
+		}
+
+		$fix = $phpcsFile->addFixableError('Incorrect order of trait use statements.', $classPointer, self::CODE_INCORRECT_ORDER);
+
+		if (!$fix) {
+			return;
+		}
+
+		$sortedContents = [];
+
+		foreach ($sortedUses as $use) {
+			$sortedContents[] = TokenHelper::getContent($phpcsFile, $use['contentStartPointer'], $use['contentEndPointer']);
+		}
+
+		$phpcsFile->fixer->beginChangeset();
+
+		foreach ($uses as $i => $use) {
+			FixerHelper::change($phpcsFile, $use['contentStartPointer'], $use['contentEndPointer'], $sortedContents[$i]);
+		}
+
+		$phpcsFile->fixer->endChangeset();
+	}
+
+	private function compare(string $a, string $b): int
+	{
+		return NamespaceHelper::compareStatements($a, $b, $this->caseSensitive);
+	}
+
+	private function processCommaSeparatedUse(File $phpcsFile, int $classPointer, int $usePointer): void
+	{
+		$tokens = $phpcsFile->getTokens();
+
+		/** @var int $endPointer */
+		$endPointer = TokenHelper::findNextLocal($phpcsFile, [T_SEMICOLON, T_OPEN_CURLY_BRACKET], $usePointer + 1);
+
+		$namePointers = [];
+		$pointer = $usePointer + 1;
+
+		while ($pointer < $endPointer) {
+			$namePointer = TokenHelper::findNext($phpcsFile, TokenHelper::NAME_TOKEN_CODES, $pointer, $endPointer);
+
+			if ($namePointer === null) {
+				break;
+			}
+
+			$namePointers[] = $namePointer;
+			$pointer = $namePointer + 1;
+		}
+
+		if (count($namePointers) <= 1) {
+			return;
+		}
+
+		$names = [];
+
+		foreach ($namePointers as $namePointer) {
+			$names[] = $tokens[$namePointer]['content'];
+		}
+
+		$sortedNames = $names;
+
+		usort($sortedNames, fn (string $a, string $b): int => $this->compare($a, $b));
+
+		if ($names === $sortedNames) {
+			return;
+		}
+
+		$fix = $phpcsFile->addFixableError('Incorrect order of trait use statements.', $classPointer, self::CODE_INCORRECT_ORDER);
+
+		if (!$fix) {
+			return;
+		}
+
+		$phpcsFile->fixer->beginChangeset();
+
+		foreach ($namePointers as $i => $namePointer) {
+			$phpcsFile->fixer->replaceToken($namePointer, $sortedNames[$i]);
+		}
+
+		$phpcsFile->fixer->endChangeset();
+	}
+
+}

--- a/SlevomatCodingStandard/Sniffs/Namespaces/AlphabeticallySortedUsesSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/AlphabeticallySortedUsesSniff.php
@@ -14,16 +14,11 @@ use SlevomatCodingStandard\Helpers\UseStatement;
 use SlevomatCodingStandard\Helpers\UseStatementHelper;
 use function array_key_exists;
 use function array_map;
-use function count;
 use function end;
-use function explode;
 use function implode;
 use function in_array;
-use function min;
 use function reset;
 use function sprintf;
-use function strcasecmp;
-use function strcmp;
 use function uasort;
 use const T_COMMA;
 use const T_OPEN_TAG;
@@ -205,29 +200,7 @@ class AlphabeticallySortedUsesSniff implements Sniff
 			return $order[$a->getType()] <=> $order[$b->getType()];
 		}
 
-		$aNameParts = explode(NamespaceHelper::NAMESPACE_SEPARATOR, $a->getFullyQualifiedTypeName());
-		$bNameParts = explode(NamespaceHelper::NAMESPACE_SEPARATOR, $b->getFullyQualifiedTypeName());
-
-		$minPartsCount = min(count($aNameParts), count($bNameParts));
-		for ($i = 0; $i < $minPartsCount; $i++) {
-			$comparison = $this->compare($aNameParts[$i], $bNameParts[$i]);
-			if ($comparison === 0) {
-				continue;
-			}
-
-			return $comparison;
-		}
-
-		return count($aNameParts) <=> count($bNameParts);
-	}
-
-	private function compare(string $a, string $b): int
-	{
-		if ($this->caseSensitive) {
-			return strcmp($a, $b);
-		}
-
-		return strcasecmp($a, $b);
+		return NamespaceHelper::compareStatements($a->getFullyQualifiedTypeName(), $b->getFullyQualifiedTypeName(), $this->caseSensitive);
 	}
 
 }

--- a/doc/classes.md
+++ b/doc/classes.md
@@ -300,6 +300,14 @@ Reports use of superfluous suffix "Trait" for traits.
 
 Prohibits multiple traits separated by commas in one `use` statement.
 
+#### SlevomatCodingStandard.Classes.TraitUseOrder 🔧
+
+Enforces alphabetical order of trait `use` statements, both when traits are on separate lines and when they are comma-separated in a single `use` statement.
+
+Sniff provides the following settings:
+
+* `caseSensitive` (default: `false`): compare trait names case-sensitively.
+
 #### SlevomatCodingStandard.Classes.TraitUseSpacing 🔧
 
 Enforces configurable number of lines before first `use`, after last `use` and between two `use` statements.

--- a/tests/Sniffs/Classes/TraitUseOrderSniffTest.php
+++ b/tests/Sniffs/Classes/TraitUseOrderSniffTest.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Classes;
+
+use SlevomatCodingStandard\Sniffs\TestCase;
+
+class TraitUseOrderSniffTest extends TestCase
+{
+
+	public function testNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/traitUseOrderNoErrors.php');
+		self::assertNoSniffErrorInFile($report);
+		$report = self::checkFile(__DIR__ . '/data/traitUseEnumOrderNoErrors.php');
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/traitUseOrderErrors.php');
+
+		self::assertSame(7, $report->getErrorCount());
+
+		self::assertSniffError($report, 3, TraitUseOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 12, TraitUseOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 21, TraitUseOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 32, TraitUseOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 39, TraitUseOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 47, TraitUseOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 57, TraitUseOrderSniff::CODE_INCORRECT_ORDER);
+
+		self::assertAllFixedInFile($report);
+	}
+
+	public function testCaseSensitiveNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/traitUseOrderCaseSensitiveNoErrors.php', [
+			'caseSensitive' => true,
+		]);
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testCaseSensitiveErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/traitUseOrderCaseSensitiveErrors.php', [
+			'caseSensitive' => true,
+		]);
+
+		self::assertSame(1, $report->getErrorCount());
+
+		self::assertSniffError($report, 3, TraitUseOrderSniff::CODE_INCORRECT_ORDER);
+
+		self::assertAllFixedInFile($report);
+	}
+
+}

--- a/tests/Sniffs/Classes/data/traitUseEnumOrderNoErrors.php
+++ b/tests/Sniffs/Classes/data/traitUseEnumOrderNoErrors.php
@@ -1,0 +1,9 @@
+<?php // lint >= 8.1
+
+enum AlreadySortedEnum
+{
+
+	use A;
+	use B;
+
+}

--- a/tests/Sniffs/Classes/data/traitUseOrderCaseSensitiveErrors.fixed.php
+++ b/tests/Sniffs/Classes/data/traitUseOrderCaseSensitiveErrors.fixed.php
@@ -1,0 +1,9 @@
+<?php
+
+class CaseSensitiveUnsorted
+{
+
+	use B;
+	use a;
+
+}

--- a/tests/Sniffs/Classes/data/traitUseOrderCaseSensitiveErrors.php
+++ b/tests/Sniffs/Classes/data/traitUseOrderCaseSensitiveErrors.php
@@ -1,0 +1,9 @@
+<?php
+
+class CaseSensitiveUnsorted
+{
+
+	use a;
+	use B;
+
+}

--- a/tests/Sniffs/Classes/data/traitUseOrderCaseSensitiveNoErrors.php
+++ b/tests/Sniffs/Classes/data/traitUseOrderCaseSensitiveNoErrors.php
@@ -1,0 +1,9 @@
+<?php
+
+class CaseSensitiveSorted
+{
+
+	use B;
+	use a;
+
+}

--- a/tests/Sniffs/Classes/data/traitUseOrderErrors.fixed.php
+++ b/tests/Sniffs/Classes/data/traitUseOrderErrors.fixed.php
@@ -1,0 +1,62 @@
+<?php
+
+class UnsortedSimple
+{
+
+	use A;
+	use B;
+	use C;
+
+}
+
+class UnsortedFqn
+{
+
+	use \Foo\A;
+	use \Foo\B;
+	use \Foo\C;
+
+}
+
+class UnsortedWithAdaptation
+{
+
+	use A;
+	use B;
+	use C {
+		C::doSomething as doAnything;
+	}
+
+}
+
+class UnsortedOneline
+{
+
+	use A, B, C;
+
+}
+
+class UnsortedAnother
+{
+
+	use A;
+	use B;
+
+}
+
+class UnsortedMixed
+{
+
+	use A;
+	use Abc;
+	use B\C;
+	use \D\E\F;
+
+}
+
+class UnsortedMixedOneline
+{
+
+	use A, \Abc, B\C, \D\E\F;
+
+}

--- a/tests/Sniffs/Classes/data/traitUseOrderErrors.php
+++ b/tests/Sniffs/Classes/data/traitUseOrderErrors.php
@@ -1,0 +1,62 @@
+<?php
+
+class UnsortedSimple
+{
+
+	use C;
+	use A;
+	use B;
+
+}
+
+class UnsortedFqn
+{
+
+	use \Foo\C;
+	use \Foo\A;
+	use \Foo\B;
+
+}
+
+class UnsortedWithAdaptation
+{
+
+	use C {
+		C::doSomething as doAnything;
+	}
+	use A;
+	use B;
+
+}
+
+class UnsortedOneline
+{
+
+	use C, A, B;
+
+}
+
+class UnsortedAnother
+{
+
+	use B;
+	use A;
+
+}
+
+class UnsortedMixed
+{
+
+	use B\C;
+	use Abc;
+	use \D\E\F;
+	use A;
+
+}
+
+class UnsortedMixedOneline
+{
+
+	use B\C, \Abc, \D\E\F, A;
+
+}

--- a/tests/Sniffs/Classes/data/traitUseOrderNoErrors.php
+++ b/tests/Sniffs/Classes/data/traitUseOrderNoErrors.php
@@ -1,0 +1,66 @@
+<?php
+
+class NoUses
+{
+
+}
+
+class SingleUse
+{
+
+	use A;
+
+}
+
+class AlreadySorted
+{
+
+	use A;
+	use B;
+	use C;
+
+}
+
+class AlreadySortedFqn
+{
+
+	use \Foo\A;
+	use \Foo\B;
+	use \Foo\C;
+
+}
+
+trait AlreadySortedTrait
+{
+
+	use A;
+	use B;
+
+}
+
+class AlreadySortedWithAdaptation
+{
+
+	use A;
+	use B {
+		B::doSomething as doAnything;
+	}
+	use C;
+
+}
+
+class AlreadySortedMixed
+{
+
+	use A;
+	use B\C;
+	use \D\E\F;
+
+}
+
+class AlreadySortedMixedOneline
+{
+
+	use A, B\C, \D\E\F;
+
+}


### PR DESCRIPTION
Hi, I’ve prepared a sniff that sorts use statements inside a class alphabetically. Please take a look — I hope you’ll like it and that it can be merged into master. This is my first sniff.

Example:

```php
class UnsortedOneline
{
	use C, A, B;
}
```

fix
```php
class UnsortedOneline
{
	use A, B, C;
}
```