### PR TITLE
Sort throws annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Slevomat Coding Standard for [PHP_CodeSniffer](https://github.com/PHPCSStandards
  - [SlevomatCodingStandard.Commenting.RequireOneDocComment](doc/commenting.md#slevomatcodingstandardcommentingrequireonedoccomment-) 🔧
  - [SlevomatCodingStandard.Commenting.RequireOneLineDocComment](doc/commenting.md#slevomatcodingstandardcommentingrequireonelinedoccomment-) 🔧
  - [SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment](doc/commenting.md#slevomatcodingstandardcommentingrequireonelinepropertydoccomment-) 🔧
+ - [SlevomatCodingStandard.Commenting.ThrowsAnnotationsOrder](doc/commenting.md#slevomatcodingstandardcommentingthrowsannotationsorder-) 🔧
  - [SlevomatCodingStandard.Commenting.UselessFunctionDocComment](doc/commenting.md#slevomatcodingstandardcommentinguselessfunctiondoccomment-) 🔧
  - [SlevomatCodingStandard.Commenting.UselessInheritDocComment](doc/commenting.md#slevomatcodingstandardcommentinguselessinheritdoccomment-) 🔧
  - [SlevomatCodingStandard.Complexity.Cognitive](doc/complexity.md#slevomatcodingstandardcomplexitycognitive)

--- a/SlevomatCodingStandard/Sniffs/Commenting/ThrowsAnnotationsOrderSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Commenting/ThrowsAnnotationsOrderSniff.php
@@ -1,0 +1,131 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ThrowsTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
+use SlevomatCodingStandard\Helpers\Annotation;
+use SlevomatCodingStandard\Helpers\AnnotationHelper;
+use SlevomatCodingStandard\Helpers\AnnotationTypeHelper;
+use SlevomatCodingStandard\Helpers\FixerHelper;
+use SlevomatCodingStandard\Helpers\IndentationHelper;
+use SlevomatCodingStandard\Helpers\NamespaceHelper;
+use SlevomatCodingStandard\Helpers\TokenHelper;
+use function array_keys;
+use function count;
+use function sprintf;
+use function trim;
+use function uasort;
+use const T_CLOSURE;
+use const T_FUNCTION;
+
+class ThrowsAnnotationsOrderSniff implements Sniff
+{
+
+	public const CODE_INCORRECT_ORDER = 'IncorrectOrder';
+
+	public bool $caseSensitive = false;
+
+	/**
+	 * @return array<int, (int|string)>
+	 */
+	public function register(): array
+	{
+		return [T_FUNCTION, T_CLOSURE];
+	}
+
+	public function process(File $phpcsFile, int $functionPointer): void
+	{
+		$annotations = AnnotationHelper::getAnnotations($phpcsFile, $functionPointer, '@throws');
+
+		if (count($annotations) <= 1) {
+			return;
+		}
+
+		$actualOrder = [];
+		foreach ($annotations as $key => $annotation) {
+			$actualOrder[$key] = $this->getExceptionName($annotation);
+		}
+
+		$expectedOrder = $actualOrder;
+		uasort($expectedOrder, fn (string $a, string $b): int => NamespaceHelper::compareStatements($a, $b, $this->caseSensitive));
+
+		if ($expectedOrder === $actualOrder) {
+			return;
+		}
+
+		$firstAnnotation = $annotations[0];
+
+		$fix = $phpcsFile->addFixableError(
+			'Incorrect order of @throws annotations.',
+			$firstAnnotation->getStartPointer(),
+			self::CODE_INCORRECT_ORDER,
+		);
+
+		if (!$fix) {
+			return;
+		}
+
+		$annotationsContent = [];
+		foreach ($annotations as $key => $annotation) {
+			$annotationsContent[$key] = trim(TokenHelper::getContent(
+				$phpcsFile,
+				$annotation->getStartPointer(),
+				$annotation->getEndPointer(),
+			));
+		}
+
+		$lastAnnotation = $annotations[count($annotations) - 1];
+		$indentation = IndentationHelper::getIndentation($phpcsFile, $firstAnnotation->getStartPointer());
+
+		// Build the replacement content
+		$fixedContent = '';
+		$isFirst = true;
+		foreach (array_keys($expectedOrder) as $key) {
+			if ($isFirst) {
+				$isFirst = false;
+			} else {
+				$fixedContent .= sprintf('%s%s', $phpcsFile->eolChar, $indentation);
+			}
+
+			$fixedContent .= $annotationsContent[$key];
+		}
+
+		$phpcsFile->fixer->beginChangeset();
+
+		FixerHelper::change(
+			$phpcsFile,
+			$firstAnnotation->getStartPointer(),
+			$lastAnnotation->getEndPointer(),
+			$fixedContent,
+		);
+
+		$phpcsFile->fixer->endChangeset();
+	}
+
+	/**
+	 * @param Annotation<ThrowsTagValueNode> $annotation
+	 */
+	private function getExceptionName(Annotation $annotation): string
+	{
+		if ($annotation->isInvalid()) {
+			return '';
+		}
+
+		$type = $annotation->getValue()->type;
+
+		if ($type instanceof IdentifierTypeNode) {
+			return $type->name;
+		}
+
+		if ($type instanceof UnionTypeNode && count($type->types) > 0 && $type->types[0] instanceof IdentifierTypeNode) {
+			return $type->types[0]->name;
+		}
+
+		return AnnotationTypeHelper::print($type);
+	}
+
+}

--- a/doc/commenting.md
+++ b/doc/commenting.md
@@ -106,6 +106,14 @@ Sniff requires comments with single-line content to be written as one-liners.
 
 Sniff requires comments with single-line content to be written as multi-liners.
 
+#### SlevomatCodingStandard.Commenting.ThrowsAnnotationsOrder 🔧
+
+Checks that `@throws` annotations are sorted alphabetically by exception class name.
+
+Sniff provides the following settings:
+
+* `caseSensitive`: compare class names case-sensitively. Default is `false`.
+
 #### SlevomatCodingStandard.Commenting.UselessFunctionDocComment 🔧
 
 * Checks for useless doc comments. If the native method declaration contains everything and the phpDoc does not add anything useful, it's reported as useless and can optionally be automatically removed with `phpcbf`.

--- a/tests/Sniffs/Commenting/ThrowsAnnotationsOrderSniffTest.php
+++ b/tests/Sniffs/Commenting/ThrowsAnnotationsOrderSniffTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatCodingStandard\Sniffs\Commenting;
+
+use SlevomatCodingStandard\Sniffs\TestCase;
+
+class ThrowsAnnotationsOrderSniffTest extends TestCase
+{
+
+	public function testNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/throwsAnnotationsOrderNoErrors.php');
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/throwsAnnotationsOrderErrors.php');
+
+		self::assertSame(7, $report->getErrorCount());
+
+		self::assertSniffError($report, 10, ThrowsAnnotationsOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 20, ThrowsAnnotationsOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 31, ThrowsAnnotationsOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 40, ThrowsAnnotationsOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 48, ThrowsAnnotationsOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 59, ThrowsAnnotationsOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 67, ThrowsAnnotationsOrderSniff::CODE_INCORRECT_ORDER);
+
+		self::assertAllFixedInFile($report);
+	}
+
+}

--- a/tests/Sniffs/Commenting/data/throwsAnnotationsOrderErrors.fixed.php
+++ b/tests/Sniffs/Commenting/data/throwsAnnotationsOrderErrors.fixed.php
@@ -1,0 +1,75 @@
+<?php
+
+use Bar;
+use Foo;
+
+class ErrorsClass
+{
+
+	/**
+	 * @throws \ArgumentCountError
+	 * @throws \Exception
+	 * @throws \InvalidArgumentException
+	 */
+	public function unorderedThrows(): void
+	{
+	}
+
+	/**
+	 * @param string $a
+	 * @throws \Aaa
+	 * @throws \Bbb
+	 * @throws \Ccc
+	 * @return int
+	 */
+	public function mixedAnnotations(string $a): int
+	{
+		return 0;
+	}
+
+	/**
+	 * @throws Bar\Exception
+	 * @throws Foo\ArgumentCountError
+	 * @throws InvalidArgumentException
+ 	 */
+	public function unqualifiedUnordered(): void
+	{
+	}
+
+	/**
+	 * @throws \Aaa Another description
+	 * @throws \Zzz Description
+	 */
+	public function withDescriptions(): void
+	{
+	}
+
+	/**
+	 * @throws A\Bc
+	 * @throws Abc
+	 * @throws C\D\E
+	 * @throws \Cd\E
+	 * @throws D\Ef
+	 */
+	public function namespacedMixed(): void
+	{
+	}
+
+	/**
+	 * @throws Def
+	 * @throws Xyz|Abc
+	 */
+	public function unionType(): void
+	{
+	}
+
+	/**
+	 * @throws
+	 * @throws Abc&Ghi
+	 * @throws Def
+	 */
+	public function invalidAndIntersection(): void
+	{
+	}
+
+}

--- a/tests/Sniffs/Commenting/data/throwsAnnotationsOrderErrors.php
+++ b/tests/Sniffs/Commenting/data/throwsAnnotationsOrderErrors.php
@@ -1,0 +1,75 @@
+<?php
+
+use Bar;
+use Foo;
+
+class ErrorsClass
+{
+
+	/**
+	 * @throws \InvalidArgumentException
+	 * @throws \ArgumentCountError
+	 * @throws \Exception
+	 */
+	public function unorderedThrows(): void
+	{
+	}
+
+	/**
+	 * @param string $a
+	 * @throws \Ccc
+	 * @throws \Aaa
+	 * @throws \Bbb
+	 * @return int
+	 */
+	public function mixedAnnotations(string $a): int
+	{
+		return 0;
+	}
+
+	/**
+	 * @throws Foo\ArgumentCountError
+	 * @throws InvalidArgumentException
+	 * @throws Bar\Exception
+ 	 */
+	public function unqualifiedUnordered(): void
+	{
+	}
+
+	/**
+	 * @throws \Zzz Description
+	 * @throws \Aaa Another description
+	 */
+	public function withDescriptions(): void
+	{
+	}
+
+	/**
+	 * @throws Abc
+	 * @throws A\Bc
+	 * @throws \Cd\E
+	 * @throws C\D\E
+	 * @throws D\Ef
+	 */
+	public function namespacedMixed(): void
+	{
+	}
+
+	/**
+	 * @throws Xyz|Abc
+	 * @throws Def
+	 */
+	public function unionType(): void
+	{
+	}
+
+	/**
+	 * @throws Def
+	 * @throws Abc&Ghi
+	 * @throws
+	 */
+	public function invalidAndIntersection(): void
+	{
+	}
+
+}

--- a/tests/Sniffs/Commenting/data/throwsAnnotationsOrderNoErrors.php
+++ b/tests/Sniffs/Commenting/data/throwsAnnotationsOrderNoErrors.php
@@ -1,0 +1,81 @@
+<?php
+
+use Bar;
+use Foo;
+
+class NoErrorsClass
+{
+
+	/**
+	 * @throws \ArgumentCountError
+	 * @throws \Exception
+	 * @throws \InvalidArgumentException
+	 */
+	public function orderedThrows(): void
+	{
+	}
+
+	/**
+	 * @throws \Exception
+	 */
+	public function singleThrow(): void
+	{
+	}
+
+	/**
+	 * No throws annotation
+	 */
+	public function noThrows(): void
+	{
+	}
+
+	/**
+	 * @param string $a
+	 * @throws \Aaa
+	 * @throws \Bbb
+	 * @throws \Ccc
+	 * @return int
+	 */
+	public function mixedAnnotations(string $a): int
+	{
+		return 0;
+	}
+
+	/**
+	 * @throws Bar\Exception
+	 * @throws Foo\ArgumentCountError
+	 * @throws InvalidArgumentException
+	 */
+	public function unqualifiedOrdered(): void
+	{
+	}
+
+	/**
+	 * @throws A\Bc
+	 * @throws Abc
+	 * @throws C\D\E
+	 * @throws \Cd\E
+	 * @throws D\Ef
+	 */
+	public function namespacedMixed(): void
+	{
+	}
+
+	/**
+	 * @throws Def
+	 * @throws Xyz|Abc
+	 */
+	public function unionType(): void
+	{
+	}
+
+	/**
+	 * @throws
+	 * @throws Abc&Ghi
+	 * @throws Def
+	 */
+	public function invalidAndIntersection(): void
+	{
+	}
+
+}


### PR DESCRIPTION
Hi, I prepared new sniff for sort @throws annotations in phpdoc alphabeticaly.

Example:
```php
class ErrorsClass
{
	/**
	 * @throws \InvalidArgumentException
	 * @throws \ArgumentCountError
	 * @throws \Exception
	 */
	public function unorderedThrows(): void
	{
	}
}
```
fix to
```php
class ErrorsClass
{
	/**
	 * @throws \ArgumentCountError
	 * @throws \Exception
	 * @throws \InvalidArgumentException
	 */
	public function unorderedThrows(): void
	{
	}
}
```