### PR TITLE
Update .gitattributes to exclude dev files from composer dist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,12 @@
 *.php text eol=lf
-/.github export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
-/codecov.yml export-ignore
+/.editorconfig export-ignore
+/.github export-ignore
 /build export-ignore
 /build.xml export-ignore
+/codecov.yml export-ignore
+/doc export-ignore
 /phpunit.xml.dist export-ignore
 /temp export-ignore
 /tests export-ignore


### PR DESCRIPTION
This avoids shipping dev/tooling files in the composer dist that aren't needed at runtime.

Last `.gitattributes` update was 2d8b243 (2020-04-16). The files below have been added or modified since, and are still included in the composer dist:
- `/doc/ export-ignore` — last touched in 4c90045 2026-05-06
- `/.editorconfig export-ignore` — last touched in 614af5a 2021-02-03

Background reading: https://blog.madewithlove.be/post/gitattributes/