### PR TITLE
FullyQualifiedClassNameInAnnotation parameter ignoredAnnotationNames working for ConstFetchNode

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Namespaces/FullyQualifiedClassNameInAnnotationSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Namespaces/FullyQualifiedClassNameInAnnotationSniff.php
@@ -48,6 +48,10 @@ class FullyQualifiedClassNameInAnnotationSniff implements Sniff
 
 			$annotationName = $annotation->getName();
 
+			if (in_array($annotationName, $this->ignoredAnnotationNames, true)) {
+				continue;
+			}
+
 			foreach ($identifierTypeNodes as $typeHintNode) {
 				$typeHint = $typeHintNode->name;
 
@@ -58,10 +62,6 @@ class FullyQualifiedClassNameInAnnotationSniff implements Sniff
 					|| !TypeHelper::isTypeName($typeHint)
 					|| TypeHintHelper::isTypeDefinedInAnnotation($phpcsFile, $docCommentOpenPointer, $typeHint)
 				) {
-					continue;
-				}
-
-				if (in_array($annotationName, $this->ignoredAnnotationNames, true)) {
 					continue;
 				}
 

--- a/tests/Sniffs/Namespaces/FullyQualifiedClassNameInAnnotationSniffTest.php
+++ b/tests/Sniffs/Namespaces/FullyQualifiedClassNameInAnnotationSniffTest.php
@@ -534,7 +534,7 @@ class FullyQualifiedClassNameInAnnotationSniffTest extends TestCase
 			'ignoredAnnotationNames' => ['@return', '@param', '@var'],
 		]);
 
-		self::assertSame(41, $report->getErrorCount());
+		self::assertSame(37, $report->getErrorCount());
 	}
 
 }


### PR DESCRIPTION
Fixed issue where check for `ignoredAnnotationNames` setting in `FullyQualifiedClassNameInAnnotationSniff` was only working for IdentifierTypeNode, but not ConstFetchNode.

Test assertion decreased by 4 - false positives in `ConstTypeNode` in test data file which were fixed incorrectly while ignored