### PR TITLE
ReadonlyClassSniff - do not mark abstract class as readonly despite a…

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Classes/ReadonlyClassSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/ReadonlyClassSniff.php
@@ -130,6 +130,10 @@ class ReadonlyClassSniff implements Sniff
 			}
 		}
 
+		if ($this->isAbstractClass($phpcsFile, $classPointer)) {
+			return;
+		}
+
 		if (!$this->allowNonFinalClasses && !ClassHelper::isFinal($phpcsFile, $classPointer)) {
 			return;
 		}
@@ -204,6 +208,24 @@ class ReadonlyClassSniff implements Sniff
 			&& in_array($tokens[$modifierPointer]['code'], [T_FINAL, T_ABSTRACT, T_READONLY], true)
 		) {
 			if ($tokens[$modifierPointer]['code'] === T_READONLY) {
+				return true;
+			}
+
+			$modifierPointer = TokenHelper::findPreviousEffective($phpcsFile, $modifierPointer - 1);
+		}
+
+		return false;
+	}
+
+	private function isAbstractClass(File $phpcsFile, int $classPointer): bool
+	{
+		$tokens = $phpcsFile->getTokens();
+		$modifierPointer = TokenHelper::findPreviousEffective($phpcsFile, $classPointer - 1);
+		while (
+			$modifierPointer !== null
+			&& in_array($tokens[$modifierPointer]['code'], [T_FINAL, T_ABSTRACT, T_READONLY], true)
+		) {
+			if ($tokens[$modifierPointer]['code'] === T_ABSTRACT) {
 				return true;
 			}
 

--- a/doc/classes.md
+++ b/doc/classes.md
@@ -236,7 +236,7 @@ Sniff provides the following settings:
 
 Reports classes where all promoted constructor properties and class body properties are declared as `readonly` and suggests marking the whole class as `readonly`.
 
-Suggestion is reported only for classes that do not `extends` another class and do not have `#[\AllowDynamicProperties]`.
+Suggestion is reported only for non-abstract classes that do not `extends` another class and do not have `#[\AllowDynamicProperties]`.
 
 Sniff provides the following settings:
 

--- a/tests/Sniffs/Classes/data/readonlyClassModifiedSettingsErrors.fixed.php
+++ b/tests/Sniffs/Classes/data/readonlyClassModifiedSettingsErrors.fixed.php
@@ -31,3 +31,15 @@ readonly class NonFinalWithTraitCandidate
 	{
 	}
 }
+
+abstract class AbstractWithPromotedProperties
+{
+	public function __construct(private readonly int $id)
+	{
+	}
+}
+
+abstract class AbstractWithBodyProperties
+{
+	private readonly int $id;
+}

--- a/tests/Sniffs/Classes/data/readonlyClassModifiedSettingsErrors.php
+++ b/tests/Sniffs/Classes/data/readonlyClassModifiedSettingsErrors.php
@@ -31,3 +31,15 @@ class NonFinalWithTraitCandidate
 	{
 	}
 }
+
+abstract class AbstractWithPromotedProperties
+{
+	public function __construct(private readonly int $id)
+	{
+	}
+}
+
+abstract class AbstractWithBodyProperties
+{
+	private readonly int $id;
+}


### PR DESCRIPTION
…ll promoted and body-property are mark as readonly