### PR TITLE
Skip locking closed issues on forks

### DIFF
--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   lock:
     name: "Lock"
+    if: ${{ github.event.repository.fork == false }}
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Prevents the scheduled lock workflow from invoking the lock action in forked repositories by adding the same fork guard used by other workflows.