### PR TITLE
Add tests for RequireSingleLineConditionSniff limits

### DIFF
--- a/tests/Sniffs/ControlStructures/RequireSingleLineConditionSniffTest.php
+++ b/tests/Sniffs/ControlStructures/RequireSingleLineConditionSniffTest.php
@@ -17,7 +17,7 @@ class RequireSingleLineConditionSniffTest extends TestCase
 	{
 		$report = self::checkFile(__DIR__ . '/data/requireSingleLineConditionErrors.php');
 
-		self::assertSame(5, $report->getErrorCount());
+		self::assertSame(7, $report->getErrorCount());
 
 		self::assertSniffError(
 			$report,
@@ -46,6 +46,18 @@ class RequireSingleLineConditionSniffTest extends TestCase
 		self::assertSniffError(
 			$report,
 			30,
+			RequireSingleLineConditionSniff::CODE_REQUIRED_SINGLE_LINE_CONDITION,
+			'Condition of "if" should be placed on a single line.',
+		);
+		self::assertSniffError(
+			$report,
+			37,
+			RequireSingleLineConditionSniff::CODE_REQUIRED_SINGLE_LINE_CONDITION,
+			'Condition of "if" should be placed on a single line.',
+		);
+		self::assertSniffError(
+			$report,
+			43,
 			RequireSingleLineConditionSniff::CODE_REQUIRED_SINGLE_LINE_CONDITION,
 			'Condition of "if" should be placed on a single line.',
 		);

--- a/tests/Sniffs/ControlStructures/RequireSingleLineConditionSniffTest.php
+++ b/tests/Sniffs/ControlStructures/RequireSingleLineConditionSniffTest.php
@@ -116,4 +116,33 @@ class RequireSingleLineConditionSniffTest extends TestCase
 		self::assertNoSniffErrorInFile($report);
 	}
 
+	public function testMaxLineLengthErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/requireSingleLineConditionMaxLineLengthErrors.php', [
+			'maxLineLength' => 80,
+		]);
+
+		self::assertSame(3, $report->getErrorCount());
+
+		self::assertSniffError($report, 4, RequireSingleLineConditionSniff::CODE_REQUIRED_SINGLE_LINE_CONDITION);
+		self::assertSniffError($report, 18, RequireSingleLineConditionSniff::CODE_REQUIRED_SINGLE_LINE_CONDITION);
+		self::assertSniffError($report, 24, RequireSingleLineConditionSniff::CODE_REQUIRED_SINGLE_LINE_CONDITION);
+
+		self::assertAllFixedInFile($report);
+	}
+
+	public function testMaxLineLengthWithoutSimpleConditionsErrors(): void
+	{
+		$report = self::checkFile(__DIR__ . '/data/requireSingleLineConditionMaxLineLengthWithoutSimpleConditionsErrors.php', [
+			'maxLineLength' => 80,
+			'alwaysForSimpleConditions' => false,
+		]);
+
+		self::assertSame(1, $report->getErrorCount());
+
+		self::assertSniffError($report, 4, RequireSingleLineConditionSniff::CODE_REQUIRED_SINGLE_LINE_CONDITION);
+
+		self::assertAllFixedInFile($report);
+	}
+
 }

--- a/tests/Sniffs/ControlStructures/data/requireSingleLineConditionErrors.fixed.php
+++ b/tests/Sniffs/ControlStructures/data/requireSingleLineConditionErrors.fixed.php
@@ -7,15 +7,23 @@ function () {
 
 	}
 
-	while (doSomething('veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long') && true) {
+	while (doSomething('veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long') && true) {
 
 	}
 
 	do {
 
-	} while (doSomething('veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long') && true);
+	} while (doSomething('veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long') && true);
 
 	if (doSomething('')) { // Very looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong fucking comment
 
 	}
 };
+
+if (doSomething('veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long')) {
+
+}
+
+if (doSomething( 'short', [ 'short', 'short' ], [ 'veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy', 'long', ] )) {
+
+}

--- a/tests/Sniffs/ControlStructures/data/requireSingleLineConditionErrors.php
+++ b/tests/Sniffs/ControlStructures/data/requireSingleLineConditionErrors.php
@@ -14,7 +14,7 @@ function () {
 	}
 
 	while (
-		doSomething('veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long')
+		doSomething('veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long')
 		&& true
 	) {
 
@@ -23,7 +23,7 @@ function () {
 	do {
 
 	} while (
-		doSomething('veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long')
+		doSomething('veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long')
 		&& true
 	);
 
@@ -33,3 +33,25 @@ function () {
 
 	}
 };
+
+if (
+	doSomething('veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long')
+) {
+
+}
+
+if (
+	doSomething(
+		'short',
+		[
+			'short',
+			'short'
+		],
+		[
+			'veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy',
+			'long',
+		]
+	)
+) {
+
+}

--- a/tests/Sniffs/ControlStructures/data/requireSingleLineConditionMaxLineLengthErrors.fixed.php
+++ b/tests/Sniffs/ControlStructures/data/requireSingleLineConditionMaxLineLengthErrors.fixed.php
@@ -1,0 +1,22 @@
+<?php
+
+function () {
+	if (doSomething('veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long') && true) {
+
+	}
+
+	if (
+		doSomething('veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long')
+		&& true
+	) {
+
+	}
+
+	if (doSomething('veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long')) {
+
+	}
+
+	if (doSomething('veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long')) {
+
+	}
+};

--- a/tests/Sniffs/ControlStructures/data/requireSingleLineConditionMaxLineLengthErrors.php
+++ b/tests/Sniffs/ControlStructures/data/requireSingleLineConditionMaxLineLengthErrors.php
@@ -1,0 +1,29 @@
+<?php
+
+function () {
+	if (
+		doSomething('veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long')
+		&& true
+	) {
+
+	}
+
+	if (
+		doSomething('veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long')
+		&& true
+	) {
+
+	}
+
+	if (
+		doSomething('veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long')
+	) {
+
+	}
+
+	if (
+		doSomething('veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long')
+	) {
+
+	}
+};

--- a/tests/Sniffs/ControlStructures/data/requireSingleLineConditionMaxLineLengthWithoutSimpleConditionsErrors.fixed.php
+++ b/tests/Sniffs/ControlStructures/data/requireSingleLineConditionMaxLineLengthWithoutSimpleConditionsErrors.fixed.php
@@ -1,0 +1,13 @@
+<?php
+
+function () {
+	if (doSomething('veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long')) {
+
+	}
+
+	if (
+		doSomething('veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long')
+	) {
+
+	}
+};

--- a/tests/Sniffs/ControlStructures/data/requireSingleLineConditionMaxLineLengthWithoutSimpleConditionsErrors.php
+++ b/tests/Sniffs/ControlStructures/data/requireSingleLineConditionMaxLineLengthWithoutSimpleConditionsErrors.php
@@ -1,0 +1,15 @@
+<?php
+
+function () {
+	if (
+		doSomething('veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long')
+	) {
+
+	}
+
+	if (
+		doSomething('veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long')
+	) {
+
+	}
+};

--- a/tests/Sniffs/ControlStructures/data/requireSingleLineConditionNoErrors.php
+++ b/tests/Sniffs/ControlStructures/data/requireSingleLineConditionNoErrors.php
@@ -5,6 +5,13 @@ function () {
 
 	}
 
+	if (
+		doSomething('veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long')
+		&& true
+	) {
+
+	}
+
 	while (doSomething('short') && true) {
 
 	}

--- a/tests/Sniffs/ControlStructures/data/requireSingleLineConditionWhenDisabledSimpleConditionsNoErrors.php
+++ b/tests/Sniffs/ControlStructures/data/requireSingleLineConditionWhenDisabledSimpleConditionsNoErrors.php
@@ -1,7 +1,23 @@
 <?php
 
 if (
-	doSomething('veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long')
+	doSomething('veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long')
+) {
+
+}
+
+if (
+	doSomething(
+		'short',
+		[
+			'short',
+			'short'
+		],
+		[
+			'veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy',
+			'long',
+		]
+	)
 ) {
 
 }


### PR DESCRIPTION
Improves unit tests of the sniff `SlevomatCodingStandard.ControlStructures.RequireSingleLineCondition`.

I also added an extra case for a simple condition involving a function call with multiple parameters, to show the extra spaces that are counted for the maximum line length.

The following changes now causes the tests to fail:

```diff
--- a/SlevomatCodingStandard/Sniffs/ControlStructures/RequireSingleLineConditionSniff.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/RequireSingleLineConditionSniff.php
@@ -15,7 +15,7 @@ class RequireSingleLineConditionSniff extends AbstractLineCondition
 
        public const CODE_REQUIRED_SINGLE_LINE_CONDITION = 'RequiredSingleLineCondition';
 
-       public int $maxLineLength = 120;
+       public int $maxLineLength = 121;
 
        public bool $alwaysForSimpleConditions = true;
```

```diff
--- a/SlevomatCodingStandard/Sniffs/ControlStructures/RequireSingleLineConditionSniff.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/RequireSingleLineConditionSniff.php
@@ -15,7 +15,7 @@ class RequireSingleLineConditionSniff extends AbstractLineCondition
 
        public const CODE_REQUIRED_SINGLE_LINE_CONDITION = 'RequiredSingleLineCondition';
 
-       public int $maxLineLength = 120;
+       public int $maxLineLength = 119;
 
        public bool $alwaysForSimpleConditions = true;
```

```diff
--- a/SlevomatCodingStandard/Sniffs/ControlStructures/RequireSingleLineConditionSniff.php
+++ b/SlevomatCodingStandard/Sniffs/ControlStructures/RequireSingleLineConditionSniff.php
@@ -17,7 +17,7 @@ class RequireSingleLineConditionSniff extends AbstractLineCondition
 
        public int $maxLineLength = 120;
 
-       public bool $alwaysForSimpleConditions = true;
+       public bool $alwaysForSimpleConditions = false;
 
        public function process(File $phpcsFile, int $controlStructurePointer): void
```
