### PR TITLE
Fix ReadonlyClassSniff to not to require class marked as readonly whe…

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Classes/ReadonlyClassSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/ReadonlyClassSniff.php
@@ -4,6 +4,7 @@ namespace SlevomatCodingStandard\Sniffs\Classes;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
+use SlevomatCodingStandard\Helpers\AttributeHelper;
 use SlevomatCodingStandard\Helpers\ClassHelper;
 use SlevomatCodingStandard\Helpers\FunctionHelper;
 use SlevomatCodingStandard\Helpers\PropertyHelper;
@@ -125,7 +126,12 @@ class ReadonlyClassSniff implements Sniff
 			}
 		}
 
-		if ($this->classExtendsAnotherClass($phpcsFile, $classPointer)) {
+		if (
+			!ClassHelper::isFinal($phpcsFile, $classPointer)
+			|| $this->classExtendsAnotherClass($phpcsFile, $classPointer)
+			|| count(ClassHelper::getTraitUsePointers($phpcsFile, $classPointer)) > 0
+			|| AttributeHelper::hasAttribute($phpcsFile, $classPointer, '\AllowDynamicProperties')
+		) {
 			return;
 		}
 

--- a/SlevomatCodingStandard/Sniffs/Classes/ReadonlyClassSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/ReadonlyClassSniff.php
@@ -36,6 +36,10 @@ class ReadonlyClassSniff implements Sniff
 
 	public ?bool $enable = null;
 
+	public bool $allowNonFinalClasses = false;
+
+	public bool $ignoreTraits = false;
+
 	/**
 	 * @return array<int, (int|string)>
 	 */
@@ -126,12 +130,19 @@ class ReadonlyClassSniff implements Sniff
 			}
 		}
 
-		if (
-			!ClassHelper::isFinal($phpcsFile, $classPointer)
-			|| $this->classExtendsAnotherClass($phpcsFile, $classPointer)
-			|| count(ClassHelper::getTraitUsePointers($phpcsFile, $classPointer)) > 0
-			|| AttributeHelper::hasAttribute($phpcsFile, $classPointer, '\AllowDynamicProperties')
-		) {
+		if (!$this->allowNonFinalClasses && !ClassHelper::isFinal($phpcsFile, $classPointer)) {
+			return;
+		}
+
+		if ($this->classExtendsAnotherClass($phpcsFile, $classPointer)) {
+			return;
+		}
+
+		if (!$this->ignoreTraits && count(ClassHelper::getTraitUsePointers($phpcsFile, $classPointer)) > 0) {
+			return;
+		}
+
+		if (AttributeHelper::hasAttribute($phpcsFile, $classPointer, '\AllowDynamicProperties')) {
 			return;
 		}
 

--- a/doc/classes.md
+++ b/doc/classes.md
@@ -236,7 +236,12 @@ Sniff provides the following settings:
 
 Reports classes where all promoted constructor properties and class body properties are declared as `readonly` and suggests marking the whole class as `readonly`.
 
-Suggestion is reported only for classes that are `final`, do not `extends` another class, do not use traits, and do not have `#[\AllowDynamicProperties]`.
+Suggestion is reported only for classes that do not `extends` another class and do not have `#[\AllowDynamicProperties]`.
+
+Sniff provides the following settings:
+
+* `allowNonFinalClasses` (default: `false`): allows suggesting `readonly` also for non-final classes.
+* `ignoreTraits` (default: `false`): ignores trait usage when evaluating whether class can be marked as `readonly`.
 
 In readonly classes, promoted constructor properties must not be explicitly declared as `readonly`.
 

--- a/doc/classes.md
+++ b/doc/classes.md
@@ -234,7 +234,9 @@ Sniff provides the following settings:
 
 #### SlevomatCodingStandard.Classes.ReadonlyClass 🔧
 
-Reports classes where all promoted constructor properties are declared as `readonly` and suggests marking the whole class as `readonly`.
+Reports classes where all promoted constructor properties and class body properties are declared as `readonly` and suggests marking the whole class as `readonly`.
+
+Suggestion is reported only for classes that are `final`, do not `extends` another class, do not use traits, and do not have `#[\AllowDynamicProperties]`.
 
 In readonly classes, promoted constructor properties must not be explicitly declared as `readonly`.
 

--- a/tests/Sniffs/Classes/ReadonlyClassSniffTest.php
+++ b/tests/Sniffs/Classes/ReadonlyClassSniffTest.php
@@ -19,8 +19,7 @@ class ReadonlyClassSniffTest extends TestCase
 	{
 		$this->skipIfReadonlyClassIsNotSupported();
 		$report = self::checkFile(__DIR__ . '/data/readonlyClassErrors.php');
-		self::assertSame(8, $report->getErrorCount());
-		self::assertSniffError($report, 3, ReadonlyClassSniff::CODE_CLASS_CAN_BE_READONLY, 'Class Candidate can be marked as readonly.');
+		self::assertSame(6, $report->getErrorCount());
 		self::assertSniffError(
 			$report,
 			16,
@@ -41,27 +40,21 @@ class ReadonlyClassSniffTest extends TestCase
 		);
 		self::assertSniffError(
 			$report,
-			30,
-			ReadonlyClassSniff::CODE_CLASS_CAN_BE_READONLY,
-			'Class WithBodyPropertiesCandidate can be marked as readonly.',
-		);
-		self::assertSniffError(
-			$report,
-			36,
-			ReadonlyClassSniff::CODE_CLASS_CAN_BE_READONLY,
-			'Class MixedPropertiesCandidate can be marked as readonly.',
-		);
-		self::assertSniffError(
-			$report,
-			45,
-			ReadonlyClassSniff::CODE_CLASS_CAN_BE_READONLY,
-			'Class WithoutPromotion can be marked as readonly.',
-		);
-		self::assertSniffError(
-			$report,
 			56,
 			ReadonlyClassSniff::CODE_PROMOTED_PROPERTY_CANNOT_BE_READONLY_IN_READONLY_CLASS,
 			'Property $extra in readonly class cannot be declared as readonly.',
+		);
+		self::assertSniffError(
+			$report,
+			65,
+			ReadonlyClassSniff::CODE_PROMOTED_PROPERTY_CANNOT_BE_READONLY_IN_READONLY_CLASS,
+			'Property $extra in readonly class cannot be declared as readonly.',
+		);
+		self::assertSniffError(
+			$report,
+			79,
+			ReadonlyClassSniff::CODE_CLASS_CAN_BE_READONLY,
+			'Class FinalWithBodyPropertiesCandidate can be marked as readonly.',
 		);
 		self::assertAllFixedInFile($report);
 	}

--- a/tests/Sniffs/Classes/ReadonlyClassSniffTest.php
+++ b/tests/Sniffs/Classes/ReadonlyClassSniffTest.php
@@ -66,6 +66,35 @@ class ReadonlyClassSniffTest extends TestCase
 		self::assertNoSniffErrorInFile($report);
 	}
 
+	public function testModifiedSettingsErrors(): void
+	{
+		$this->skipIfReadonlyClassIsNotSupported();
+		$report = self::checkFile(__DIR__ . '/data/readonlyClassModifiedSettingsErrors.php', [
+			'allowNonFinalClasses' => true,
+			'ignoreTraits' => true,
+		]);
+		self::assertSame(3, $report->getErrorCount());
+		self::assertSniffError(
+			$report,
+			10,
+			ReadonlyClassSniff::CODE_CLASS_CAN_BE_READONLY,
+			'Class NonFinalCandidate can be marked as readonly.',
+		);
+		self::assertSniffError(
+			$report,
+			17,
+			ReadonlyClassSniff::CODE_CLASS_CAN_BE_READONLY,
+			'Class FinalWithTraitCandidate can be marked as readonly.',
+		);
+		self::assertSniffError(
+			$report,
+			26,
+			ReadonlyClassSniff::CODE_CLASS_CAN_BE_READONLY,
+			'Class NonFinalWithTraitCandidate can be marked as readonly.',
+		);
+		self::assertAllFixedInFile($report);
+	}
+
 	public function testFindConstructorPointerBranchesNoErrors(): void
 	{
 		$this->skipIfReadonlyClassIsNotSupported();

--- a/tests/Sniffs/Classes/data/readonlyClassErrors.fixed.php
+++ b/tests/Sniffs/Classes/data/readonlyClassErrors.fixed.php
@@ -1,10 +1,10 @@
 <?php // lint >= 8.2
 
-readonly class Candidate
+class Candidate
 {
     public function __construct(
-		private int $id,
-		public string $name,
+		private readonly int $id,
+		public readonly string $name,
 	)
     {
     }
@@ -27,24 +27,24 @@ final readonly class FinalCandidate
     }
 }
 
-readonly class WithBodyPropertiesCandidate
+class WithBodyPropertiesCandidate
 {
-    private int $id;
-    public string $name;
+    private readonly int $id;
+    public readonly string $name;
 }
 
-readonly class MixedPropertiesCandidate
+class MixedPropertiesCandidate
 {
-    private string $extra;
+    private readonly string $extra;
 
-    public function __construct(private int $id)
+    public function __construct(private readonly int $id)
     {
     }
 }
 
-readonly class WithoutPromotion
+class WithoutPromotion
 {
-    private int $id;
+    private readonly int $id;
     public function __construct(int $id)
     {
         $this->id = $id;
@@ -58,4 +58,26 @@ readonly class InvalidReadonlyWithBodyProperty
     public function __construct(private int $id)
     {
     }
+}
+
+readonly class InvalidReadonlyWithBodyProperty extends InvalidReadonly
+{
+	private int $extra;
+
+	public function __construct(private int $id)
+	{
+	}
+}
+
+final class FinalExtendingCandidate extends ParentClass
+{
+	public function __construct(private readonly int $id, private readonly string $name)
+	{
+	}
+}
+
+final readonly class FinalWithBodyPropertiesCandidate
+{
+	private int $id;
+	public string $name;
 }

--- a/tests/Sniffs/Classes/data/readonlyClassErrors.php
+++ b/tests/Sniffs/Classes/data/readonlyClassErrors.php
@@ -59,3 +59,25 @@ readonly class InvalidReadonlyWithBodyProperty
     {
     }
 }
+
+readonly class InvalidReadonlyWithBodyProperty extends InvalidReadonly
+{
+	private readonly int $extra;
+
+	public function __construct(private int $id)
+	{
+	}
+}
+
+final class FinalExtendingCandidate extends ParentClass
+{
+	public function __construct(private readonly int $id, private readonly string $name)
+	{
+	}
+}
+
+final class FinalWithBodyPropertiesCandidate
+{
+	private readonly int $id;
+	public readonly string $name;
+}

--- a/tests/Sniffs/Classes/data/readonlyClassModifiedSettingsErrors.fixed.php
+++ b/tests/Sniffs/Classes/data/readonlyClassModifiedSettingsErrors.fixed.php
@@ -1,0 +1,33 @@
+<?php // lint >= 8.2
+
+trait SomeTrait
+{
+	public function process(): void
+	{
+	}
+}
+
+readonly class NonFinalCandidate
+{
+	public function __construct(private int $id)
+	{
+	}
+}
+
+final readonly class FinalWithTraitCandidate
+{
+	use SomeTrait;
+
+	public function __construct(private int $id)
+	{
+	}
+}
+
+readonly class NonFinalWithTraitCandidate
+{
+	use SomeTrait;
+
+	public function __construct(private int $id)
+	{
+	}
+}

--- a/tests/Sniffs/Classes/data/readonlyClassModifiedSettingsErrors.php
+++ b/tests/Sniffs/Classes/data/readonlyClassModifiedSettingsErrors.php
@@ -1,0 +1,33 @@
+<?php // lint >= 8.2
+
+trait SomeTrait
+{
+	public function process(): void
+	{
+	}
+}
+
+class NonFinalCandidate
+{
+	public function __construct(private readonly int $id)
+	{
+	}
+}
+
+final class FinalWithTraitCandidate
+{
+	use SomeTrait;
+
+	public function __construct(private readonly int $id)
+	{
+	}
+}
+
+class NonFinalWithTraitCandidate
+{
+	use SomeTrait;
+
+	public function __construct(private readonly int $id)
+	{
+	}
+}

--- a/tests/Sniffs/Classes/data/readonlyClassNoErrors.php
+++ b/tests/Sniffs/Classes/data/readonlyClassNoErrors.php
@@ -35,3 +35,25 @@ class ChildClassWithReadonlyBodyProperties extends ParentClass
     private readonly int $id;
     public readonly string $name;
 }
+
+trait TraitWithMutableProperty
+{
+	public int $traitProperty;
+}
+
+final class FinalClassUsingTrait
+{
+	use TraitWithMutableProperty;
+
+	public function __construct(private readonly int $id)
+	{
+	}
+}
+
+#[\AllowDynamicProperties]
+final class FinalClassWithAllowDynamicProperties
+{
+	public function __construct(private readonly int $id)
+	{
+	}
+}


### PR DESCRIPTION
…n it is not final, not marked as AllowDynamicProperties and without traits