### PR TITLE
Add full docblock support for DNFTypeHintFormatSniff

### DIFF
--- a/SlevomatCodingStandard/Sniffs/TypeHints/DNFTypeHintFormatSniff.php
+++ b/SlevomatCodingStandard/Sniffs/TypeHints/DNFTypeHintFormatSniff.php
@@ -4,19 +4,42 @@ namespace SlevomatCodingStandard\Sniffs\TypeHints;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
+use PHPStan\PhpDocParser\Ast\Attribute;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PropertyTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IntersectionTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\NullableTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
+use SlevomatCodingStandard\Helpers\Annotation;
+use SlevomatCodingStandard\Helpers\AnnotationHelper;
+use SlevomatCodingStandard\Helpers\AnnotationTypeHelper;
+use SlevomatCodingStandard\Helpers\DocCommentHelper;
 use SlevomatCodingStandard\Helpers\FixerHelper;
 use SlevomatCodingStandard\Helpers\FunctionHelper;
+use SlevomatCodingStandard\Helpers\ParsedDocComment;
+use SlevomatCodingStandard\Helpers\PhpDocParserHelper;
 use SlevomatCodingStandard\Helpers\PropertyHelper;
 use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
 use SlevomatCodingStandard\Helpers\TokenHelper;
 use SlevomatCodingStandard\Helpers\TypeHint;
+use function array_unshift;
+use function count;
 use function in_array;
+use function preg_match;
+use function preg_quote;
 use function preg_replace;
 use function sprintf;
+use function str_replace;
 use function strpos;
 use function strtolower;
 use function substr;
 use function substr_count;
+use function trim;
+use const T_DOC_COMMENT_OPEN_TAG;
 use const T_TYPE_CLOSE_PARENTHESIS;
 use const T_TYPE_INTERSECTION;
 use const T_TYPE_OPEN_PARENTHESIS;
@@ -44,6 +67,8 @@ class DNFTypeHintFormatSniff implements Sniff
 
 	public ?bool $enable = null;
 
+	public bool $enableForDocComments = false;
+
 	public ?string $withSpacesAroundOperators = null;
 
 	public ?string $withSpacesInsideParentheses = null;
@@ -60,6 +85,7 @@ class DNFTypeHintFormatSniff implements Sniff
 		return [
 			T_VARIABLE,
 			...TokenHelper::FUNCTION_TOKEN_CODES,
+			T_DOC_COMMENT_OPEN_TAG,
 		];
 	}
 
@@ -72,6 +98,15 @@ class DNFTypeHintFormatSniff implements Sniff
 		}
 
 		$tokens = $phpcsFile->getTokens();
+
+		if ($tokens[$pointer]['code'] === T_DOC_COMMENT_OPEN_TAG) {
+			if (!$this->enableForDocComments) {
+				return;
+			}
+
+			$this->processDocComment($phpcsFile, $pointer);
+			return;
+		}
 
 		if ($tokens[$pointer]['code'] === T_VARIABLE) {
 			if (!PropertyHelper::isProperty($phpcsFile, $pointer)) {
@@ -96,6 +131,363 @@ class DNFTypeHintFormatSniff implements Sniff
 				$this->checkTypeHint($phpcsFile, $parameterTypeHint);
 			}
 		}
+	}
+
+	private function processDocComment(File $phpcsFile, int $docCommentOpenPointer): void
+	{
+		$parsedDocComment = DocCommentHelper::parseDocComment($phpcsFile, $docCommentOpenPointer);
+		if ($parsedDocComment === null) {
+			return;
+		}
+
+		$annotations = AnnotationHelper::getAnnotations($phpcsFile, $docCommentOpenPointer);
+
+		foreach ($annotations as $annotation) {
+			if ($annotation->isInvalid()) {
+				continue;
+			}
+
+			if ($this->withSpacesAroundOperators !== null) {
+				foreach (AnnotationHelper::getAnnotationNodesByType($annotation->getNode(), UnionTypeNode::class) as $unionTypeNode) {
+					$this->checkDocCommentOperatorSpacing($phpcsFile, $annotation, $unionTypeNode, $parsedDocComment, '|');
+				}
+
+				foreach (AnnotationHelper::getAnnotationNodesByType(
+					$annotation->getNode(),
+					IntersectionTypeNode::class,
+				) as $intersectionTypeNode) {
+					$this->checkDocCommentOperatorSpacing($phpcsFile, $annotation, $intersectionTypeNode, $parsedDocComment, '&');
+				}
+			}
+
+			if ($this->withSpacesInsideParentheses !== null) {
+				foreach (AnnotationHelper::getAnnotationNodesByType($annotation->getNode(), UnionTypeNode::class) as $unionTypeNode) {
+					foreach ($unionTypeNode->types as $typeNode) {
+						if (!$typeNode instanceof IntersectionTypeNode) {
+							continue;
+						}
+
+						$this->checkDocCommentParenthesesSpacing($phpcsFile, $annotation, $typeNode, $parsedDocComment);
+					}
+				}
+			}
+
+			if ($this->nullPosition !== null) {
+				foreach (AnnotationHelper::getAnnotationNodesByType($annotation->getNode(), UnionTypeNode::class) as $unionTypeNode) {
+					$this->checkDocCommentNullPosition($phpcsFile, $annotation, $unionTypeNode, $parsedDocComment);
+				}
+			}
+
+			if ($this->shortNullable === null) {
+				continue;
+			}
+
+			if ($this->shortNullable === self::NO) {
+				foreach (AnnotationHelper::getAnnotationNodesByType(
+					$annotation->getNode(),
+					NullableTypeNode::class,
+				) as $nullableTypeNode) {
+					$this->checkDocCommentNullableExpansion($phpcsFile, $annotation, $nullableTypeNode, $parsedDocComment);
+				}
+			} elseif ($this->shortNullable === self::YES) {
+				$this->checkDocCommentNullableContraction($phpcsFile, $annotation, $parsedDocComment);
+			}
+		}
+	}
+
+	/**
+	 * @param UnionTypeNode|IntersectionTypeNode $typeNode
+	 */
+	private function checkDocCommentOperatorSpacing(
+		File $phpcsFile,
+		Annotation $annotation,
+		TypeNode $typeNode,
+		ParsedDocComment $parsedDocComment,
+		string $operator
+	): void
+	{
+		$rawTypeText = trim($parsedDocComment->getTokens()->getContentBetween(
+			$typeNode->getAttribute(Attribute::START_INDEX),
+			$typeNode->getAttribute(Attribute::END_INDEX) + 1,
+		));
+
+		$escapedOperator = preg_quote($operator, '~');
+
+		if ($this->withSpacesAroundOperators === self::NO) {
+			if (preg_match('~\s' . $escapedOperator . '|' . $escapedOperator . '\s~', $rawTypeText) === 0) {
+				return;
+			}
+
+			$fix = $phpcsFile->addFixableError(
+				sprintf('Spaces around "|" or "&" in type hint "%s" are disallowed.', $rawTypeText),
+				$annotation->getStartPointer(),
+				self::CODE_DISALLOWED_WHITESPACE_AROUND_OPERATOR,
+			);
+
+			if ($fix) {
+				$fixedTypeText = (string) preg_replace('~\s*' . $escapedOperator . '\s*~', $operator, $rawTypeText);
+				$this->fixDocCommentTypeText($phpcsFile, $parsedDocComment, $rawTypeText, $fixedTypeText);
+			}
+		} elseif ($this->withSpacesAroundOperators === self::YES) {
+			if (preg_match('~(?<! )' . $escapedOperator . '|' . $escapedOperator . '(?! )~', $rawTypeText) === 0) {
+				return;
+			}
+
+			$fix = $phpcsFile->addFixableError(
+				sprintf('One space required around each "|" or "&" in type hint "%s".', $rawTypeText),
+				$annotation->getStartPointer(),
+				self::CODE_REQUIRED_WHITESPACE_AROUND_OPERATOR,
+			);
+
+			if ($fix) {
+				$fixedTypeText = (string) preg_replace('~\s*' . $escapedOperator . '\s*~', ' ' . $operator . ' ', $rawTypeText);
+				$this->fixDocCommentTypeText($phpcsFile, $parsedDocComment, $rawTypeText, $fixedTypeText);
+			}
+		}
+	}
+
+	private function checkDocCommentParenthesesSpacing(
+		File $phpcsFile,
+		Annotation $annotation,
+		IntersectionTypeNode $intersectionTypeNode,
+		ParsedDocComment $parsedDocComment
+	): void
+	{
+		$rawTypeText = trim($parsedDocComment->getTokens()->getContentBetween(
+			$intersectionTypeNode->getAttribute(Attribute::START_INDEX),
+			$intersectionTypeNode->getAttribute(Attribute::END_INDEX) + 1,
+		));
+
+		if ($this->withSpacesInsideParentheses === self::NO) {
+			if (preg_match('~^\(\s|\s\)$~', $rawTypeText) === 0) {
+				return;
+			}
+
+			$fix = $phpcsFile->addFixableError(
+				sprintf('Spaces inside parentheses in type hint "%s" are disallowed.', $rawTypeText),
+				$annotation->getStartPointer(),
+				self::CODE_DISALLOWED_WHITESPACE_INSIDE_PARENTHESES,
+			);
+
+			if ($fix) {
+				$fixedTypeText = (string) preg_replace(['~\(\s+~', '~\s+\)~'], ['(', ')'], $rawTypeText);
+				$this->fixDocCommentTypeText($phpcsFile, $parsedDocComment, $rawTypeText, $fixedTypeText);
+			}
+		} elseif ($this->withSpacesInsideParentheses === self::YES) {
+			if (preg_match('~^\([^ ]|[^ ]\)$~', $rawTypeText) === 0) {
+				return;
+			}
+
+			$fix = $phpcsFile->addFixableError(
+				sprintf('One space required around expression inside parentheses in type hint "%s".', $rawTypeText),
+				$annotation->getStartPointer(),
+				self::CODE_REQUIRED_WHITESPACE_INSIDE_PARENTHESES,
+			);
+
+			if ($fix) {
+				$fixedTypeText = (string) preg_replace(['~^\(\s*~', '~\s*\)$~'], ['( ', ' )'], $rawTypeText);
+				$this->fixDocCommentTypeText($phpcsFile, $parsedDocComment, $rawTypeText, $fixedTypeText);
+			}
+		}
+	}
+
+	private function checkDocCommentNullPosition(
+		File $phpcsFile,
+		Annotation $annotation,
+		UnionTypeNode $unionTypeNode,
+		ParsedDocComment $parsedDocComment
+	): void
+	{
+		$nullTypeNode = null;
+		$nullPosition = 0;
+		$position = 0;
+
+		foreach ($unionTypeNode->types as $typeNode) {
+			if ($typeNode instanceof IdentifierTypeNode && strtolower($typeNode->name) === 'null') {
+				$nullTypeNode = $typeNode;
+				$nullPosition = $position;
+				break;
+			}
+
+			$position++;
+		}
+
+		if ($nullTypeNode === null) {
+			return;
+		}
+
+		if ($this->nullPosition === self::LAST && $nullPosition === count($unionTypeNode->types) - 1) {
+			return;
+		}
+
+		if ($this->nullPosition === self::FIRST && $nullPosition === 0) {
+			return;
+		}
+
+		$errorCode = $this->nullPosition === self::LAST
+			? self::CODE_NULL_TYPE_HINT_NOT_ON_LAST_POSITION
+			: self::CODE_NULL_TYPE_HINT_NOT_ON_FIRST_POSITION;
+
+		$fix = $phpcsFile->addFixableError(
+			sprintf(
+				'Null type hint should be on %s position in "%s".',
+				$this->nullPosition,
+				AnnotationTypeHelper::print($unionTypeNode),
+			),
+			$annotation->getStartPointer(),
+			$errorCode,
+		);
+
+		if (!$fix) {
+			return;
+		}
+
+		$fixedTypeNodes = [];
+		foreach ($unionTypeNode->types as $typeNode) {
+			if ($typeNode === $nullTypeNode) {
+				continue;
+			}
+
+			$fixedTypeNodes[] = $typeNode;
+		}
+
+		if ($this->nullPosition === self::FIRST) {
+			array_unshift($fixedTypeNodes, $nullTypeNode);
+		} else {
+			$fixedTypeNodes[] = $nullTypeNode;
+		}
+
+		$fixedUnionTypeNode = PhpDocParserHelper::cloneNode($unionTypeNode);
+		$fixedUnionTypeNode->types = $fixedTypeNodes;
+
+		$phpcsFile->fixer->beginChangeset();
+
+		$fixedDocComment = AnnotationHelper::fixAnnotation($parsedDocComment, $annotation, $unionTypeNode, $fixedUnionTypeNode);
+
+		FixerHelper::change(
+			$phpcsFile,
+			$parsedDocComment->getOpenPointer(),
+			$parsedDocComment->getClosePointer(),
+			$fixedDocComment,
+		);
+
+		$phpcsFile->fixer->endChangeset();
+	}
+
+	private function checkDocCommentNullableExpansion(
+		File $phpcsFile,
+		Annotation $annotation,
+		NullableTypeNode $nullableTypeNode,
+		ParsedDocComment $parsedDocComment
+	): void
+	{
+		$rawTypeText = trim($parsedDocComment->getTokens()->getContentBetween(
+			$nullableTypeNode->getAttribute(Attribute::START_INDEX),
+			$nullableTypeNode->getAttribute(Attribute::END_INDEX) + 1,
+		));
+
+		$fix = $phpcsFile->addFixableError(
+			sprintf('Usage of short nullable type hint in "%s" is disallowed.', $rawTypeText),
+			$annotation->getStartPointer(),
+			self::CODE_DISALLOWED_SHORT_NULLABLE,
+		);
+
+		if (!$fix) {
+			return;
+		}
+
+		$innerTypeText = AnnotationTypeHelper::print($nullableTypeNode->type);
+		$separator = $this->withSpacesAroundOperators === self::YES ? ' | ' : '|';
+		$fixedTypeText = $this->nullPosition === self::FIRST
+			? 'null' . $separator . $innerTypeText
+			: $innerTypeText . $separator . 'null';
+
+		$this->fixDocCommentTypeText($phpcsFile, $parsedDocComment, $rawTypeText, $fixedTypeText);
+	}
+
+	private function checkDocCommentNullableContraction(File $phpcsFile, Annotation $annotation, ParsedDocComment $parsedDocComment): void
+	{
+		$directType = $this->getAnnotationDirectType($annotation);
+
+		if (!$directType instanceof UnionTypeNode || count($directType->types) !== 2) {
+			return;
+		}
+
+		$nullTypeNode = null;
+		$otherTypeNode = null;
+
+		foreach ($directType->types as $typeNode) {
+			if ($typeNode instanceof IdentifierTypeNode && strtolower($typeNode->name) === 'null') {
+				$nullTypeNode = $typeNode;
+			} else {
+				$otherTypeNode = $typeNode;
+			}
+		}
+
+		if ($nullTypeNode === null || $otherTypeNode === null || $otherTypeNode instanceof IntersectionTypeNode) {
+			return;
+		}
+
+		$rawTypeText = trim($parsedDocComment->getTokens()->getContentBetween(
+			$directType->getAttribute(Attribute::START_INDEX),
+			$directType->getAttribute(Attribute::END_INDEX) + 1,
+		));
+
+		$fix = $phpcsFile->addFixableError(
+			sprintf('Short nullable type hint in "%s" is required.', $rawTypeText),
+			$annotation->getStartPointer(),
+			self::CODE_REQUIRED_SHORT_NULLABLE,
+		);
+
+		if (!$fix) {
+			return;
+		}
+
+		$fixedTypeText = '?' . AnnotationTypeHelper::print($otherTypeNode);
+		$this->fixDocCommentTypeText($phpcsFile, $parsedDocComment, $rawTypeText, $fixedTypeText);
+	}
+
+	private function fixDocCommentTypeText(
+		File $phpcsFile,
+		ParsedDocComment $parsedDocComment,
+		string $originalText,
+		string $fixedText
+	): void
+	{
+		$rawDocblockContent = TokenHelper::getContent(
+			$phpcsFile,
+			$parsedDocComment->getOpenPointer(),
+			$parsedDocComment->getClosePointer(),
+		);
+
+		$fixedDocblockContent = str_replace($originalText, $fixedText, $rawDocblockContent);
+
+		$phpcsFile->fixer->beginChangeset();
+
+		FixerHelper::change(
+			$phpcsFile,
+			$parsedDocComment->getOpenPointer(),
+			$parsedDocComment->getClosePointer(),
+			$fixedDocblockContent,
+		);
+
+		$phpcsFile->fixer->endChangeset();
+	}
+
+	private function getAnnotationDirectType(Annotation $annotation): ?TypeNode
+	{
+		$value = $annotation->getValue();
+
+		if (
+			$value instanceof ParamTagValueNode
+			|| $value instanceof ReturnTagValueNode
+			|| $value instanceof VarTagValueNode
+			|| $value instanceof PropertyTagValueNode
+		) {
+			return $value->type;
+		}
+
+		return null;
 	}
 
 	private function checkTypeHint(File $phpcsFile, TypeHint $typeHint): void

--- a/SlevomatCodingStandard/Sniffs/TypeHints/NullTypeHintOnLastPositionSniff.php
+++ b/SlevomatCodingStandard/Sniffs/TypeHints/NullTypeHintOnLastPositionSniff.php
@@ -16,6 +16,9 @@ use function sprintf;
 use function strtolower;
 use const T_DOC_COMMENT_OPEN_TAG;
 
+/**
+ * @deprecated Use DNFTypeHintFormatSniff with nullPosition set to 'last' and enableForDocComments set to true, which enforces the same rule for both PHP code and docblocks.
+ */
 class NullTypeHintOnLastPositionSniff implements Sniff
 {
 

--- a/doc/type-hints.md
+++ b/doc/type-hints.md
@@ -35,11 +35,12 @@ Disallows usage of "mixed" type hint in phpDocs.
 
 #### SlevomatCodingStandard.TypeHints.DNFTypeHintFormat 🔧
 
-Checks format of DNF type hints.
+Checks format of DNF type hints. The same checks can also be applied to type hints inside `@param`, `@return`, `@var`, `@property` and `@property-read` annotations by enabling `enableForDocComments`.
 
 Sniff provides the following settings:
 
 * `enable`: either to enable or not this sniff. By default, it is enabled for PHP versions 8.0 or higher.
+* `enableForDocComments`: `true` also applies the configured checks to type hints in doc-comment annotations. Disabled by default.
 * `withSpacesAroundOperators`: `yes` requires spaces around `|` and `&`, `no` requires no space around `|`and `&`. None is set by default so both are enabled.
 * `withSpacesInsideParentheses`: `yes` requires spaces inside parentheses, `no` requires no spaces inside parentheses. None is set by default so both are enabled.
 * `shortNullable`: `yes` requires usage of `?` for nullable type hint, `no` disallows it. None is set by default so both are enabled.
@@ -50,6 +51,8 @@ Sniff provides the following settings:
 Enforces using shorthand scalar typehint variants in phpDocs: `int` instead of `integer` and `bool` instead of `boolean`. This is for consistency with native scalar typehints which also allow shorthand variants only.
 
 #### SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition 🔧
+
+> **Deprecated.** Use [`SlevomatCodingStandard.TypeHints.DNFTypeHintFormat`](#slevomatcodingstandardtypehintsdnftypehintformat-) with `nullPosition` set to `last` and `enableForDocComments` set to `true`, which enforces the same rule for both PHP code and annotations.
 
 Enforces `null` type hint on last position in annotations.
 

--- a/tests/Sniffs/TypeHints/DNFTypeHintFormatSniffTest.php
+++ b/tests/Sniffs/TypeHints/DNFTypeHintFormatSniffTest.php
@@ -339,6 +339,414 @@ class DNFTypeHintFormatSniffTest extends TestCase
 		self::assertAllFixedInFile($report);
 	}
 
+	public function testDocBlockWhitespaceAroundOperatorsNotSetNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/dnfTypeHintFormatDocBlockWhitespaceAroundOperatorsNotSetNoErrors.php', [
+			'enable' => true,
+			'enableForDocComments' => true,
+		]);
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testDocBlockWhitespaceAroundOperatorsDisallowedNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/dnfTypeHintFormatDocBlockWhitespaceAroundOperatorsDisallowedNoErrors.php', [
+			'enable' => true,
+			'enableForDocComments' => true,
+			'withSpacesAroundOperators' => 'no',
+		]);
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testDocBlockWhitespaceAroundOperatorsDisallowedErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/dnfTypeHintFormatDocBlockWhitespaceAroundOperatorsDisallowedErrors.php', [
+			'enable' => true,
+			'enableForDocComments' => true,
+			'withSpacesAroundOperators' => 'no',
+		]);
+
+		self::assertSame(5, $report->getErrorCount());
+
+		self::assertSniffError(
+			$report,
+			7,
+			DNFTypeHintFormatSniff::CODE_DISALLOWED_WHITESPACE_AROUND_OPERATOR,
+			'Spaces around "|" or "&" in type hint "null | string" are disallowed.',
+		);
+		self::assertSniffError(
+			$report,
+			8,
+			DNFTypeHintFormatSniff::CODE_DISALLOWED_WHITESPACE_AROUND_OPERATOR,
+			'Spaces around "|" or "&" in type hint "int | null" are disallowed.',
+		);
+		self::assertSniffError(
+			$report,
+			15,
+			DNFTypeHintFormatSniff::CODE_DISALLOWED_WHITESPACE_AROUND_OPERATOR,
+			'Spaces around "|" or "&" in type hint "bool | null" are disallowed.',
+		);
+		self::assertSniffError(
+			$report,
+			25,
+			DNFTypeHintFormatSniff::CODE_DISALLOWED_WHITESPACE_AROUND_OPERATOR,
+			'Spaces around "|" or "&" in type hint "(Foo & Bar) | null" are disallowed.',
+		);
+		self::assertSniffError(
+			$report,
+			25,
+			DNFTypeHintFormatSniff::CODE_DISALLOWED_WHITESPACE_AROUND_OPERATOR,
+			'Spaces around "|" or "&" in type hint "(Foo & Bar)" are disallowed.',
+		);
+
+		self::assertAllFixedInFile($report);
+	}
+
+	public function testDocBlockWhitespaceAroundOperatorsRequiredNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/dnfTypeHintFormatDocBlockWhitespaceAroundOperatorsRequiredNoErrors.php', [
+			'enable' => true,
+			'enableForDocComments' => true,
+			'withSpacesAroundOperators' => 'yes',
+		]);
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testDocBlockWhitespaceAroundOperatorsRequiredErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/dnfTypeHintFormatDocBlockWhitespaceAroundOperatorsRequiredErrors.php', [
+			'enable' => true,
+			'enableForDocComments' => true,
+			'withSpacesAroundOperators' => 'yes',
+		]);
+
+		self::assertSame(5, $report->getErrorCount());
+
+		self::assertSniffError(
+			$report,
+			7,
+			DNFTypeHintFormatSniff::CODE_REQUIRED_WHITESPACE_AROUND_OPERATOR,
+			'One space required around each "|" or "&" in type hint "null|string".',
+		);
+		self::assertSniffError(
+			$report,
+			8,
+			DNFTypeHintFormatSniff::CODE_REQUIRED_WHITESPACE_AROUND_OPERATOR,
+			'One space required around each "|" or "&" in type hint "int|null".',
+		);
+		self::assertSniffError(
+			$report,
+			15,
+			DNFTypeHintFormatSniff::CODE_REQUIRED_WHITESPACE_AROUND_OPERATOR,
+			'One space required around each "|" or "&" in type hint "bool|null".',
+		);
+		self::assertSniffError(
+			$report,
+			25,
+			DNFTypeHintFormatSniff::CODE_REQUIRED_WHITESPACE_AROUND_OPERATOR,
+			'One space required around each "|" or "&" in type hint "(Foo&Bar)|null".',
+		);
+		self::assertSniffError(
+			$report,
+			25,
+			DNFTypeHintFormatSniff::CODE_REQUIRED_WHITESPACE_AROUND_OPERATOR,
+			'One space required around each "|" or "&" in type hint "(Foo&Bar)".',
+		);
+
+		self::assertAllFixedInFile($report);
+	}
+
+	public function testDocBlockWhitespaceInsideParenthesesNotSetNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/dnfTypeHintFormatDocBlockWhitespaceInsideParenthesesNotSetNoErrors.php', [
+			'enable' => true,
+			'enableForDocComments' => true,
+		]);
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testDocBlockWhitespaceInsideParenthesesDisallowedNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/dnfTypeHintFormatDocBlockWhitespaceInsideParenthesesDisallowedNoErrors.php', [
+			'enable' => true,
+			'enableForDocComments' => true,
+			'withSpacesInsideParentheses' => 'no',
+		]);
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testDocBlockWhitespaceInsideParenthesesDisallowedErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/dnfTypeHintFormatDocBlockWhitespaceInsideParenthesesDisallowedErrors.php', [
+			'enable' => true,
+			'enableForDocComments' => true,
+			'withSpacesInsideParentheses' => 'no',
+		]);
+
+		self::assertSame(3, $report->getErrorCount());
+
+		self::assertSniffError(
+			$report,
+			7,
+			DNFTypeHintFormatSniff::CODE_DISALLOWED_WHITESPACE_INSIDE_PARENTHESES,
+			'Spaces inside parentheses in type hint "( Foo&Bar )" are disallowed.',
+		);
+		self::assertSniffError(
+			$report,
+			8,
+			DNFTypeHintFormatSniff::CODE_DISALLOWED_WHITESPACE_INSIDE_PARENTHESES,
+			'Spaces inside parentheses in type hint "( Baz&Qux )" are disallowed.',
+		);
+		self::assertSniffError(
+			$report,
+			15,
+			DNFTypeHintFormatSniff::CODE_DISALLOWED_WHITESPACE_INSIDE_PARENTHESES,
+			'Spaces inside parentheses in type hint "( Foo&Bar )" are disallowed.',
+		);
+
+		self::assertAllFixedInFile($report);
+	}
+
+	public function testDocBlockWhitespaceInsideParenthesesRequiredNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/dnfTypeHintFormatDocBlockWhitespaceInsideParenthesesRequiredNoErrors.php', [
+			'enable' => true,
+			'enableForDocComments' => true,
+			'withSpacesInsideParentheses' => 'yes',
+		]);
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testDocBlockWhitespaceInsideParenthesesRequiredErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/dnfTypeHintFormatDocBlockWhitespaceInsideParenthesesRequiredErrors.php', [
+			'enable' => true,
+			'enableForDocComments' => true,
+			'withSpacesInsideParentheses' => 'yes',
+		]);
+
+		self::assertSame(3, $report->getErrorCount());
+
+		self::assertSniffError(
+			$report,
+			7,
+			DNFTypeHintFormatSniff::CODE_REQUIRED_WHITESPACE_INSIDE_PARENTHESES,
+			'One space required around expression inside parentheses in type hint "(Foo&Bar)".',
+		);
+		self::assertSniffError(
+			$report,
+			8,
+			DNFTypeHintFormatSniff::CODE_REQUIRED_WHITESPACE_INSIDE_PARENTHESES,
+			'One space required around expression inside parentheses in type hint "(Baz&Qux)".',
+		);
+		self::assertSniffError(
+			$report,
+			15,
+			DNFTypeHintFormatSniff::CODE_REQUIRED_WHITESPACE_INSIDE_PARENTHESES,
+			'One space required around expression inside parentheses in type hint "(Foo&Bar)".',
+		);
+
+		self::assertAllFixedInFile($report);
+	}
+
+	public function testDocBlockShortNullableNotSetNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/dnfTypeHintFormatDocBlockShortNullableNotSetNoErrors.php', [
+			'enable' => true,
+			'enableForDocComments' => true,
+		], [DNFTypeHintFormatSniff::CODE_REQUIRED_SHORT_NULLABLE, DNFTypeHintFormatSniff::CODE_DISALLOWED_SHORT_NULLABLE]);
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testDocBlockShortNullableRequiredNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/dnfTypeHintFormatDocBlockShortNullableRequiredNoErrors.php', [
+			'enable' => true,
+			'enableForDocComments' => true,
+			'shortNullable' => 'yes',
+		], [DNFTypeHintFormatSniff::CODE_REQUIRED_SHORT_NULLABLE]);
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testDocBlockShortNullableRequiredErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/dnfTypeHintFormatDocBlockShortNullableRequiredErrors.php', [
+			'enable' => true,
+			'enableForDocComments' => true,
+			'shortNullable' => 'yes',
+		], [DNFTypeHintFormatSniff::CODE_REQUIRED_SHORT_NULLABLE]);
+
+		self::assertSame(3, $report->getErrorCount());
+
+		self::assertSniffError(
+			$report,
+			7,
+			DNFTypeHintFormatSniff::CODE_REQUIRED_SHORT_NULLABLE,
+			'Short nullable type hint in "string|null" is required.',
+		);
+		self::assertSniffError(
+			$report,
+			8,
+			DNFTypeHintFormatSniff::CODE_REQUIRED_SHORT_NULLABLE,
+			'Short nullable type hint in "int|null" is required.',
+		);
+		self::assertSniffError(
+			$report,
+			15,
+			DNFTypeHintFormatSniff::CODE_REQUIRED_SHORT_NULLABLE,
+			'Short nullable type hint in "bool|null" is required.',
+		);
+
+		self::assertAllFixedInFile($report);
+	}
+
+	public function testDocBlockShortNullableDisallowedNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/dnfTypeHintFormatDocBlockShortNullableDisallowedNoErrors.php', [
+			'enable' => true,
+			'enableForDocComments' => true,
+			'shortNullable' => 'no',
+		], [DNFTypeHintFormatSniff::CODE_DISALLOWED_SHORT_NULLABLE]);
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testDocBlockShortNullableDisallowedErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/dnfTypeHintFormatDocBlockShortNullableDisallowedErrors.php', [
+			'enable' => true,
+			'enableForDocComments' => true,
+			'shortNullable' => 'no',
+		], [DNFTypeHintFormatSniff::CODE_DISALLOWED_SHORT_NULLABLE]);
+
+		self::assertSame(3, $report->getErrorCount());
+
+		self::assertSniffError(
+			$report,
+			7,
+			DNFTypeHintFormatSniff::CODE_DISALLOWED_SHORT_NULLABLE,
+			'Usage of short nullable type hint in "?string" is disallowed.',
+		);
+		self::assertSniffError(
+			$report,
+			8,
+			DNFTypeHintFormatSniff::CODE_DISALLOWED_SHORT_NULLABLE,
+			'Usage of short nullable type hint in "?int" is disallowed.',
+		);
+		self::assertSniffError(
+			$report,
+			15,
+			DNFTypeHintFormatSniff::CODE_DISALLOWED_SHORT_NULLABLE,
+			'Usage of short nullable type hint in "?bool" is disallowed.',
+		);
+
+		self::assertAllFixedInFile($report);
+	}
+
+	public function testDocBlockNullPositionNotSetNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/dnfTypeHintFormatDocBlockNullPositionNotSetNoErrors.php', [
+			'enable' => true,
+			'enableForDocComments' => true,
+		], [DNFTypeHintFormatSniff::CODE_NULL_TYPE_HINT_NOT_ON_FIRST_POSITION, DNFTypeHintFormatSniff::CODE_NULL_TYPE_HINT_NOT_ON_LAST_POSITION]);
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testDocBlockNullPositionFirstNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/dnfTypeHintFormatDocBlockNullPositionFirstNoErrors.php', [
+			'enable' => true,
+			'enableForDocComments' => true,
+			'nullPosition' => 'first',
+		], [DNFTypeHintFormatSniff::CODE_NULL_TYPE_HINT_NOT_ON_FIRST_POSITION]);
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testDocBlockNullPositionFirstErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/dnfTypeHintFormatDocBlockNullPositionFirstErrors.php', [
+			'enable' => true,
+			'enableForDocComments' => true,
+			'nullPosition' => 'first',
+		], [DNFTypeHintFormatSniff::CODE_NULL_TYPE_HINT_NOT_ON_FIRST_POSITION]);
+
+		self::assertSame(3, $report->getErrorCount());
+
+		self::assertSniffError(
+			$report,
+			7,
+			DNFTypeHintFormatSniff::CODE_NULL_TYPE_HINT_NOT_ON_FIRST_POSITION,
+			'Null type hint should be on first position in "string|null".',
+		);
+		self::assertSniffError(
+			$report,
+			8,
+			DNFTypeHintFormatSniff::CODE_NULL_TYPE_HINT_NOT_ON_FIRST_POSITION,
+			'Null type hint should be on first position in "int|null".',
+		);
+		self::assertSniffError(
+			$report,
+			15,
+			DNFTypeHintFormatSniff::CODE_NULL_TYPE_HINT_NOT_ON_FIRST_POSITION,
+			'Null type hint should be on first position in "bool|null".',
+		);
+
+		self::assertAllFixedInFile($report);
+	}
+
+	public function testDocBlockNullPositionLastNoErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/dnfTypeHintFormatDocBlockNullPositionLastNoErrors.php', [
+			'enable' => true,
+			'enableForDocComments' => true,
+			'nullPosition' => 'last',
+		], [DNFTypeHintFormatSniff::CODE_NULL_TYPE_HINT_NOT_ON_LAST_POSITION]);
+		self::assertNoSniffErrorInFile($report);
+	}
+
+	public function testDocBlockNullPositionLastErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/dnfTypeHintFormatDocBlockNullPositionLastErrors.php', [
+			'enable' => true,
+			'enableForDocComments' => true,
+			'nullPosition' => 'last',
+		], [DNFTypeHintFormatSniff::CODE_NULL_TYPE_HINT_NOT_ON_LAST_POSITION]);
+
+		self::assertSame(3, $report->getErrorCount());
+
+		self::assertSniffError(
+			$report,
+			7,
+			DNFTypeHintFormatSniff::CODE_NULL_TYPE_HINT_NOT_ON_LAST_POSITION,
+			'Null type hint should be on last position in "null|string".',
+		);
+		self::assertSniffError(
+			$report,
+			8,
+			DNFTypeHintFormatSniff::CODE_NULL_TYPE_HINT_NOT_ON_LAST_POSITION,
+			'Null type hint should be on last position in "null|int".',
+		);
+		self::assertSniffError(
+			$report,
+			15,
+			DNFTypeHintFormatSniff::CODE_NULL_TYPE_HINT_NOT_ON_LAST_POSITION,
+			'Null type hint should be on last position in "null|bool".',
+		);
+
+		self::assertAllFixedInFile($report);
+	}
+
+	public function testShouldNotReportDocCommentsIfNotEnabledForDocComments(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/dnfTypeHintFormatDocBlockShortNullableRequiredErrors.php', [
+			'enable' => true,
+			'withSpacesAroundOperators' => 'yes',
+			'withSpacesInsideParentheses' => 'yes',
+			'shortNullable' => 'yes',
+			'nullPosition' => 'last',
+		]);
+		self::assertNoSniffErrorInFile($report);
+	}
+
 	public function testShouldNotReportIfSniffIsDisabled(): void
 	{
 		$report = self::checkFile(__DIR__ . '/data/dnfTypeHintFormatShortNullableNotSetNoErrors.php', [

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockNullPositionFirstErrors.fixed.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockNullPositionFirstErrors.fixed.php
@@ -1,0 +1,19 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param null|string $param
+	 * @return null|int
+	 */
+	public function method($param)
+	{
+	}
+
+	/**
+	 * @var null|bool
+	 */
+	private $property;
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockNullPositionFirstErrors.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockNullPositionFirstErrors.php
@@ -1,0 +1,19 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param string|null $param
+	 * @return int|null
+	 */
+	public function method($param)
+	{
+	}
+
+	/**
+	 * @var bool|null
+	 */
+	private $property;
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockNullPositionFirstNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockNullPositionFirstNoErrors.php
@@ -1,0 +1,26 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param null|string $param
+	 * @return null|int
+	 */
+	public function method($param)
+	{
+	}
+
+	/**
+	 * @var null|bool
+	 */
+	private $property;
+
+	/**
+	 * @param string $noNull
+	 */
+	public function noNullParam($noNull)
+	{
+	}
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockNullPositionLastErrors.fixed.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockNullPositionLastErrors.fixed.php
@@ -1,0 +1,19 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param string|null $param
+	 * @return int|null
+	 */
+	public function method($param)
+	{
+	}
+
+	/**
+	 * @var bool|null
+	 */
+	private $property;
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockNullPositionLastErrors.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockNullPositionLastErrors.php
@@ -1,0 +1,19 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param null|string $param
+	 * @return null|int
+	 */
+	public function method($param)
+	{
+	}
+
+	/**
+	 * @var null|bool
+	 */
+	private $property;
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockNullPositionLastNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockNullPositionLastNoErrors.php
@@ -1,0 +1,26 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param string|null $param
+	 * @return int|null
+	 */
+	public function method($param)
+	{
+	}
+
+	/**
+	 * @var bool|null
+	 */
+	private $property;
+
+	/**
+	 * @param string $noNull
+	 */
+	public function noNullParam($noNull)
+	{
+	}
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockNullPositionNotSetNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockNullPositionNotSetNoErrors.php
@@ -1,0 +1,19 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param null|string $nullFirst
+	 * @return int|null
+	 */
+	public function method($nullFirst)
+	{
+	}
+
+	/**
+	 * @var bool|null
+	 */
+	private $property;
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockShortNullableDisallowedErrors.fixed.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockShortNullableDisallowedErrors.fixed.php
@@ -1,0 +1,19 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param string|null $param
+	 * @return int|null
+	 */
+	public function method($param)
+	{
+	}
+
+	/**
+	 * @var bool|null
+	 */
+	private $property;
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockShortNullableDisallowedErrors.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockShortNullableDisallowedErrors.php
@@ -1,0 +1,19 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param ?string $param
+	 * @return ?int
+	 */
+	public function method($param)
+	{
+	}
+
+	/**
+	 * @var ?bool
+	 */
+	private $property;
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockShortNullableDisallowedNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockShortNullableDisallowedNoErrors.php
@@ -1,0 +1,19 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param string|null $param
+	 * @return int|null
+	 */
+	public function method($param)
+	{
+	}
+
+	/**
+	 * @var bool|null
+	 */
+	private $property;
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockShortNullableNotSetNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockShortNullableNotSetNoErrors.php
@@ -1,0 +1,19 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param ?string $short
+	 * @return int|null
+	 */
+	public function method($short)
+	{
+	}
+
+	/**
+	 * @var ?bool
+	 */
+	private $property;
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockShortNullableRequiredErrors.fixed.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockShortNullableRequiredErrors.fixed.php
@@ -1,0 +1,19 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param ?string $param
+	 * @return ?int
+	 */
+	public function method($param)
+	{
+	}
+
+	/**
+	 * @var ?bool
+	 */
+	private $property;
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockShortNullableRequiredErrors.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockShortNullableRequiredErrors.php
@@ -1,0 +1,19 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param string|null $param
+	 * @return int|null
+	 */
+	public function method($param)
+	{
+	}
+
+	/**
+	 * @var bool|null
+	 */
+	private $property;
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockShortNullableRequiredNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockShortNullableRequiredNoErrors.php
@@ -1,0 +1,33 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param ?string $param
+	 * @return ?int
+	 */
+	public function method($param)
+	{
+	}
+
+	/**
+	 * @var ?bool
+	 */
+	private $property;
+
+	/**
+	 * @param string $noNull
+	 */
+	public function noNullParam($noNull)
+	{
+	}
+
+	/**
+	 * @param string|int|null $multipleTypes
+	 */
+	public function multipleTypes($multipleTypes)
+	{
+	}
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceAroundOperatorsDisallowedErrors.fixed.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceAroundOperatorsDisallowedErrors.fixed.php
@@ -1,0 +1,29 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param null|string $param
+	 * @return int|null
+	 */
+	public function method($param)
+	{
+	}
+
+	/**
+	 * @var bool|null
+	 */
+	private $property;
+
+}
+
+class WithIntersection
+{
+
+	/**
+	 * @var (Foo&Bar)|null
+	 */
+	private $dnf;
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceAroundOperatorsDisallowedErrors.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceAroundOperatorsDisallowedErrors.php
@@ -1,0 +1,29 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param null | string $param
+	 * @return int | null
+	 */
+	public function method($param)
+	{
+	}
+
+	/**
+	 * @var bool | null
+	 */
+	private $property;
+
+}
+
+class WithIntersection
+{
+
+	/**
+	 * @var (Foo & Bar) | null
+	 */
+	private $dnf;
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceAroundOperatorsDisallowedNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceAroundOperatorsDisallowedNoErrors.php
@@ -1,0 +1,29 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param null|string $param
+	 * @return int|null
+	 */
+	public function method($param)
+	{
+	}
+
+	/**
+	 * @var bool|null
+	 */
+	private $property;
+
+}
+
+class WithIntersection
+{
+
+	/**
+	 * @var (Foo&Bar)|null
+	 */
+	private $dnf;
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceAroundOperatorsNotSetNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceAroundOperatorsNotSetNoErrors.php
@@ -1,0 +1,19 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param null|string $withoutSpaces
+	 * @return int | null
+	 */
+	public function method($withoutSpaces)
+	{
+	}
+
+	/**
+	 * @var bool|null
+	 */
+	private $property;
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceAroundOperatorsRequiredErrors.fixed.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceAroundOperatorsRequiredErrors.fixed.php
@@ -1,0 +1,29 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param null | string $param
+	 * @return int | null
+	 */
+	public function method($param)
+	{
+	}
+
+	/**
+	 * @var bool | null
+	 */
+	private $property;
+
+}
+
+class WithIntersection
+{
+
+	/**
+	 * @var (Foo & Bar) | null
+	 */
+	private $dnf;
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceAroundOperatorsRequiredErrors.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceAroundOperatorsRequiredErrors.php
@@ -1,0 +1,29 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param null|string $param
+	 * @return int|null
+	 */
+	public function method($param)
+	{
+	}
+
+	/**
+	 * @var bool|null
+	 */
+	private $property;
+
+}
+
+class WithIntersection
+{
+
+	/**
+	 * @var (Foo&Bar)|null
+	 */
+	private $dnf;
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceAroundOperatorsRequiredNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceAroundOperatorsRequiredNoErrors.php
@@ -1,0 +1,50 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param null | string $param
+	 * @return int | null
+	 */
+	public function method($param)
+	{
+	}
+
+	/**
+	 * @var bool | null
+	 */
+	private $property;
+
+	/**
+	 * @property int | null $propertyAnnotation
+	 * @property-read string | null $propertyRead
+	 */
+}
+
+class WithIntersection
+{
+
+	/**
+	 * @var (Foo & Bar) | null
+	 */
+	private $dnf;
+
+	/**
+	 * @return (Foo & Bar) | (Baz & Qux) | null
+	 */
+	public function method()
+	{
+	}
+
+}
+
+class WithGeneric
+{
+
+	/**
+	 * @var Foo<int | null>
+	 */
+	private $generic;
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceInsideParenthesesDisallowedErrors.fixed.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceInsideParenthesesDisallowedErrors.fixed.php
@@ -1,0 +1,19 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param (Foo&Bar)|null $param
+	 * @return (Baz&Qux) | null
+	 */
+	public function method($param)
+	{
+	}
+
+	/**
+	 * @var (Foo&Bar) | null
+	 */
+	private $property;
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceInsideParenthesesDisallowedErrors.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceInsideParenthesesDisallowedErrors.php
@@ -1,0 +1,19 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param ( Foo&Bar )|null $param
+	 * @return ( Baz&Qux ) | null
+	 */
+	public function method($param)
+	{
+	}
+
+	/**
+	 * @var ( Foo&Bar ) | null
+	 */
+	private $property;
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceInsideParenthesesDisallowedNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceInsideParenthesesDisallowedNoErrors.php
@@ -1,0 +1,34 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param (Foo&Bar)|null $param
+	 * @return (Baz&Qux) | null
+	 */
+	public function method($param)
+	{
+	}
+
+	/**
+	 * @var (Foo&Bar) | null
+	 */
+	private $property;
+
+	/**
+	 * @property (Foo&Bar) | null $propertyAnnotation
+	 */
+}
+
+class WithoutIntersection
+{
+
+	/**
+	 * @param string|null $noIntersection
+	 */
+	public function method($noIntersection)
+	{
+	}
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceInsideParenthesesNotSetNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceInsideParenthesesNotSetNoErrors.php
@@ -1,0 +1,14 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param ( Foo&Bar )|null $withSpaces
+	 * @return (Baz&Qux) | null
+	 */
+	public function method($withSpaces)
+	{
+	}
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceInsideParenthesesRequiredErrors.fixed.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceInsideParenthesesRequiredErrors.fixed.php
@@ -1,0 +1,19 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param ( Foo&Bar )|null $param
+	 * @return ( Baz&Qux ) | null
+	 */
+	public function method($param)
+	{
+	}
+
+	/**
+	 * @var ( Foo&Bar ) | null
+	 */
+	private $property;
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceInsideParenthesesRequiredErrors.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceInsideParenthesesRequiredErrors.php
@@ -1,0 +1,19 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param (Foo&Bar)|null $param
+	 * @return (Baz&Qux) | null
+	 */
+	public function method($param)
+	{
+	}
+
+	/**
+	 * @var (Foo&Bar) | null
+	 */
+	private $property;
+
+}

--- a/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceInsideParenthesesRequiredNoErrors.php
+++ b/tests/Sniffs/TypeHints/data/dnfTypeHintFormatDocBlockWhitespaceInsideParenthesesRequiredNoErrors.php
@@ -1,0 +1,34 @@
+<?php
+
+class Whatever
+{
+
+	/**
+	 * @param ( Foo&Bar )|null $param
+	 * @return ( Baz&Qux ) | null
+	 */
+	public function method($param)
+	{
+	}
+
+	/**
+	 * @var ( Foo&Bar ) | null
+	 */
+	private $property;
+
+	/**
+	 * @property ( Foo&Bar ) | null $propertyAnnotation
+	 */
+}
+
+class WithoutIntersection
+{
+
+	/**
+	 * @param string|null $noIntersection
+	 */
+	public function method($noIntersection)
+	{
+	}
+
+}


### PR DESCRIPTION
Hi there!

This PR extends ``DNFTypeHintFormatSniff`` to enforce type hint formatting in docblocks

``DNFTypeHintFormatSniff`` previously only enforced its formatting rules on PHP code type hints. Docblock annotations (``@param``, ``@return``, ``@var``, ``@property``, ``@property-read``) were silently ignored, leaving them out of sync with the configured rules.

This PR extends the sniff to apply the same four rules to docblock type hints:
- ``withSpacesAroundOperators`` — spaces around | and & in union/intersection types
- ``withSpacesInsideParentheses`` — spaces inside ( ) in DNF intersection types
- ``shortNullable`` — ?Type vs Type|null (both directions)
- ``nullPosition`` — null first or last in union types (both directions)

All violations are auto-fixable, consistent with the existing PHP code behaviour.

These changes make the ``NullTypeHintOnLastPositionSniff`` redundant. ``NullTypeHintOnLastPositionSniff`` only ever applied to docblocks and is now fully covered by ``DNFTypeHintFormatSniff`` with ``nullPosition: 'last'``, which handles both PHP code and docblocks. I marked ``NullTypeHintOnLastPositionSniff`` ``@deprecated`` with a pointer to the replacement.