### PR TITLE
[#1842] Fixed undefined array key in 'ReferencedNameHelper' when processing fully-qualified names in strings.

### DIFF
--- a/SlevomatCodingStandard/Helpers/ReferencedNameHelper.php
+++ b/SlevomatCodingStandard/Helpers/ReferencedNameHelper.php
@@ -44,7 +44,6 @@ use const T_OPEN_PARENTHESIS;
 use const T_OPEN_SHORT_ARRAY;
 use const T_OPEN_TAG;
 use const T_PARAM_NAME;
-use const T_STRING;
 use const T_TRAIT;
 use const T_TYPE_INTERSECTION;
 use const T_TYPE_UNION;
@@ -438,7 +437,11 @@ class ReferencedNameHelper
 				$referencedName = '';
 				$tmpPosition = $position - 1;
 				while (true) {
-					if (!is_array($subTokens[$tmpPosition]) || $subTokens[$tmpPosition][0] !== T_STRING) {
+					if (!isset($subTokens[$tmpPosition]) || !is_array($subTokens[$tmpPosition])) {
+						break;
+					}
+					// We need to check namespace separator because of support for PHP 7.4
+					if (!in_array($subTokens[$tmpPosition][0], [T_NS_SEPARATOR, ...TokenHelper::NAME_TOKEN_CODES], true)) {
 						break;
 					}
 
@@ -446,12 +449,14 @@ class ReferencedNameHelper
 					$tmpPosition--;
 				}
 
-				$referencedNames[] = $referencedName;
+				if ($referencedName !== '') {
+					$referencedNames[] = $referencedName;
+				}
 			} elseif (is_array($token) && $token[0] === T_NEW) {
 				$referencedName = '';
 				$tmpPosition = $position + 1;
 				while (true) {
-					if (!is_array($subTokens[$tmpPosition])) {
+					if (!isset($subTokens[$tmpPosition]) || !is_array($subTokens[$tmpPosition])) {
 						break;
 					}
 					if ($subTokens[$tmpPosition][0] === T_WHITESPACE) {

--- a/tests/Helpers/ReferencedNameHelperTest.php
+++ b/tests/Helpers/ReferencedNameHelperTest.php
@@ -243,4 +243,25 @@ class ReferencedNameHelperTest extends TestCase
 		}
 	}
 
+	public function testReferencedNamesFromStringBoundsCheck(): void
+	{
+		$phpcsFile = $this->getCodeSnifferFile(__DIR__ . '/data/referencedNamesFromStringBoundsCheck.php');
+
+		$expectedTypes = [
+			['\Exception', false, false],
+			['\Some\ClassName', false, false],
+			['\Another\ClassName', false, false],
+		];
+
+		$names = ReferencedNameHelper::getAllReferencedNames($phpcsFile, 0);
+		self::assertCount(count($expectedTypes), $names);
+		foreach ($names as $i => $referencedName) {
+			[$type, $isFunction, $isConstant] = $expectedTypes[$i];
+
+			self::assertSame($type, $referencedName->getNameAsReferencedInFile());
+			self::assertSame($isFunction, $referencedName->isFunction(), $type);
+			self::assertSame($isConstant, $referencedName->isConstant(), $type);
+		}
+	}
+
 }

--- a/tests/Helpers/data/referencedNamesFromStringBoundsCheck.php
+++ b/tests/Helpers/data/referencedNamesFromStringBoundsCheck.php
@@ -1,0 +1,8 @@
+<?php
+
+$a = "{$foo(\Exception::class)}";
+$b = "{$foo(new \Some\ClassName)}";
+$c = <<<EOT
+{$foo(new \Another\ClassName)}
+EOT;
+$d = "{$foo($var::method)}";


### PR DESCRIPTION
Closes #1842

## Summary

Fixed `ReferencedNameHelper::getReferencedNamesFromString()` crashing with "Undefined array key" when processing fully-qualified class references inside interpolated strings and heredocs. The `T_DOUBLE_COLON` backward loop only checked for `T_STRING` tokens, missing `T_NAME_FULLY_QUALIFIED` and `T_NS_SEPARATOR` (used in PHP 8+ and PHP 7.4 respectively). Both the `T_DOUBLE_COLON` and `T_NEW` loops also lacked array bounds checking, which could cause crashes when class references appeared near the end of a tokenized string.

## Changes

### Bug fix — `SlevomatCodingStandard/Helpers/ReferencedNameHelper.php`

- **T_DOUBLE_COLON backward loop**: Added `isset()` bounds check and expanded token matching from just `T_STRING` to `[T_NS_SEPARATOR, ...TokenHelper::NAME_TOKEN_CODES]` (which includes `T_STRING`, `T_NAME_FULLY_QUALIFIED`, `T_NAME_QUALIFIED`, `T_NAME_RELATIVE`). Also skip empty referenced names, consistent with the `T_NEW` branch.
- **T_NEW forward loop**: Added `isset()` bounds check before accessing `$subTokens[$tmpPosition]`.

### Tests — `tests/Helpers/`

- Added `testReferencedNamesFromStringBoundsCheck` test method covering fully-qualified class references via `::class` and `new` inside double-quoted strings and heredocs.
- Added fixture file `referencedNamesFromStringBoundsCheck.php` with three cases: `\Exception::class` in a double-quoted string, `new \Some\ClassName` in a double-quoted string, and `new \Another\ClassName` in a heredoc.

## Before / After

```
Before:
┌─────────────────────────────────────────────────────┐
│ T_DOUBLE_COLON backward loop                        │
│                                                     │
│  while (true) {                                     │
│    if (!is_array(tokens[pos])                        │  ← no isset() check
│        || tokens[pos][0] !== T_STRING) break;        │  ← only T_STRING
│    name = tokens[pos][1] . name;                     │
│    pos--;                                            │
│  }                                                   │
│  names[] = name;   ← always adds, even if empty      │
└─────────────────────────────────────────────────────┘

After:
┌─────────────────────────────────────────────────────┐
│ T_DOUBLE_COLON backward loop                        │
│                                                     │
│  while (true) {                                     │
│    if (!isset(tokens[pos])                           │  ← bounds check
│        || !is_array(tokens[pos])) break;             │
│    if (!in_array(tokens[pos][0],                     │  ← NAME_TOKEN_CODES
│        [T_NS_SEPARATOR, ...NAME_TOKEN_CODES])) break;│    + T_NS_SEPARATOR
│    name = tokens[pos][1] . name;                     │
│    pos--;                                            │
│  }                                                   │
│  if (name !== '') names[] = name;  ← skip empty      │
└─────────────────────────────────────────────────────┘
```
