### PR TITLE
SlevomatCodingStandard.Classes.TraitUseOrder: Sort comments with trait use statements

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Classes/TraitUseOrderSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/TraitUseOrderSniff.php
@@ -12,6 +12,8 @@ use function count;
 use function usort;
 use const T_ANON_CLASS;
 use const T_CLASS;
+use const T_COMMENT;
+use const T_DOC_COMMENT_CLOSE_TAG;
 use const T_ENUM;
 use const T_OPEN_CURLY_BRACKET;
 use const T_SEMICOLON;
@@ -70,9 +72,28 @@ class TraitUseOrderSniff implements Sniff
 				$endPointer = $tokens[$endPointer]['bracket_closer'];
 			}
 
+			$contentStartPointer = $usePointer;
+			$previousNonWhitespace = TokenHelper::findPreviousNonWhitespace($phpcsFile, $usePointer - 1);
+
+			if ($previousNonWhitespace !== null && $tokens[$previousNonWhitespace]['code'] === T_DOC_COMMENT_CLOSE_TAG) {
+				$contentStartPointer = $tokens[$previousNonWhitespace]['comment_opener'];
+			} elseif ($previousNonWhitespace !== null && $tokens[$previousNonWhitespace]['code'] === T_COMMENT) {
+				$contentStartPointer = $previousNonWhitespace;
+
+				while (true) {
+					$prev = TokenHelper::findPreviousNonWhitespace($phpcsFile, $contentStartPointer - 1);
+
+					if ($prev === null || $tokens[$prev]['code'] !== T_COMMENT) {
+						break;
+					}
+
+					$contentStartPointer = $prev;
+				}
+			}
+
 			$uses[] = [
 				'name' => $name,
-				'contentStartPointer' => $nameStartPointer,
+				'contentStartPointer' => $contentStartPointer,
 				'contentEndPointer' => $endPointer,
 			];
 		}

--- a/tests/Sniffs/Classes/TraitUseOrderSniffTest.php
+++ b/tests/Sniffs/Classes/TraitUseOrderSniffTest.php
@@ -19,7 +19,7 @@ class TraitUseOrderSniffTest extends TestCase
 	{
 		$report = self::checkFile(__DIR__ . '/data/traitUseOrderErrors.php');
 
-		self::assertSame(7, $report->getErrorCount());
+		self::assertSame(11, $report->getErrorCount());
 
 		self::assertSniffError($report, 3, TraitUseOrderSniff::CODE_INCORRECT_ORDER);
 		self::assertSniffError($report, 12, TraitUseOrderSniff::CODE_INCORRECT_ORDER);
@@ -28,6 +28,10 @@ class TraitUseOrderSniffTest extends TestCase
 		self::assertSniffError($report, 39, TraitUseOrderSniff::CODE_INCORRECT_ORDER);
 		self::assertSniffError($report, 47, TraitUseOrderSniff::CODE_INCORRECT_ORDER);
 		self::assertSniffError($report, 57, TraitUseOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 64, TraitUseOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 74, TraitUseOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 84, TraitUseOrderSniff::CODE_INCORRECT_ORDER);
+		self::assertSniffError($report, 96, TraitUseOrderSniff::CODE_INCORRECT_ORDER);
 
 		self::assertAllFixedInFile($report);
 	}

--- a/tests/Sniffs/Classes/data/traitUseOrderErrors.fixed.php
+++ b/tests/Sniffs/Classes/data/traitUseOrderErrors.fixed.php
@@ -60,3 +60,49 @@ class UnsortedMixedOneline
 	use A, \Abc, B\C, \D\E\F;
 
 }
+
+class UnsortedWithDocBlocks
+{
+
+	/** @use AnotherGenericTrait<int> */
+	use AnotherGenericTrait;
+	/** @use GenericTrait<string> */
+	use GenericTrait;
+
+}
+
+class UnsortedWithInlineComments
+{
+
+	// AnotherGenericTrait comment
+	use AnotherGenericTrait;
+	// GenericTrait comment
+	use GenericTrait;
+
+}
+
+class UnsortedWithMultiLineInlineComments
+{
+
+	// AnotherGenericTrait comment
+	// second line
+	use AnotherGenericTrait;
+	// GenericTrait comment
+	// second line
+	use GenericTrait;
+
+}
+
+class UnsortedWithMultiLineDocBlocks
+{
+
+	/**
+	 * @use AnotherGenericTrait<int>
+	 */
+	use AnotherGenericTrait;
+	/**
+	 * @use GenericTrait<string>
+	 */
+	use GenericTrait;
+
+}

--- a/tests/Sniffs/Classes/data/traitUseOrderErrors.php
+++ b/tests/Sniffs/Classes/data/traitUseOrderErrors.php
@@ -60,3 +60,49 @@ class UnsortedMixedOneline
 	use B\C, \Abc, \D\E\F, A;
 
 }
+
+class UnsortedWithDocBlocks
+{
+
+	/** @use GenericTrait<string> */
+	use GenericTrait;
+	/** @use AnotherGenericTrait<int> */
+	use AnotherGenericTrait;
+
+}
+
+class UnsortedWithInlineComments
+{
+
+	// GenericTrait comment
+	use GenericTrait;
+	// AnotherGenericTrait comment
+	use AnotherGenericTrait;
+
+}
+
+class UnsortedWithMultiLineInlineComments
+{
+
+	// GenericTrait comment
+	// second line
+	use GenericTrait;
+	// AnotherGenericTrait comment
+	// second line
+	use AnotherGenericTrait;
+
+}
+
+class UnsortedWithMultiLineDocBlocks
+{
+
+	/**
+	 * @use GenericTrait<string>
+	 */
+	use GenericTrait;
+	/**
+	 * @use AnotherGenericTrait<int>
+	 */
+	use AnotherGenericTrait;
+
+}

--- a/tests/Sniffs/Classes/data/traitUseOrderNoErrors.php
+++ b/tests/Sniffs/Classes/data/traitUseOrderNoErrors.php
@@ -64,3 +64,49 @@ class AlreadySortedMixedOneline
 	use A, B\C, \D\E\F;
 
 }
+
+class AlreadySortedWithDocBlocks
+{
+
+	/** @use AnotherGenericTrait<int> */
+	use AnotherGenericTrait;
+	/** @use GenericTrait<string> */
+	use GenericTrait;
+
+}
+
+class AlreadySortedWithInlineComments
+{
+
+	// AnotherGenericTrait comment
+	use AnotherGenericTrait;
+	// GenericTrait comment
+	use GenericTrait;
+
+}
+
+class AlreadySortedWithMultiLineInlineComments
+{
+
+	// AnotherGenericTrait comment
+	// second line
+	use AnotherGenericTrait;
+	// GenericTrait comment
+	// second line
+	use GenericTrait;
+
+}
+
+class AlreadySortedWithMultiLineDocBlocks
+{
+
+	/**
+	 * @use AnotherGenericTrait<int>
+	 */
+	use AnotherGenericTrait;
+	/**
+	 * @use GenericTrait<string>
+	 */
+	use GenericTrait;
+
+}


### PR DESCRIPTION
Stumbled upon this when trying to integrate PHPCS into our codebase. Laravel has some generic traits and `SlevomatCodingStandard.Classes.TraitUseOrder` ignores the DocBlocks when sorting the `use` statements.