### PR TITLE
Sort exceptions in catch block

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Slevomat Coding Standard for [PHP_CodeSniffer](https://github.com/PHPCSStandards
  - [SlevomatCodingStandard.ControlStructures.UselessIfConditionWithReturn](doc/control-structures.md#slevomatcodingstandardcontrolstructuresuselessifconditionwithreturn-) 🔧
  - [SlevomatCodingStandard.ControlStructures.UselessTernaryOperator](doc/control-structures.md#slevomatcodingstandardcontrolstructuresuselessternaryoperator-) 🔧
  - [SlevomatCodingStandard.Exceptions.DeadCatch](doc/exceptions.md#slevomatcodingstandardexceptionsdeadcatch)
+ - [SlevomatCodingStandard.Exceptions.CatchExceptionsOrder](doc/exceptions.md#slevomatcodingstandardexceptionscatchexceptionsorder-) 🔧
  - [SlevomatCodingStandard.Exceptions.DisallowNonCapturingCatch](doc/exceptions.md#slevomatcodingstandardexceptionsdisallownoncapturingcatch)
  - [SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly](doc/exceptions.md#slevomatcodingstandardexceptionsreferencethrowableonly-) 🔧🚧
  - [SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch](doc/exceptions.md#slevomatcodingstandardexceptionsrequirenoncapturingcatch-) 🔧

--- a/SlevomatCodingStandard/Sniffs/Exceptions/CatchExceptionsOrderSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Exceptions/CatchExceptionsOrderSniff.php
@@ -1,0 +1,111 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Exceptions;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use SlevomatCodingStandard\Helpers\FixerHelper;
+use SlevomatCodingStandard\Helpers\NamespaceHelper;
+use SlevomatCodingStandard\Helpers\TokenHelper;
+use function count;
+use function usort;
+use const T_BITWISE_OR;
+use const T_CATCH;
+
+class CatchExceptionsOrderSniff implements Sniff
+{
+
+	public const CODE_INCORRECT_ORDER = 'IncorrectOrder';
+
+	public bool $caseSensitive = false;
+
+	/**
+	 * @return array<int, (int|string)>
+	 */
+	public function register(): array
+	{
+		return [
+			T_CATCH,
+		];
+	}
+
+	public function process(File $phpcsFile, int $catchPointer): void
+	{
+		$tokens = $phpcsFile->getTokens();
+		$catchToken = $tokens[$catchPointer];
+
+		/** @var int $parenthesisOpenerPointer */
+		$parenthesisOpenerPointer = $catchToken['parenthesis_opener'];
+		/** @var int $parenthesisCloserPointer */
+		$parenthesisCloserPointer = $catchToken['parenthesis_closer'];
+
+		/** @var list<array{name: string, startPointer: int, endPointer: int}> $exceptions */
+		$exceptions = [];
+		$nameEndPointer = $parenthesisOpenerPointer;
+
+		do {
+			$nameStartPointer = TokenHelper::findNext(
+				$phpcsFile,
+				[T_BITWISE_OR, ...TokenHelper::NAME_TOKEN_CODES],
+				$nameEndPointer + 1,
+				$parenthesisCloserPointer,
+			);
+
+			if ($nameStartPointer === null) {
+				break;
+			}
+
+			if ($tokens[$nameStartPointer]['code'] === T_BITWISE_OR) {
+				/** @var int $nameStartPointer */
+				$nameStartPointer = TokenHelper::findNextEffective($phpcsFile, $nameStartPointer + 1, $parenthesisCloserPointer);
+			}
+
+			$pointerAfterNameEndPointer = TokenHelper::findNextExcluding($phpcsFile, TokenHelper::NAME_TOKEN_CODES, $nameStartPointer + 1);
+			$nameEndPointer = $pointerAfterNameEndPointer === null ? $nameStartPointer : $pointerAfterNameEndPointer - 1;
+
+			$exceptions[] = [
+				'name' => TokenHelper::getContent($phpcsFile, $nameStartPointer, $nameEndPointer),
+				'startPointer' => $nameStartPointer,
+				'endPointer' => $nameEndPointer,
+			];
+		} while (true);
+
+		if (count($exceptions) <= 1) {
+			return;
+		}
+
+		$sortedNames = [];
+		foreach ($exceptions as $exception) {
+			$sortedNames[] = $exception['name'];
+		}
+		usort($sortedNames, fn (string $a, string $b): int => NamespaceHelper::compareStatements($a, $b, $this->caseSensitive));
+
+		$originalNames = [];
+		foreach ($exceptions as $exception) {
+			$originalNames[] = $exception['name'];
+		}
+
+		if ($sortedNames === $originalNames) {
+			return;
+		}
+
+		$fix = $phpcsFile->addFixableError(
+			'Caught exception types are not in alphabetical order.',
+			$catchPointer,
+			self::CODE_INCORRECT_ORDER,
+		);
+
+		if (!$fix) {
+			return;
+		}
+
+		$phpcsFile->fixer->beginChangeset();
+
+		foreach ($exceptions as $i => $exception) {
+			FixerHelper::change($phpcsFile, $exception['startPointer'], $exception['endPointer'], $sortedNames[$i]);
+		}
+
+		$phpcsFile->fixer->endChangeset();
+	}
+
+}

--- a/doc/exceptions.md
+++ b/doc/exceptions.md
@@ -1,5 +1,13 @@
 ## Exceptions
 
+#### SlevomatCodingStandard.Exceptions.CatchExceptionsOrder 🔧
+
+Enforces alphabetical order of caught exception types within a `catch` block.
+
+Sniff provides the following settings:
+
+* `caseSensitive` (default: `false`): compare exception names case-sensitively.
+
 #### SlevomatCodingStandard.Exceptions.DeadCatch
 
 This sniff finds unreachable catch blocks:

--- a/tests/Sniffs/Exceptions/CatchExceptionsOrderSniffTest.php
+++ b/tests/Sniffs/Exceptions/CatchExceptionsOrderSniffTest.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Exceptions;
+
+use SlevomatCodingStandard\Sniffs\TestCase;
+
+class CatchExceptionsOrderSniffTest extends TestCase
+{
+
+	public function testNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/catchExceptionsOrderNoErrors.php');
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/catchExceptionsOrderErrors.php');
+
+		self::assertSame(11, $report->getErrorCount());
+
+		self::assertSniffError($report, 8, CatchExceptionsOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 14, CatchExceptionsOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 20, CatchExceptionsOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 26, CatchExceptionsOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 32, CatchExceptionsOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 42, CatchExceptionsOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 51, CatchExceptionsOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 60, CatchExceptionsOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 66, CatchExceptionsOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 68, CatchExceptionsOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 70, CatchExceptionsOrderSniff::CODE_INCORRECT_ORDER);
+
+		self::assertAllFixedInFile($report);
+	}
+
+	public function testCaseSensitiveNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/catchExceptionsOrderCaseSensitiveNoErrors.php', [
+			'caseSensitive' => true,
+		]);
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testCaseSensitiveErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/catchExceptionsOrderCaseSensitiveErrors.php', [
+			'caseSensitive' => true,
+		]);
+
+		self::assertSame(2, $report->getErrorCount());
+
+		self::assertSniffError($report, 5, CatchExceptionsOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 11, CatchExceptionsOrderSniff::CODE_INCORRECT_ORDER);
+
+		self::assertAllFixedInFile($report);
+	}
+
+}

--- a/tests/Sniffs/Exceptions/data/catchExceptionsOrderCaseSensitiveErrors.fixed.php
+++ b/tests/Sniffs/Exceptions/data/catchExceptionsOrderCaseSensitiveErrors.fixed.php
@@ -1,0 +1,13 @@
+<?php
+
+try {
+	doSomething();
+} catch (BException | aException $e) {
+
+}
+
+try {
+	doSomething();
+} catch (\BBB | \Ccc | \aaa $e) {
+
+}

--- a/tests/Sniffs/Exceptions/data/catchExceptionsOrderCaseSensitiveErrors.php
+++ b/tests/Sniffs/Exceptions/data/catchExceptionsOrderCaseSensitiveErrors.php
@@ -1,0 +1,13 @@
+<?php
+
+try {
+	doSomething();
+} catch (aException | BException $e) {
+
+}
+
+try {
+	doSomething();
+} catch (\aaa | \BBB | \Ccc $e) {
+
+}

--- a/tests/Sniffs/Exceptions/data/catchExceptionsOrderCaseSensitiveNoErrors.php
+++ b/tests/Sniffs/Exceptions/data/catchExceptionsOrderCaseSensitiveNoErrors.php
@@ -1,0 +1,19 @@
+<?php
+
+try {
+	doSomething();
+} catch (BException | aException $e) {
+
+}
+
+try {
+	doSomething();
+} catch (\Aaa | \Bbb\DDD | Ccc $e) {
+
+}
+
+try {
+	doSomething();
+} catch (\BBB | \Ccc | \aaa $e) {
+
+}

--- a/tests/Sniffs/Exceptions/data/catchExceptionsOrderErrors.fixed.php
+++ b/tests/Sniffs/Exceptions/data/catchExceptionsOrderErrors.fixed.php
@@ -1,0 +1,72 @@
+<?php
+
+use Bar;
+use Foo;
+
+try {
+	doSomething();
+} catch (AException | BException $e) {
+
+}
+
+try {
+	doSomething();
+} catch (\Aaa | \Bbb | \Ccc $e) {
+
+}
+
+try {
+	doSomething();
+} catch (\Exception | \InvalidArgumentException $e) {
+
+}
+
+try {
+	doSomething();
+} catch (Bar\Aaa | Foo\Bbb $e) {
+
+}
+
+try {
+	doSomething();
+} catch (
+	\Aaa |
+	\Bbb |
+	\Ccc $e
+) {
+
+}
+
+try {
+	doSomething();
+} catch (
+	Bar\Aaa |
+	Foo\Bbb $e
+) {
+
+}
+
+try {
+	doSomething();
+} catch (
+	\Exception |
+	\InvalidArgumentException $e
+) {
+
+}
+
+try {
+	doSomething();
+} catch (\Aaa | \Bbb\DDD | Ccc $e) {
+
+}
+
+try {
+	doSomething();
+} catch (AException | CException | DException $e) {
+
+} catch (\Aaa | \Mmm | \Zzz $e) {
+
+} catch (Bar\Aaa | Bar\Ccc | Foo\Bbb $e) {
+
+}

--- a/tests/Sniffs/Exceptions/data/catchExceptionsOrderErrors.php
+++ b/tests/Sniffs/Exceptions/data/catchExceptionsOrderErrors.php
@@ -1,0 +1,72 @@
+<?php
+
+use Bar;
+use Foo;
+
+try {
+	doSomething();
+} catch (BException | AException $e) {
+
+}
+
+try {
+	doSomething();
+} catch (\Ccc | \Aaa | \Bbb $e) {
+
+}
+
+try {
+	doSomething();
+} catch (\InvalidArgumentException | \Exception $e) {
+
+}
+
+try {
+	doSomething();
+} catch (Foo\Bbb | Bar\Aaa $e) {
+
+}
+
+try {
+	doSomething();
+} catch (
+	\Ccc |
+	\Aaa |
+	\Bbb $e
+) {
+
+}
+
+try {
+	doSomething();
+} catch (
+	Foo\Bbb |
+	Bar\Aaa $e
+) {
+
+}
+
+try {
+	doSomething();
+} catch (
+	\InvalidArgumentException |
+	\Exception $e
+) {
+
+}
+
+try {
+	doSomething();
+} catch (Ccc | \Aaa | \Bbb\DDD $e) {
+
+}
+
+try {
+	doSomething();
+} catch (DException | CException | AException $e) {
+
+} catch (\Zzz | \Mmm | \Aaa $e) {
+
+} catch (Foo\Bbb | Bar\Ccc | Bar\Aaa $e) {
+
+}

--- a/tests/Sniffs/Exceptions/data/catchExceptionsOrderNoErrors.php
+++ b/tests/Sniffs/Exceptions/data/catchExceptionsOrderNoErrors.php
@@ -1,0 +1,41 @@
+<?php
+
+try {
+	doSomething();
+} catch (AException | BException $e) {
+
+}
+
+try {
+	doSomething();
+} catch (\AException | \BException $e) {
+
+}
+
+try {
+	doSomething();
+} catch (AException $e) {
+
+}
+
+try {
+	doSomething();
+} catch (\Aaa | \Bbb | \Ccc $e) {
+
+}
+
+try {
+	doSomething();
+} catch (Bar\Aaa | Foo\Bbb $e) {
+
+}
+
+try {
+	doSomething();
+} catch (AException | BException | CException $e) {
+
+} catch (\Ddd | \Eee | \Fff $e) {
+
+} catch (\Ggg | \Hhh $e) {
+
+}


### PR DESCRIPTION
Hi, I prepared sniff for check and sort exceptions in catch block alphabetically. 

Example:

```php
try {
	doSomething();
} catch (
	\Ccc |
	\Aaa |
	\Bbb $e
) {

}
```

fix to
```php
try {
	doSomething();
} catch (
	\Aaa |
	\Bbb |
	\Ccc $e
) {

}
```