### PR TITLE
Use exisiting alias in ReferenceUsedNamesOnlySniff

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Namespaces/ReferenceUsedNamesOnlySniff.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/ReferenceUsedNamesOnlySniff.php
@@ -429,21 +429,25 @@ class ReferenceUsedNamesOnlySniff implements Sniff
 				$canBeFixed = false;
 			}
 
+			$hasExistingUseForCanonicalName = false;
+			$hasCollision = false;
 			foreach ($useStatements as $useStatement) {
 				if ($useStatement->getType() !== $reference->type) {
 					continue;
 				}
 
 				if ($useStatement->getFullyQualifiedTypeName() === $canonicalName) {
-					continue;
+					$hasExistingUseForCanonicalName = true;
+					break;
 				}
 
-				if ($useStatement->getCanonicalNameAsReferencedInFile() !== $canonicalNameToReference) {
-					continue;
+				if ($useStatement->getCanonicalNameAsReferencedInFile() === $canonicalNameToReference) {
+					$hasCollision = true;
 				}
+			}
 
+			if ($hasCollision && !$hasExistingUseForCanonicalName) {
 				$canBeFixed = false;
-				break;
 			}
 
 			$label = sprintf(

--- a/tests/Sniffs/Namespaces/ReferenceUsedNamesOnlySniffTest.php
+++ b/tests/Sniffs/Namespaces/ReferenceUsedNamesOnlySniffTest.php
@@ -1214,6 +1214,15 @@ class ReferenceUsedNamesOnlySniffTest extends TestCase
 		self::assertAllFixedInFile($report);
 	}
 
+	public function testWithExistingAlias(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/referenceUsedNamesOnlyWithExistingAlias.php');
+
+		self::assertSniffError($report, 8, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
+
+		self::assertAllFixedInFile($report);
+	}
+
 	public function testAttributes(): void
 	{
 		$report = self::checkFile(__DIR__ . '/data/referenceUsedNamesOnlyInAttributes.php', [

--- a/tests/Sniffs/Namespaces/data/referenceUsedNamesOnlyWithExistingAlias.fixed.php
+++ b/tests/Sniffs/Namespaces/data/referenceUsedNamesOnlyWithExistingAlias.fixed.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace TestNamespace;
+
+use Foo\Bar;
+use Baz\Bar as BazBar;
+
+$x = new BazBar();

--- a/tests/Sniffs/Namespaces/data/referenceUsedNamesOnlyWithExistingAlias.php
+++ b/tests/Sniffs/Namespaces/data/referenceUsedNamesOnlyWithExistingAlias.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace TestNamespace;
+
+use Foo\Bar;
+use Baz\Bar as BazBar;
+
+$x = new \Baz\Bar();


### PR DESCRIPTION
There was an issue in `ReferenceUsedNamesOnlySniff` where it would not replace a FQCN with an already existing alias.