### PR TITLE
Fix ReferenceUsedNamesOnlySniff to use existing alias when colliding class names are allowed

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Namespaces/ReferenceUsedNamesOnlySniff.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/ReferenceUsedNamesOnlySniff.php
@@ -214,58 +214,71 @@ class ReferenceUsedNamesOnlySniff implements Sniff
 			}
 
 			if ($isFullyQualified) {
-				if ($reference->isClass && $this->allowFullyQualifiedNameForCollidingClasses) {
-					$lowerCasedUnqualifiedClassName = strtolower($unqualifiedName);
+				$hasExistingUseForCanonicalName = false;
+				foreach ($useStatements as $useStatement) {
 					if (
-						array_key_exists($lowerCasedUnqualifiedClassName, $definedClassesIndex)
-						&& $canonicalName !== NamespaceHelper::normalizeToCanonicalName(
-							$definedClassesIndex[$lowerCasedUnqualifiedClassName],
-						)
+						$useStatement->getType() === $reference->type
+						&& $useStatement->getFullyQualifiedTypeName() === $canonicalName
 					) {
-						continue;
+						$hasExistingUseForCanonicalName = true;
+						break;
 					}
+				}
 
-					if (
-						array_key_exists($lowerCasedUnqualifiedClassName, $classReferencesIndex)
-						&& $name !== $classReferencesIndex[$lowerCasedUnqualifiedClassName]
-					) {
-						continue;
-					}
+				if (!$hasExistingUseForCanonicalName) {
+					if ($reference->isClass && $this->allowFullyQualifiedNameForCollidingClasses) {
+						$lowerCasedUnqualifiedClassName = strtolower($unqualifiedName);
+						if (
+							array_key_exists($lowerCasedUnqualifiedClassName, $definedClassesIndex)
+							&& $canonicalName !== NamespaceHelper::normalizeToCanonicalName(
+								$definedClassesIndex[$lowerCasedUnqualifiedClassName],
+							)
+						) {
+							continue;
+						}
 
-					if (
-						array_key_exists($collidingUseStatementUniqueId, $useStatements)
-						&& $canonicalName !== NamespaceHelper::normalizeToCanonicalName(
-							$useStatements[$collidingUseStatementUniqueId]->getFullyQualifiedTypeName(),
-						)
-					) {
-						continue;
-					}
-				} elseif ($reference->isFunction && $this->allowFullyQualifiedNameForCollidingFunctions) {
-					$lowerCasedUnqualifiedFunctionName = strtolower($unqualifiedName);
-					if (array_key_exists($lowerCasedUnqualifiedFunctionName, $definedFunctionsIndex)) {
-						continue;
-					}
+						if (
+							array_key_exists($lowerCasedUnqualifiedClassName, $classReferencesIndex)
+							&& $name !== $classReferencesIndex[$lowerCasedUnqualifiedClassName]
+						) {
+							continue;
+						}
 
-					if (
-						array_key_exists($collidingUseStatementUniqueId, $useStatements)
-						&& $canonicalName !== NamespaceHelper::normalizeToCanonicalName(
-							$useStatements[$collidingUseStatementUniqueId]->getFullyQualifiedTypeName(),
-						)
-					) {
-						continue;
-					}
-				} elseif ($reference->isConstant && $this->allowFullyQualifiedNameForCollidingConstants) {
-					if (array_key_exists($unqualifiedName, $definedConstantsIndex)) {
-						continue;
-					}
+						if (
+							array_key_exists($collidingUseStatementUniqueId, $useStatements)
+							&& $canonicalName !== NamespaceHelper::normalizeToCanonicalName(
+								$useStatements[$collidingUseStatementUniqueId]->getFullyQualifiedTypeName(),
+							)
+						) {
+							continue;
+						}
+					} elseif ($reference->isFunction && $this->allowFullyQualifiedNameForCollidingFunctions) {
+						$lowerCasedUnqualifiedFunctionName = strtolower($unqualifiedName);
+						if (array_key_exists($lowerCasedUnqualifiedFunctionName, $definedFunctionsIndex)) {
+							continue;
+						}
 
-					if (
-						array_key_exists($collidingUseStatementUniqueId, $useStatements)
-						&& $canonicalName !== NamespaceHelper::normalizeToCanonicalName(
-							$useStatements[$collidingUseStatementUniqueId]->getFullyQualifiedTypeName(),
-						)
-					) {
-						continue;
+						if (
+							array_key_exists($collidingUseStatementUniqueId, $useStatements)
+							&& $canonicalName !== NamespaceHelper::normalizeToCanonicalName(
+								$useStatements[$collidingUseStatementUniqueId]->getFullyQualifiedTypeName(),
+							)
+						) {
+							continue;
+						}
+					} elseif ($reference->isConstant && $this->allowFullyQualifiedNameForCollidingConstants) {
+						if (array_key_exists($unqualifiedName, $definedConstantsIndex)) {
+							continue;
+						}
+
+						if (
+							array_key_exists($collidingUseStatementUniqueId, $useStatements)
+							&& $canonicalName !== NamespaceHelper::normalizeToCanonicalName(
+								$useStatements[$collidingUseStatementUniqueId]->getFullyQualifiedTypeName(),
+							)
+						) {
+							continue;
+						}
 					}
 				}
 			}
@@ -412,23 +425,6 @@ class ReferenceUsedNamesOnlySniff implements Sniff
 				true,
 			);
 
-			if (
-				(
-					$reference->isClass
-					&& array_key_exists($canonicalNameToReference, $definedClassesIndex)
-					&& $canonicalName !== NamespaceHelper::normalizeToCanonicalName($definedClassesIndex[$canonicalNameToReference])
-				)
-				|| (
-					$reference->isClass
-					&& array_key_exists($canonicalNameToReference, $classReferencesIndex)
-					&& $canonicalName !== NamespaceHelper::normalizeToCanonicalName($classReferencesIndex[$canonicalNameToReference])
-				)
-				|| ($reference->isFunction && array_key_exists($canonicalNameToReference, $definedFunctionsIndex))
-				|| ($reference->isConstant && array_key_exists($canonicalNameToReference, $definedConstantsIndex))
-			) {
-				$canBeFixed = false;
-			}
-
 			$hasExistingUseForCanonicalName = false;
 			$hasCollision = false;
 			foreach ($useStatements as $useStatement) {
@@ -446,8 +442,27 @@ class ReferenceUsedNamesOnlySniff implements Sniff
 				}
 			}
 
-			if ($hasCollision && !$hasExistingUseForCanonicalName) {
-				$canBeFixed = false;
+			if (!$hasExistingUseForCanonicalName) {
+				if (
+					(
+						$reference->isClass
+						&& array_key_exists($canonicalNameToReference, $definedClassesIndex)
+						&& $canonicalName !== NamespaceHelper::normalizeToCanonicalName($definedClassesIndex[$canonicalNameToReference])
+					)
+					|| (
+						$reference->isClass
+						&& array_key_exists($canonicalNameToReference, $classReferencesIndex)
+						&& $canonicalName !== NamespaceHelper::normalizeToCanonicalName($classReferencesIndex[$canonicalNameToReference])
+					)
+					|| ($reference->isFunction && array_key_exists($canonicalNameToReference, $definedFunctionsIndex))
+					|| ($reference->isConstant && array_key_exists($canonicalNameToReference, $definedConstantsIndex))
+				) {
+					$canBeFixed = false;
+				}
+
+				if ($hasCollision) {
+					$canBeFixed = false;
+				}
 			}
 
 			$label = sprintf(

--- a/tests/Sniffs/Namespaces/ReferenceUsedNamesOnlySniffTest.php
+++ b/tests/Sniffs/Namespaces/ReferenceUsedNamesOnlySniffTest.php
@@ -627,6 +627,38 @@ class ReferenceUsedNamesOnlySniffTest extends TestCase
 		self::assertSniffError($report, 14, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
 	}
 
+	public function testCollidingClassNameWithExistingAliasAllowed(): void
+	{
+		$report = self::checkFile(
+			__DIR__ . '/data/collidingClassNameWithExistingAlias.php',
+			['allowFullyQualifiedNameForCollidingClasses' => true],
+		);
+
+		self::assertSame(2, $report->getErrorCount());
+
+		self::assertSniffError($report, 15, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
+		self::assertSniffError($report, 17, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
+
+		self::assertAllFixedInFile($report);
+	}
+
+	public function testCollidingClassNameWithExistingAliasInAnnotationAllowed(): void
+	{
+		$report = self::checkFile(
+			__DIR__ . '/data/collidingClassNameWithExistingAliasInAnnotation.php',
+			[
+				'searchAnnotations' => true,
+				'allowFullyQualifiedNameForCollidingClasses' => true,
+			],
+		);
+
+		self::assertSame(1, $report->getErrorCount());
+
+		self::assertSniffError($report, 11, ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME);
+
+		self::assertAllFixedInFile($report);
+	}
+
 	public function testFixableWhenCollidingClassNames(): void
 	{
 		$report = self::checkFile(

--- a/tests/Sniffs/Namespaces/data/collidingClassNameWithExistingAlias.fixed.php
+++ b/tests/Sniffs/Namespaces/data/collidingClassNameWithExistingAlias.fixed.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace TestNamespace;
+
+use Foo\User;
+use Bar\User as BarUser;
+
+class Test {
+
+	public function foo(): User
+	{
+		return new User();
+	}
+
+	public function bar(): BarUser
+	{
+		return new BarUser();
+	}
+
+}

--- a/tests/Sniffs/Namespaces/data/collidingClassNameWithExistingAlias.php
+++ b/tests/Sniffs/Namespaces/data/collidingClassNameWithExistingAlias.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace TestNamespace;
+
+use Foo\User;
+use Bar\User as BarUser;
+
+class Test {
+
+	public function foo(): User
+	{
+		return new User();
+	}
+
+	public function bar(): \Bar\User
+	{
+		return new \Bar\User();
+	}
+
+}

--- a/tests/Sniffs/Namespaces/data/collidingClassNameWithExistingAliasInAnnotation.fixed.php
+++ b/tests/Sniffs/Namespaces/data/collidingClassNameWithExistingAliasInAnnotation.fixed.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace TestNamespace;
+
+use Foo\User;
+use Bar\User as BarUser;
+
+class Test {
+
+	/**
+	 * @var User|BarUser|null
+	 */
+	public $prop;
+
+}

--- a/tests/Sniffs/Namespaces/data/collidingClassNameWithExistingAliasInAnnotation.php
+++ b/tests/Sniffs/Namespaces/data/collidingClassNameWithExistingAliasInAnnotation.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace TestNamespace;
+
+use Foo\User;
+use Bar\User as BarUser;
+
+class Test {
+
+	/**
+	 * @var User|\Bar\User|null
+	 */
+	public $prop;
+
+}


### PR DESCRIPTION
When `allowFullyQualifiedNameForCollidingClasses` was enabled and a FQN reference collided on the unqualified name with another class, the sniff incorrectly skipped the reference even when a use statement with an alias
already existed for that exact FQN. Now the sniff detects the existing alias and flags the FQN for replacement in both the detection and fix phases.