### PR TITLE
Fix (Disallow|Require)TrailingComma*Sniff to handle null parenthesis pointers

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Functions/DisallowTrailingCommaInCallSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Functions/DisallowTrailingCommaInCallSniff.php
@@ -53,7 +53,7 @@ class DisallowTrailingCommaInCallSniff implements Sniff
 		$parenthesisCloserPointer = $tokens[$parenthesisOpenerPointer]['parenthesis_closer'];
 		$pointerBeforeParenthesisCloser = TokenHelper::findPreviousEffective($phpcsFile, $parenthesisCloserPointer - 1);
 
-		if ($tokens[$pointerBeforeParenthesisCloser]['code'] !== T_COMMA) {
+		if ($pointerBeforeParenthesisCloser === null || $tokens[$pointerBeforeParenthesisCloser]['code'] !== T_COMMA) {
 			return;
 		}
 

--- a/SlevomatCodingStandard/Sniffs/Functions/DisallowTrailingCommaInClosureUseSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Functions/DisallowTrailingCommaInClosureUseSniff.php
@@ -50,7 +50,7 @@ class DisallowTrailingCommaInClosureUseSniff implements Sniff
 			$useParenthesisOpenerPointer,
 		);
 
-		if ($tokens[$pointerBeforeUseParenthesisCloser]['code'] !== T_COMMA) {
+		if ($pointerBeforeUseParenthesisCloser === null || $tokens[$pointerBeforeUseParenthesisCloser]['code'] !== T_COMMA) {
 			return;
 		}
 

--- a/SlevomatCodingStandard/Sniffs/Functions/DisallowTrailingCommaInDeclarationSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Functions/DisallowTrailingCommaInDeclarationSniff.php
@@ -38,7 +38,7 @@ class DisallowTrailingCommaInDeclarationSniff implements Sniff
 			$parenthesisOpenerPointer,
 		);
 
-		if ($tokens[$pointerBeforeParenthesisCloser]['code'] !== T_COMMA) {
+		if ($pointerBeforeParenthesisCloser === null || $tokens[$pointerBeforeParenthesisCloser]['code'] !== T_COMMA) {
 			return;
 		}
 

--- a/SlevomatCodingStandard/Sniffs/Functions/RequireTrailingCommaInCallSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Functions/RequireTrailingCommaInCallSniff.php
@@ -60,7 +60,9 @@ class RequireTrailingCommaInCallSniff implements Sniff
 
 		$parenthesisCloserPointer = $tokens[$parenthesisOpenerPointer]['parenthesis_closer'];
 
-		if ($tokens[$parenthesisOpenerPointer]['line'] === $tokens[$parenthesisCloserPointer]['line']) {
+		if ($parenthesisCloserPointer === null
+			|| $tokens[$parenthesisOpenerPointer]['line'] === $tokens[$parenthesisCloserPointer]['line']
+		) {
 			return;
 		}
 

--- a/SlevomatCodingStandard/Sniffs/Functions/RequireTrailingCommaInClosureUseSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Functions/RequireTrailingCommaInClosureUseSniff.php
@@ -48,7 +48,10 @@ class RequireTrailingCommaInClosureUseSniff implements Sniff
 		$useParenthesisOpenerPointer = $tokens[$usePointer]['parenthesis_opener'];
 		$useParenthesisCloserPointer = $tokens[$usePointer]['parenthesis_closer'];
 
-		if ($tokens[$useParenthesisOpenerPointer]['line'] === $tokens[$useParenthesisCloserPointer]['line']) {
+		if ($useParenthesisOpenerPointer === null
+			|| $useParenthesisCloserPointer === null
+			|| $tokens[$useParenthesisOpenerPointer]['line'] === $tokens[$useParenthesisCloserPointer]['line']
+		) {
 			return;
 		}
 

--- a/SlevomatCodingStandard/Sniffs/Functions/RequireTrailingCommaInDeclarationSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Functions/RequireTrailingCommaInDeclarationSniff.php
@@ -37,7 +37,10 @@ class RequireTrailingCommaInDeclarationSniff implements Sniff
 		$parenthesisOpenerPointer = $tokens[$functionPointer]['parenthesis_opener'];
 		$parenthesisCloserPointer = $tokens[$functionPointer]['parenthesis_closer'];
 
-		if ($tokens[$parenthesisOpenerPointer]['line'] === $tokens[$parenthesisCloserPointer]['line']) {
+		if ($parenthesisOpenerPointer === null
+			|| $parenthesisCloserPointer === null
+			|| $tokens[$parenthesisOpenerPointer]['line'] === $tokens[$parenthesisCloserPointer]['line']
+		) {
 			return;
 		}
 


### PR DESCRIPTION
**Fix `(Disallow|Require)TrailingComma*Sniff` crash on empty parameter lists (PHP 8.2+)**

## Problem

`DisallowTrailingCommaInDeclarationSniff` (and by extension the other five `*TrailingComma*Sniff` sniffs) crash with a fatal error during a `phpcbf` run when a function has an empty parameter list.

`TokenHelper::findPreviousExcluding()` returns `null` when there are no non-whitespace tokens between the parenthesis opener and closer — i.e. `()`. The sniff then immediately dereferences `$tokens[$pointerBeforeParenthesisCloser]` without a null guard. Using `null` as an array offset is deprecated in PHP 8.1 and fatal in PHP 8.2+ when CodeSniffer's error handler converts `E_DEPRECATED` to a `RuntimeException`.

## Why only `phpcbf`

The crash is triggered indirectly. The following constructor is valid PHP and passes `phpcs` cleanly:

```php
public function __construct(
    // Inject your services here
) {
}
```

When `phpcbf` applies `RequireSingleLineMethodSignature`, it collapses the signature to `public function __construct()`, producing an empty `()`. In the same fix pass, `DisallowTrailingCommaInDeclarationSniff` is invoked on the now-empty parameter list, `findPreviousExcluding()` returns `null`, and the crash occurs.

## Fix

Added a null guard before indexing `$tokens` in all six affected sniffs:

- `DisallowTrailingCommaInCallSniff`
- `DisallowTrailingCommaInClosureUseSniff`
- `DisallowTrailingCommaInDeclarationSniff`
- `RequireTrailingCommaInCallSniff`
- `RequireTrailingCommaInClosureUseSniff`
- `RequireTrailingCommaInDeclarationSniff`

## Reproducer

```php
<?php

class Foo
{
    public function __construct(
        // some comment
    ) {
    }
}
```

Run `phpcbf` with a ruleset that includes both `RequireSingleLineMethodSignature` and `DisallowTrailingCommaInDeclaration` on PHP 8.2+.
